### PR TITLE
Fix/reversed proxy

### DIFF
--- a/kube/services/revproxy/10nginx-config.yaml
+++ b/kube/services/revproxy/10nginx-config.yaml
@@ -68,6 +68,10 @@ data:
       		}
       		location /api {
       		    proxy_next_upstream off;
+                    # Forward the host and set Subdir header so api
+                    # knows the original request path for hmac signing
+      		    proxy_set_header   Host $host;
+      		    proxy_set_header   Subdir /api;
       		    proxy_pass http://gdcapi-service.default/;
       		}
       	}

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: revproxy-deployment
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/tf_files/configs/api_reverse_proxy.conf
+++ b/tf_files/configs/api_reverse_proxy.conf
@@ -27,6 +27,8 @@ server {
     }
     location /api {
         proxy_pass http://kubenode.internal.io:30004/;
+        proxy_set_header   Host $host;
+        proxy_set_header   Subdir api;
     }
 }
 server {

--- a/tf_files/configs/api_reverse_proxy.conf
+++ b/tf_files/configs/api_reverse_proxy.conf
@@ -28,7 +28,7 @@ server {
     location /api {
         proxy_pass http://kubenode.internal.io:30004/;
         proxy_set_header   Host $host;
-        proxy_set_header   Subdir api;
+        proxy_set_header   Subdir /api;
     }
 }
 server {


### PR DESCRIPTION
fix hmac break with subdirectory. Related to issue in cdis-python-utils
https://github.com/uc-cdis/cdis-python-utils/pull/11

nginx for gdcapi needs add a header named Subdir
r @philloooo 