### PR TITLE
fix(Jenkinsfile): Terraform pipeline checkout scm

### DIFF
--- a/Jenkins/Pipelines/Terraform/Jenkinsfile
+++ b/Jenkins/Pipelines/Terraform/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   stages {
     stage('FetchCode'){
       steps {
-        git url: "https://github.com/uc-cdis/cloud-automation.git", branch: 'fix/variable-state'
+        checkout scm
         dir('Secrets') {
             sh 'aws s3 cp s3://cdis-terraform-state/planx-pla.net/v1/config.tfvars config.tfvars'
             sh 'aws s3 cp s3://cdis-terraform-state/planx-pla.net/v1/backend.tfvars backend.tfvars'


### PR DESCRIPTION
Reset Jenkins 'Terraform' job to just checkout Jenkinsfile
from the same repo/branch that the Jenkins job is configured
to point at

I had the Pipeline script inline in the Jenkins script before ... show you what I mean next week