### PR TITLE
Feat/loadbalancer - use ELB for exposing services

### DIFF
--- a/kube/kubes.sh
+++ b/kube/kubes.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+
+patch_kube() {
+    kubectl patch deployment $1 -p   "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
+}
+
+get_pod() {
+    pod=$(kubectl get pods --output=jsonpath='{range .items[*]}{.metadata.name}  {"\n"}{end}' | grep -m 1 $1)
+    echo $pod
+}
+
+update_config() {
+    kubectl delete configmap $1
+    kubectl create configmap $1 --from-file $2
+}

--- a/kube/services/revproxy/00cert-config.yaml
+++ b/kube/services/revproxy/00cert-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: revproxy-cert 
+  namespace: default 
+data:
+  revproxy_cert: $REVPROXY_CERT

--- a/kube/services/revproxy/10nginx-config.yaml
+++ b/kube/services/revproxy/10nginx-config.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: revproxy-nginx-conf
+  namespace: default 
+data:
+  nginx.conf: |
+      user www-data;
+      worker_processes 4;
+        
+      pid /run/nginx.pid;
+      
+      events {
+      	worker_connections 768;
+      	# multi_accept on;
+      }
+      
+      http {
+      
+      	##
+      	# Basic Settings
+      	##
+      
+      	sendfile on;
+      	tcp_nopush on;
+      	tcp_nodelay on;
+      	keepalive_timeout 65;
+      	types_hash_max_size 2048;
+      	# server_tokens off;
+      
+      	# server_names_hash_bucket_size 64;
+      	# server_name_in_redirect off;
+      
+      	include /etc/nginx/mime.types;
+      	default_type application/octet-stream;
+      
+      	##
+      	# Logging Settings
+      	##
+      
+      	access_log /dev/stdout;
+      	error_log /dev/stderr;
+      
+      	##
+      	# Gzip Settings
+      	##
+      
+      	gzip on;
+      	gzip_disable "msie6";
+      
+              ##
+      	# Proxy Settings
+      	##
+      	server {
+      		listen 80;
+      		server_tokens off;
+      		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+      		add_header X-Frame-Options "SAMEORIGIN";
+      		if ($http_x_forwarded_proto = "http") { rewrite ^/(.*)$ https://$host$request_uri permanent; }
+      		location / {
+      		    proxy_pass http://portal-service.default/;
+      		}
+      		location /index {
+      		    proxy_pass http://indexd-service.default/;
+      		}
+      		location /user {
+      		    proxy_pass http://userapi-service.default/;
+      		}
+      		location /api {
+      		    proxy_next_upstream off;
+      		    proxy_pass http://gdcapi-service.default/;
+      		}
+      	}
+      }

--- a/kube/services/revproxy/READMD.md
+++ b/kube/services/revproxy/READMD.md
@@ -1,0 +1,14 @@
+## Reverse proxy
+Right now all services external facing go through this reverse proxy as they serve under subdirectories of the same domain name
+
+### Run reverse proxy
+- create a cert in AWS Certificate Manager, this will require the admin for the domain approve it through email
+- ./apply_cert
+- kubectl apply -f 10nginx-config.yaml
+- kubectl apply -f services/revproxy/revproxy-deployment.yaml
+- ./apply_service
+
+_Right now there are a lot of features not supported in kubernete, these need to be automated when they support them_
+- change the load balancer settings in AWS to use "Listeners->Cipher for port 443->ELBSecurityPolicy-TLS-1-2-2017-01" 
+- change the subnets to add the private subnet
+- change the port 80 listen to use http protocol "Listensers->Edit->Load Balancer Protocol for port 80 -> HTTP"

--- a/kube/services/revproxy/READMD.md
+++ b/kube/services/revproxy/READMD.md
@@ -7,8 +7,5 @@ Right now all services external facing go through this reverse proxy as they ser
 - kubectl apply -f 10nginx-config.yaml
 - kubectl apply -f services/revproxy/revproxy-deployment.yaml
 - ./apply_service
-
-_Right now there are a lot of features not supported in kubernete, these need to be automated when they support them_
-- change the load balancer settings in AWS to use "Listeners->Cipher for port 443->ELBSecurityPolicy-TLS-1-2-2017-01" 
-- change the subnets to add the private subnet
-- change the port 80 listen to use http protocol "Listensers->Edit->Load Balancer Protocol for port 80 -> HTTP"
+- change the load balancer settings in AWS to use "Listeners->Cipher for port 443->ELBSecurityPolicy-TLS-1-2-2017-01" [issue 151](https://github.com/kubernetes/kubernetes/issues/43744)
+- update DNS to point to your ELB

--- a/kube/services/revproxy/apply_cert
+++ b/kube/services/revproxy/apply_cert
@@ -1,0 +1,11 @@
+#!/bin/bash
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+echo "ARN for created certificate in AWS Certificate Manager:"
+read arn
+export REVPROXY_CERT=$arn
+if [[ ! -z $arn  ]]; then
+    envsubst < $scriptDir/00cert-config.yaml | kubectl apply -f -
+else
+    echo 'arn not provided'
+fi

--- a/kube/services/revproxy/apply_service
+++ b/kube/services/revproxy/apply_service
@@ -1,0 +1,10 @@
+#!/bin/bash
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+export ARN=$(kubectl get configmap revproxy-cert --output=jsonpath='{.data.revproxy_cert}')
+if [[ ! -z $ARN ]]; then
+  envsubst <$scriptDir/revproxy-service.yaml | kubectl apply -f -
+
+else
+  echo "Global configmap not configured"
+fi

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -1,0 +1,32 @@
+apiVersion: extensions/v1beta1 
+kind: Deployment
+metadata:
+  name: revproxy-deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: revproxy
+    spec:
+      volumes:
+        - name: revproxy-conf
+          configMap:
+            name: revproxy-nginx-conf
+      containers:
+      - name: revproxy
+        image: nginx 
+        command:
+          - /usr/sbin/nginx
+          - -g
+          - 'daemon off;'
+        ports:
+        - containerPort: 80
+        volumeMounts:
+          - name: "revproxy-conf"
+            readOnly: true
+            mountPath: "/etc/nginx/nginx.conf"
+            subPath: nginx.conf 
+      imagePullSecrets:
+        - name: cdis-devservices-pull-secret
+

--- a/kube/services/revproxy/revproxy-service.yaml
+++ b/kube/services/revproxy/revproxy-service.yaml
@@ -1,0 +1,23 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: revproxy-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http 
+    # would be much better if annotation can use configmap, so I don't need to use envsubst
+    # to parameterize it
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: $ARN 
+spec:
+  selector:
+    app: revproxy
+  ports:
+    - protocol: TCP 
+      port: 443 
+      targetPort: 80 
+      name: https
+    # right now kubernete make them both https for the elb protocol, has to manually fix it after you apply this file
+    - protocol: TCP 
+      port: 80 
+      targetPort: 80 
+      name: http
+  type: LoadBalancer 

--- a/kube/services/revproxy/revproxy-service.yaml
+++ b/kube/services/revproxy/revproxy-service.yaml
@@ -4,9 +4,10 @@ metadata:
   name: revproxy-service
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http 
-    # would be much better if annotation can use configmap, so I don't need to use envsubst
-    # to parameterize it
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-ssl-cert: $ARN 
+    # this is not supported yet
+    service.beta.kubernetes.io/aws-load-balancer-security-policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 spec:
   selector:
     app: revproxy

--- a/tf_files/cloud.tf
+++ b/tf_files/cloud.tf
@@ -236,8 +236,8 @@ resource "aws_subnet" "public" {
     tags {
         Name = "public"
         Environment = "${var.vpc_name}"
-        KubernetesCluster = "${var.vpc_name}",
-        kubernetes.io/role/elb
+        KubernetesCluster = "${var.vpc_name}"
+        "kubernetes.io/role/elb" = ""
     }
 }
 
@@ -557,7 +557,8 @@ resource "aws_elb" "elb" {
     }
 
     tags {
+        Environment = "${var.vpc_name}"
         KubernetesCluster = "${var.vpc_name}",
-        kubernetes.io/role/elb
+        "kubernetes.io/role/elb" = ""
     }
 }

--- a/tf_files/cloud.tf
+++ b/tf_files/cloud.tf
@@ -249,6 +249,7 @@ resource "aws_subnet" "private" {
     tags {
         Name = "private"
         Environment = "${var.vpc_name}"
+        KubernetesCluster = "${var.vpc_name}"
     }
 }
 

--- a/tf_files/configs/kube-services.sh
+++ b/tf_files/configs/kube-services.sh
@@ -16,33 +16,41 @@ cp ~/cloud-automation/apis_configs/user.yaml ~/${vpc_name}/apis_configs
 
 cd ~/${vpc_name}
 
-kubectl --kubeconfig=kubeconfig create -f cdis-devservices-secret.yml
+export KUBECONFIG=~/${vpc_name}/kubeconfig
+kubectl create -f cdis-devservices-secret.yml
 rm cdis-devservices-secret.yml
 
-kubectl --kubeconfig=kubeconfig create configmap userapi --from-file=apis_configs/user.yaml
+kubectl create configmap userapi --from-file=apis_configs/user.yaml
 
-kubectl --kubeconfig=kubeconfig create secret generic userapi-secret --from-file=local_settings.py=./apis_configs/userapi_settings.py
-kubectl --kubeconfig=kubeconfig create secret generic indexd-secret --from-file=local_settings.py=./apis_configs/indexd_settings.py
+kubectl create secret generic userapi-secret --from-file=local_settings.py=./apis_configs/userapi_settings.py
+kubectl create secret generic indexd-secret --from-file=local_settings.py=./apis_configs/indexd_settings.py
 
-kubectl --kubeconfig=kubeconfig apply -f services/portal/portal-deploy.yaml
-kubectl --kubeconfig=kubeconfig apply -f services/userapi/userapi-deploy.yaml
-kubectl --kubeconfig=kubeconfig apply -f services/indexd/indexd-deploy.yaml
+kubectl apply -f services/portal/portal-deploy.yaml
+kubectl apply -f services/userapi/userapi-deploy.yaml
+kubectl apply -f services/indexd/indexd-deploy.yaml
 
 cd ~/${vpc_name}_output; python render_creds.py userapi_db
 python render_creds.py  secrets
 
 
-cd ~/${vpc_name}; kubectl --kubeconfig=kubeconfig create secret generic gdcapi-secret --from-file=wsgi.py=./apis_configs/gdcapi_settings.py
-kubectl --kubeconfig=kubeconfig apply -f services/gdcapi/gdcapi-deploy.yaml
+cd ~/${vpc_name}; kubectl create secret generic gdcapi-secret --from-file=wsgi.py=./apis_configs/gdcapi_settings.py
+kubectl apply -f services/gdcapi/gdcapi-deploy.yaml
 
 
 cd ~/${vpc_name}_output; python render_creds.py gdcapi_db
 
-cd ~/${vpc_name} 
-kubectl --kubeconfig=kubeconfig apply -f services/userapi/userapi-service.yaml
-kubectl --kubeconfig=kubeconfig apply -f services/portal/portal-service.yaml
-kubectl --kubeconfig=kubeconfig apply -f services/indexd/indexd-service.yaml
-kubectl --kubeconfig=kubeconfig apply -f services/gdcapi/gdcapi-service.yaml
+cd ~/${vpc_name}
+kubectl apply -f services/userapi/userapi-service.yaml
+kubectl apply -f services/portal/portal-service.yaml
+kubectl apply -f services/indexd/indexd-service.yaml
+kubectl apply -f services/gdcapi/gdcapi-service.yaml
+
+cat >>~/.bashrc << EOF
+export KUBECONFIG=~/${vpc_name}/kubeconfig
+if [ -f ~/cloud-automation/kube/kubes.sh ]; then
+    . ~/cloud-automation/kube/kubes.sh
+fi
+EOF
 
 echo
 echo "Worker node IPs:"


### PR DESCRIPTION
resolve https://github.com/uc-cdis/cloud-automation/issues/8
- a revproxy service is created to substitute the external reverse proxy
- a public_kube subnet is added to put ELB in it, this is created to make sure that this subnet use the same availability zone as the private subnet that kubernete is using, otherwise it can't reach kubernete cluster
- this pr doesn't remove the deprecated external reverse proxy
- created a kubes.sh for some shortcuts

I spent sometime to try to figure out how to automate fixing ELB after kubernete set it up, but apparently I can't do most of what I want through awscli or python client, so I gave up and hope kubernete will fix them later.
r? @uc-cdis/planx-devs 