### PR TITLE
feat(proxy): use squid as NAT instance

### DIFF
--- a/tf_files/cloud.tf
+++ b/tf_files/cloud.tf
@@ -188,16 +188,11 @@ resource "aws_eip_association" "revproxy_eip" {
     allocation_id = "${aws_eip.revproxy.id}"
 }
 
-resource "aws_nat_gateway" "gw" {
-  allocation_id = "${aws_eip.nat.id}"
-  subnet_id     = "${aws_subnet.public.id}"
-}
-
 resource "aws_route_table" "private" {
     vpc_id = "${aws_vpc.main.id}"
     route {
         cidr_block = "0.0.0.0/0"
-        nat_gateway_id = "${aws_nat_gateway.gw.id}"
+        instance_id = "${aws_instance.proxy.id}"
     }
     tags {
         Name = "private"
@@ -363,7 +358,6 @@ data "template_file" "cluster" {
         subnet_id = "${aws_subnet.private.id}"
         subnet_cidr = "${aws_subnet.private.cidr_block}"
         subnet_zone = "${aws_subnet.private.availability_zone}"
-        nat_id = "${aws_nat_gateway.gw.id}"
         security_group_id = "${aws_security_group.kube-worker.id}"
         kube_additional_keys = "${var.kube_additional_keys}"
         hosted_zone = "${aws_route53_zone.main.id}"
@@ -499,6 +493,7 @@ resource "aws_instance" "proxy" {
     subnet_id = "${aws_subnet.public.id}"
     instance_type = "t2.micro"
     monitoring = true
+    source_dest_check = false
     vpc_security_group_ids = ["${aws_security_group.proxy.id}","${aws_security_group.login-ssh.id}", "${aws_security_group.out.id}"]
     tags {
         Name = "HTTP Proxy"

--- a/tf_files/cloud.tf
+++ b/tf_files/cloud.tf
@@ -272,7 +272,7 @@ resource "aws_subnet" "private_3" {
 }
 
 resource "aws_db_subnet_group" "private_group" {
-    name = "private_group"
+    name = "${var.vpc_name}_private_group"
     subnet_ids = ["${aws_subnet.private.id}", "${aws_subnet.private_3.id}"]
 
     tags {
@@ -541,7 +541,7 @@ resource "aws_kms_key" "kube_key" {
 }
 
 resource "aws_key_pair" "automation_dev" {
-    key_name = "automation_dev"
+    key_name = "${var.vpc_name}_automation_dev"
     public_key = "${var.kube_ssh_key}"
 }
 

--- a/tf_files/configs/cluster.yaml
+++ b/tf_files/configs/cluster.yaml
@@ -44,8 +44,8 @@ etcd:
 routeTableId: ${route_table_id}
 # CIDR for Kubernetes VPC. If vpcId is specified, must match the CIDR of existing vpc.
 # vpcCIDR: "10.0.0.0/16"
-vpcId: ${vpc_id}
-vpcCIDR: ${vpc_cidr}
+vpc:
+  id: ${vpc_id}
 
 # CIDR for Kubernetes subnet when placing nodes in a single availability zone (not highly-available) Leave commented out for multi availability zone setting and use the below `subnets` section instead.
 # instanceCIDR: "10.0.0.0/24"

--- a/tf_files/configs/cluster.yaml
+++ b/tf_files/configs/cluster.yaml
@@ -55,8 +55,6 @@ subnets:
     id: "${subnet_id}"
     instanceCIDR: "${subnet_cidr}"
     availabilityZone: "${subnet_zone}"
-    natGateway:
-      id: "${nat_id}"
     securityGroupIds:
       - ${security_group_id}
 

--- a/tf_files/configs/kube-up.sh
+++ b/tf_files/configs/kube-up.sh
@@ -5,8 +5,8 @@ export https_proxy=http://cloud-proxy.internal.io:3128
 
 sudo -E apt-get update
 sudo -E apt-get install -y git
-mkdir ~/.aws
-mkdir ~/${vpc_name}
+mkdir -p ~/.aws
+mkdir -p ~/${vpc_name}
 mv credentials ~/.aws
 cp cluster.yaml ~/${vpc_name}
 cp 00configmap.yaml ~/${vpc_name}

--- a/tf_files/variables.template
+++ b/tf_files/variables.template
@@ -1,48 +1,48 @@
 # VPC name is also used for DB name, so only alphanumeric characters
-vpc_name=""
+vpc_name="$VPC_NAME"
 
-aws_access_key=""
+aws_access_key="$AWS_ACCESS_KEY"
 
-aws_secret_key=""
+aws_secret_key="$AWS_SECRET_KEY"
 
-login_ami=""
+login_ami="$LOGIN_AMI"
 
-proxy_ami=""
+proxy_ami="$PROXY_AMI"
 
-base_ami=""
+base_ami="$BASE_AMI"
 
 db_size=10
 
-hostname="www.example.com"
+hostname="$CHOSTNAME"
 
 # ssh key to be added to kube nodes
-kube_ssh_key="ssh-rsa XXXX"
+kube_ssh_key="$SSHKEY"
 
 # additional keys
 # format like kube_additional_keys="- \"ssh-rsa XXXX\"\n  - \"ssh-rsa XXXX\""
-kube_additional_keys=""
+kube_additional_keys="- \"${ADDSSHKEY}\""
 
 # S3 bucket for storing kube states
-kube_bucket=""
+kube_bucket="$BUCKET"
 
-google_client_secret=""
-google_client_id=""
+google_client_secret="$CLIENTSECRET"
+google_client_id="$CLIENTID"
 
 
 # Following variables can be randomly generated passwords
 
 # base64 encoded 32 alphanumeric characters
 # cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1 | base64
-hmac_encryption_key=""
+hmac_encryption_key="$HMAC"
 
 # don't use ( ) " ' { } < > @ in password
-db_password_userapi=""
+db_password_userapi="$USERAPIDBPASS"
 
-db_password_gdcapi=""
+db_password_gdcapi="$GDCAPIDBPASS"
 
-db_password_indexd=""
+db_password_indexd="$INDEXDDBPASS"
 
 db_instance="db.t2.micro"
 
 # password for write access to indexd
-gdcapi_indexd_password=""
+gdcapi_indexd_password="$INDEXD"


### PR DESCRIPTION
resolve #55 
- removed NAT gateway
- moved tf_variables and tfstate to `~/.creds/{vpc_name}` so that I can use cloud-automation with different vpcs locally
- used envsubst instead of sed for tf_variables templating
- some minor fixes

tested in OCC with `pr65` vpc name :p

r? @zflamig 