### PR TITLE
Fix/jenkins

### DIFF
--- a/Jenkins/Docker/Jenkins/Dockerfile
+++ b/Jenkins/Docker/Jenkins/Dockerfile
@@ -1,9 +1,25 @@
 FROM jenkins/jenkins:latest
 
 USER root
+
+# install python and pip and aws cli
 RUN apt-get update && apt-get install -y python python-setuptools python-dev build-essential zip unzip && rm -rf /var/lib/apt/lists/*
 RUN easy_install pip
 RUN pip install awscli --upgrade
+
+# install terraform
 RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_amd64.zip
 RUN unzip /tmp/terraform.zip -d /usr/local/bin; /bin/rm /tmp/terraform.zip
+
+# install kubectl
+RUN wget -P /tmp https://dl.k8s.io/v1.7.10/kubernetes-client-linux-amd64.tar.gz
+RUN tar xvfz /tmp/kubernetes-client-linux-amd64.tar.gz -C /tmp
+RUN chmod -R a+rX /tmp/kubernetes/client/bin && mv /tmp/kubernetes/client/bin/kube* /usr/local/bin/
+RUN rm -r /tmp/kubernetes /tmp/kubernetes-client-linux-amd64.tar.gz
+
+# add our custom start script
+COPY jenkins.sh /opt/cdis/bin/jenkins.sh
+RUN chmod -R a+rX /opt/cdis
+ENTRYPOINT ["/bin/tini", "--", "/opt/cdis/bin/jenkins.sh"]
+
 USER jenkins

--- a/Jenkins/Docker/Jenkins/Dockerfile
+++ b/Jenkins/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:latest
+FROM jenkins/jenkins:2.89
 
 USER root
 
@@ -19,7 +19,7 @@ RUN rm -r /tmp/kubernetes /tmp/kubernetes-client-linux-amd64.tar.gz
 
 # add our custom start script
 COPY jenkins.sh /opt/cdis/bin/jenkins.sh
-RUN chmod -R a+rX /opt/cdis
+RUN chmod -R a+rx /opt/cdis
 ENTRYPOINT ["/bin/tini", "--", "/opt/cdis/bin/jenkins.sh"]
 
 USER jenkins

--- a/Jenkins/Docker/Jenkins/Dockerfile
+++ b/Jenkins/Docker/Jenkins/Dockerfile
@@ -2,8 +2,9 @@ FROM jenkins/jenkins:2.89
 
 USER root
 
+ENV DEBIAN_FRONTEND=noninteractive
 # install python and pip and aws cli
-RUN apt-get update && apt-get install -y python python-setuptools python-dev build-essential zip unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apt-utils python python-setuptools python-dev build-essential zip unzip && rm -rf /var/lib/apt/lists/*
 RUN easy_install pip
 RUN pip install awscli --upgrade
 

--- a/Jenkins/Docker/Jenkins/Dockerfile
+++ b/Jenkins/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.89
+FROM jenkins/jenkins:2.90
 
 USER root
 
@@ -9,8 +9,12 @@ RUN easy_install pip
 RUN pip install awscli --upgrade
 
 # install terraform
-RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.10.8/terraform_0.10.8_linux_amd64.zip
+RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.0/terraform_0.11.0_linux_amd64.zip
 RUN unzip /tmp/terraform.zip -d /usr/local/bin; /bin/rm /tmp/terraform.zip
+
+# install packer
+RUN curl -o /tmp/packer.zip https://releases.hashicorp.com/packer/1.1.2/packer_1.1.2_linux_amd64.zip
+RUN unzip /tmp/packer.zip -d /usr/local/bin; /bin/rm /tmp/packer.zip
 
 # install kubectl
 RUN wget -P /tmp https://dl.k8s.io/v1.7.10/kubernetes-client-linux-amd64.tar.gz

--- a/Jenkins/Docker/Jenkins/build.sh
+++ b/Jenkins/Docker/Jenkins/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t cdis-jenkins:1.0.0 .
+

--- a/Jenkins/Docker/Jenkins/jenkins.sh
+++ b/Jenkins/Docker/Jenkins/jenkins.sh
@@ -2,12 +2,33 @@
 
 # No! set -e
 
-if [ ! -d "/var/jenkins_home/jobs" ]; then
-  # download latest backup from S3 - collected via Pipelines/Backup :-)
-  latestFile="$(aws s3 ls s3://cdis-terraform-state/JenkinsBackup/ | sort | tail -1 | awk '{ print $4}')"
-  aws s3 cp "s3://cdis-terraform-state/JenkinsBackup/$latestFile" /tmp/backup.tar.xz
-  tar xvf /tmp/backup.tar.xz -C /tmp
-  mv /tmp/var/jenkins_home/* /var/jenkins_home/
+if [ -z "$JENKINS_HOME" ]; then
+  # To simplify testing
+  JENKINS_HOME=/var/jenkins_home
 fi
 
-source /usr/local/bin/jenkins.sh
+if [ "$JENKINS_HOME" = "/tmp/var/jenkins_home" ]; then
+  echo "ERROR: JENKINS_HOME points at temp space that will be overwritten: $JENKINS_HOME"
+  exit 1
+fi
+
+if [ ! -d "$JENKINS_HOME/jobs" ]; then
+  if [ -d "$JENKINS_HOME" ]; then
+    # download latest backup from S3 - collected via Pipelines/Backup :-)
+    latestFile="$(aws s3 ls s3://cdis-terraform-state/JenkinsBackup/ | sort | tail -1 | awk '{ print $4}')"
+    S3PATH="s3://cdis-terraform-state/JenkinsBackup/$latestFile"
+    echo "Downloading $S3PATH"
+    aws s3 cp "$S3PATH" /tmp/backup.tar.xz
+    tar xvf /tmp/backup.tar.xz -C /tmp
+    mv /tmp/var/jenkins_home/* "$JENKINS_HOME/"
+  else
+    echo "Jenkins home not in expected location: /var/jenkins_home"
+  fi
+fi
+
+if [ -f /usr/local/bin/jenkins.sh ]; then
+  source /usr/local/bin/jenkins.sh
+else
+  echo "Jenkins startup script not where expected: /usr/local/bin/jenkins.sh"
+fi
+

--- a/Jenkins/Docker/Jenkins/jenkins.sh
+++ b/Jenkins/Docker/Jenkins/jenkins.sh
@@ -12,7 +12,7 @@ if [ "$JENKINS_HOME" = "/tmp/var/jenkins_home" ]; then
   exit 1
 fi
 
-if [ ! -d "$JENKINS_HOME/jobs" ]; then
+if [ ! -d "$JENKINS_HOME/jobs" ]; then # restore from s3 is necessary
   if [ -d "$JENKINS_HOME" ]; then
     # download latest backup from S3 - collected via Pipelines/Backup :-)
     latestFile="$(aws s3 ls s3://cdis-terraform-state/JenkinsBackup/ | sort | tail -1 | awk '{ print $4}')"

--- a/Jenkins/Docker/Jenkins/jenkins.sh
+++ b/Jenkins/Docker/Jenkins/jenkins.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# No! set -e
+
+if [ ! -d "/var/jenkins_home/jobs" ]; then
+  # download latest backup from S3 - collected via Pipelines/Backup :-)
+  latestFile="$(aws s3 ls s3://cdis-terraform-state/JenkinsBackup/ | sort | tail -1 | awk '{ print $4}')"
+  aws s3 cp "s3://cdis-terraform-state/JenkinsBackup/$latestFile" /tmp/backup.tar.xz
+  tar xvf /tmp/backup.tar.xz -C /tmp
+  mv /tmp/var/jenkins_home/* /var/jenkins_home/
+fi
+
+source /usr/local/bin/jenkins.sh

--- a/Jenkins/Docker/Jenkins/push.sh
+++ b/Jenkins/Docker/Jenkins/push.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker tag cdis-jenkins:1.0.0 quay.io/cdis/jenkins:1.0.0
+docker push quay.io/cdis/jenkins:1.0.0

--- a/Jenkins/Pipelines/Backup/Jenkinsfile
+++ b/Jenkins/Pipelines/Backup/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     stage('BuildArchive'){
       steps {
         echo "BuildArchive $env.JENKINS_HOME"
-        sh "tar cvJf backup.tar.xz --exclude '$env.JENKINS_HOME/jobs/[^/]*/builds/*' --exclude '$env.JENKINS_HOME/jobs/[^/]*/last*' --exclude '$env.JENKINS_HOME/workspace' --exclude '$env.JENKINS_HOME/jobs/[^/]*/workspace/'  $env.JENKINS_HOME"
+        sh "tar cvJf backup.tar.xz --exclude '$env.JENKINS_HOME/jobs/[^/]*/builds/*' --exclude '$env.JENKINS_HOME/jobs/[^/]*/last*' --exclude '$env.JENKINS_HOME/workspace' --exclude '$env.JENKINS_HOME/war' --exclude '$env.JENKINS_HOME/jobs/[^/]*/workspace/'  $env.JENKINS_HOME"
       }
     }
     stage('UploadToS3') {

--- a/Jenkins/Pipelines/Backup/Jenkinsfile
+++ b/Jenkins/Pipelines/Backup/Jenkinsfile
@@ -23,4 +23,15 @@ pipeline {
       }
     }
   }
+  post {
+    success {
+      slackSend color: 'good', message: 'Jenkins backup pipeline succeeded'
+    }
+    failure {
+      slackSend color: 'bad', message: 'Jenkins backup pipeline failed'
+    }
+    unstable {
+      slackSend color: 'bad', message: 'Jenkins backup pipeline unstable'
+    }
+  }
 }

--- a/Jenkins/Pipelines/KubeCheck/Jenkinsfile
+++ b/Jenkins/Pipelines/KubeCheck/Jenkinsfile
@@ -1,0 +1,27 @@
+#!groovy
+
+pipeline {
+  agent any
+
+  stages {
+    stage('List pods'){
+      steps {
+        script {
+          summary = sh script: "kubectl get pods", returnStdout: true
+          imageInfo = sh script: 'kubectl get pods -o yaml | awk \'{ print $2 }\' | grep -e \'^quay.io\' | sort -u', returnStdout: true
+          message = "https://jenkins.planx-pla.net/job/$env.JOB_NAME/\nJenkins KubeCheck result: \n" + summary + "\n" + imageInfo
+          echo message
+          slackSend color: 'good', message: message
+        }
+      }
+    }
+  }
+  post {
+    failure {
+      slackSend color: 'bad', message: "https://jenkins.planx-pla.net/job/$env.JOB_NAME/\nKubeCheck pipeline failed"
+    }
+    unstable {
+      slackSend color: 'bad', message: "https://jenkins.planx-pla.net/job/$env.JOB_NAME/\nKubeCheck pipeline unstable"
+    }
+  }
+}

--- a/Jenkins/Pipelines/Terraform/Jenkinsfile
+++ b/Jenkins/Pipelines/Terraform/Jenkinsfile
@@ -54,4 +54,15 @@ pipeline {
       }
     }
   }
+  post {
+    success {
+      slackSend color: 'good', message: 'Jenkins Terraform pipeline succeeded'
+    }
+    failure {
+      slackSend color: 'bad', message: 'Jenkins Terraform pipeline failed'
+    }
+    unstable {
+      slackSend color: 'bad', message: 'Jenkins Terraform pipeline unstable'
+    }
+  }
 }

--- a/Jenkins/Pipelines/Terraform/Jenkinsfile
+++ b/Jenkins/Pipelines/Terraform/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   stages {
     stage('FetchCode'){
       steps {
+        //git url: "https://github.com/uc-cdis/cloud-automation.git", branch: 'fix/Jenkins'
         checkout scm
         dir('Secrets') {
             sh 'aws s3 cp s3://cdis-terraform-state/planx-pla.net/v1/config.tfvars config.tfvars'
@@ -16,12 +17,12 @@ pipeline {
     stage('Prep') {
       steps {
         dir('Secrets') {
-          sh 'terraform init -backend-config /mnt/Secrets/terraform/aws.backend.tfvars -backend-config backend.tfvars ../tf_files/aws'
+          sh 'terraform init -backend-config access_key=$AWS_ACCESS_KEY_ID -backend-config secret_key=$AWS_SECRET_ACCESS_KEY -backend-config backend.tfvars ../tf_files/aws'
         }
         dir('SecretsNoPlan') {
           sh 'cp ../Secrets/*.tfvars .'
           sh 'echo \'key = "noplan/terraform.tfstate"\' > noplan.tfvars'
-          sh 'terraform init -backend-config /mnt/Secrets/terraform/aws.backend.tfvars -backend-config backend.tfvars --backend-config noplan.tfvars ../tf_files/aws'
+          sh 'terraform init -backend-config access_key=$AWS_ACCESS_KEY_ID -backend-config secret_key=$AWS_SECRET_ACCESS_KEY -backend-config backend.tfvars --backend-config noplan.tfvars ../tf_files/aws'
         }
       }
     }
@@ -29,7 +30,7 @@ pipeline {
       steps {
         dir('SecretsNoPlan') {
           echo 'Planning - no state ...'
-          sh 'terraform plan --var-file /mnt/Secrets/terraform/aws.tfvars --var-file config.tfvars ../tf_files/aws'
+          sh 'terraform plan --var aws_access_key=$AWS_ACCESS_KEY_ID --var aws_secret_key=$AWS_SECRET_ACCESS_KEY --var-file config.tfvars ../tf_files/aws'
         }
       }
     }
@@ -37,7 +38,7 @@ pipeline {
       steps {
         dir('Secrets') {
           echo 'Planning ...'
-          sh 'terraform plan --var-file /mnt/Secrets/terraform/aws.tfvars --var-file config.tfvars -out plan.terraform ../tf_files/aws'
+          sh 'terraform plan --var aws_access_key=$AWS_ACCESS_KEY_ID --var aws_secret_key=$AWS_SECRET_ACCESS_KEY --var-file config.tfvars -out plan.terraform ../tf_files/aws'
         }
       }
     }

--- a/Jenkins/Pipelines/TerraformPlanOnly/Jenkinsfile
+++ b/Jenkins/Pipelines/TerraformPlanOnly/Jenkinsfile
@@ -42,4 +42,15 @@ pipeline {
       }
     }
   }
+  post {
+    success {
+      slackSend color: 'good', message: 'Jenkins TerraformPlanOnly pipeline succeeded'
+    }
+    failure {
+      slackSend color: 'bad', message: 'Jenkins TerraformPlanOnly pipeline failed'
+    }
+    unstable {
+      slackSend color: 'bad', message: 'Jenkins TerraformPlanOnly pipeline unstable'
+    }
+  }
 }

--- a/Jenkins/Pipelines/TerraformPlanOnly/Jenkinsfile
+++ b/Jenkins/Pipelines/TerraformPlanOnly/Jenkinsfile
@@ -16,12 +16,12 @@ pipeline {
     stage('Prep') {
       steps {
         dir('Secrets') {
-          sh 'terraform init -backend-config /mnt/Secrets/terraform/aws.backend.tfvars -backend-config backend.tfvars ../tf_files/aws'
+          sh 'terraform init -backend-config access_key=$AWS_ACCESS_KEY_ID -backend-config secret_key=$AWS_SECRET_ACCESS_KEY -backend-config backend.tfvars ../tf_files/aws'
         }
         dir('SecretsNoPlan') {
           sh 'cp ../Secrets/*.tfvars .'
           sh 'echo \'key = "noplan/terraform.tfstate"\' > noplan.tfvars'
-          sh 'terraform init -backend-config /mnt/Secrets/terraform/aws.backend.tfvars -backend-config backend.tfvars --backend-config noplan.tfvars ../tf_files/aws'
+          sh 'terraform init -backend-config access_key=$AWS_ACCESS_KEY_ID -backend-config secret_key=$AWS_SECRET_ACCESS_KEY -backend-config backend.tfvars --backend-config noplan.tfvars ../tf_files/aws'
         }
       }
     }
@@ -29,7 +29,7 @@ pipeline {
       steps {
         dir('SecretsNoPlan') {
           echo 'Planning - no state ...'
-          sh 'terraform plan --var-file /mnt/Secrets/terraform/aws.tfvars --var-file config.tfvars ../tf_files/aws'
+          sh 'terraform plan --var aws_access_key=$AWS_ACCESS_KEY_ID --var aws_secret_key=$AWS_SECRET_ACCESS_KEY --var-file config.tfvars ../tf_files/aws'
         }
       }
     }
@@ -37,7 +37,7 @@ pipeline {
       steps {
         dir('Secrets') {
           echo 'Planning ...'
-          sh 'terraform plan --var-file /mnt/Secrets/terraform/aws.tfvars --var-file config.tfvars -out plan.terraform ../tf_files/aws'
+          sh 'terraform plan --var aws_access_key=$AWS_ACCESS_KEY_ID --var aws_secret_key=$AWS_SECRET_ACCESS_KEY --var-file config.tfvars -out plan.terraform ../tf_files/aws'
         }
       }
     }

--- a/Jenkins/Stacks/Jenkins/jenkins.env.sample
+++ b/Jenkins/Stacks/Jenkins/jenkins.env.sample
@@ -1,0 +1,6 @@
+HTTP_POXY=http://cloud-proxy.internal.io:3128
+HTTPS_PROXY=http://cloud-proxy.internal.io:3128
+NO_PROXY=localhost,127.0.0.1,.internal.io
+AWS_ACCESS_KEY_ID=FILL/THIS/IN
+AWS_SECRET_ACCESS_KEY=FILL/THIS/IN
+AWS_DEFAULT_REGION=us-east-1

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,13 +44,16 @@ pipeline {
   }
   post {
     success {
-      slackSend color: 'good', message: 'Jenkins uc-cdis/cloud-automation pipeline succeeded'
+      slackSend color: 'good', message: "https://jenkins.planx-pla.net/job/$env.JOB_NAME/
+uc-cdis/cloud-automation pipeline succeeded"
     }
     failure {
-      slackSend color: 'bad', message: 'Jenkins uc-cdis/cloud-automation pipeline failed'
+      slackSend color: 'bad', message: "https://jenkins.planx-pla.net/job/$env.JOB_NAME/
+uc-cdis/cloud-automation pipeline failed"
     }
     unstable {
-      slackSend color: 'bad', message: 'Jenkins uc-cdis/cloud-automation pipeline unstable'
+      slackSend color: 'bad', message: "https://jenkins.planx-pla.net/job/$env.JOB_NAME/
+uc-cdis/cloud-automation pipeline unstable"
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,13 +44,13 @@ pipeline {
   }
   post {
     success {
-      slackSend color: 'good', message: 'Jenkins TerraformPlanOnly pipeline succeeded'
+      slackSend color: 'good', message: 'Jenkins uc-cdis/cloud-automation pipeline succeeded'
     }
     failure {
-      slackSend color: 'bad', message: 'Jenkins TerraformPlanOnly pipeline failed'
+      slackSend color: 'bad', message: 'Jenkins uc-cdis/cloud-automation pipeline failed'
     }
     unstable {
-      slackSend color: 'bad', message: 'Jenkins TerraformPlanOnly pipeline unstable'
+      slackSend color: 'bad', message: 'Jenkins uc-cdis/cloud-automation pipeline unstable'
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ to destroy the whole stack.
 - Login node. This VM opens  port 22 to the world and is the entry point for ssh access to the cloud.
 - HTTP/HTTPS proxy node(cloud-proxy.internal.io). This proxies all HTTP/HTTPS traffic for internal VMs.
 - Kubernete provisioner VM (kube.internal.io). This is the VM to use [kube-aws](https://github.com/kubernetes-incubator/kube-aws) to setup the kubernete cluster. kube-aws can be run anywhere, but since we want to setup our k8 cluster inside the private subnet, we have to provision it also inside the same subnet. Since terraform doesn't support ssh access through head node, the needed scripts to setup this node are copied to tf_files/${vpc_name}_output directory, and you need to copy the directory to this VM and follow the [instruction](https://github.com/uc-cdis/cloud-automation/blob/master/kube/README.md) to setup this VM.
-- API reverse proxy node(revproxy.internal.io). This is the current single reverse proxy VM for Gen 3 stack apis. This should later be migrated to ELB. Since terraform doesn't support ssh access through head node, the needed scripts to setup this node are copied to tf_files/${vpc_name}_output directory, and you need to copy `proxy.conf` and `revproxy-setup.sh` to this VM and run the setup script after the kubernete cluster is up.
 
 ## Working inside VPC
 1. Load your ssh key pair in EC2 -> Key Pairs dashboard.

--- a/apis_configs/user.yaml
+++ b/apis_configs/user.yaml
@@ -50,4 +50,15 @@ users:
     projects:
     - auth_id: acct
       privilege: ['create', 'read', 'update', 'delete', 'upload']
+  avantol@uchicago.edu:
+    admin: True
+    projects:
+    - auth_id: acct
+      privilege: ['create', 'read', 'update', 'delete', 'upload']
+  chris.g.meyer@gmail.com:
+    admin: True
+    projects:
+    - auth_id: acct
+      privilege: ['create', 'read', 'update', 'delete', 'upload']
+
   

--- a/apis_configs/user.yaml
+++ b/apis_configs/user.yaml
@@ -35,3 +35,19 @@ users:
     projects:
     - auth_id: acct
       privilege: ['create', 'read', 'update', 'delete', 'upload']
+  reuben@frickjack.com:
+    admin: True
+    projects:
+    - auth_id: acct
+      privilege: ['create', 'read', 'update', 'delete', 'upload']
+  reubenonrye@uchicago.edu:
+    admin: True
+    projects:
+    - auth_id: acct
+      privilege: ['create', 'read', 'update', 'delete', 'upload']
+  rudyardrichter@uchicago.edu:
+    admin: True
+    projects:
+    - auth_id: acct
+      privilege: ['create', 'read', 'update', 'delete', 'upload']
+  

--- a/kube/README.md
+++ b/kube/README.md
@@ -107,6 +107,27 @@ Then you can do ssh port forward from your laptop:
 ssh -L9090:localhost:9090 -N kube_provisioner_vm
 ```
 
+### Setting up users and roles
+
+K8s 1.6.+ includes RBAC support for both user and service accounts, but the RBAC plugin is 
+not enabled by default in the latest stable kube-aws release - the next stable release of kube-aws [(v0.9.9)](https://github.com/kubernetes-incubator/kube-aws/releases) will
+[enable RBAC enforcement by default](https://github.com/kubernetes-incubator/kube-aws/issues/655).
+
+* [service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) are intended for use by pods running on the cluster.
+   If not otherwise specified a pod is automatically associated with the 'default' service account.  (https://kubernetes.io/docs/admin/authorization/rbac/#upgrading-from-15).
+    * [service accounts administration guide](https://kubernetes.io/docs/admin/service-accounts-admin/)
+    * [linking pods with service accounts](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
+    * [k8s built in secrets management](https://kubernetes.io/docs/concepts/configuration/secret/#built-in-secrets) automatically handles injecting service account credentials into pods
+    * [upgrading non-RBAC clusters](https://kubernetes.io/docs/admin/authorization/rbac/#upgrading-from-15) - the current kube-aws 'default' service account currently grants admin privileges on the cluster to all services - v0.9.9 will enable RBAC
+    by default with reasonble roles for the different core services.
+
+* user accounts 
+    * k8s supports multiple [approaches to authentication](https://kubernetes.io/docs/admin/authentication/)
+    * [k8s RBAC](https://kubernetes.io/docs/admin/authorization/rbac/) is one way to restrict how an authenticated user can access k8s
+    * k8s also supports [ABAC](https://kubernetes.io/docs/admin/authorization/abac/) (attribute based acess control)
+    * [this page](https://docs.bitnami.com/kubernetes/how-to/configure-rbac-in-your-kubernetes-cluster/#use-case-1-create-user-with-limited-namespace-access) walks through creating a user account authenticated via a TLS certificate and associated with an RBAC role
+  
+
 ### Services
 #### [userapi](https://github.com/uc-cdis/user-api)
 The authentication and authorization provider.
@@ -123,6 +144,7 @@ Elasticsearch-Logstash-Kibana pod for log aggregation using filebeat.
 
 ### bash functions
 There are some helper functions in [kubes.sh](https://github.com/uc-cdis/cloud-automation/blob/master/kube/kubes.sh) for k8s related operations.
+
 #### patch_kube
 `patch_kube $DEPLOYMENT_NAME` to let k8s recycle pods when there is no change.
 

--- a/kube/services/gdcapi/gdcapi-deploy.yaml
+++ b/kube/services/gdcapi/gdcapi-deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: gdcapi-deployment
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kube/services/indexd/indexd-deploy.yaml
+++ b/kube/services/indexd/indexd-deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: indexd-deployment
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kube/services/jenkins/00pvc.yaml
+++ b/kube/services/jenkins/00pvc.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: datadir-jenkins
+  annotations:
+    volume.beta.kubernetes.io/storage-class: gp2 
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi

--- a/kube/services/jenkins/10storageclass.yaml
+++ b/kube/services/jenkins/10storageclass.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: gp2
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2 
+  zone: us-east-1a

--- a/kube/services/jenkins/apply_service.sh
+++ b/kube/services/jenkins/apply_service.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+
+export ARN=$(kubectl get configmap global --output=jsonpath='{.data.revproxy_arn}')
+if [[ ! -z $ARN ]]; then
+  envsubst <$scriptDir/jenkins-service.yaml | kubectl apply -f -
+else
+  echo "Global configmap not configured"
+fi

--- a/kube/services/jenkins/deploy_jenkins.sh
+++ b/kube/services/jenkins/deploy_jenkins.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Just a little helper for deploying jenkins onto k8s the first time
+#
+
+set -e
+echo 'Registering Jenkins with k8s'
+
+#
+# Assume Jenkins should use the credentials harvested by terraform,
+# then copied into ~/.aws/credentials by kube-up.sh ...
+#
+if [ -f ~/.aws/credentials ]; then
+  aws_access_key_id="$(cat ~/.aws/credentials | grep aws_access_key_id | sed 's/.*=//' | sed 's/\s*//g' | head -1)"
+  aws_secret_access_key="$(cat ~/.aws/credentials | grep aws_secret_access_key | sed 's/.*=//' | sed 's/\s*//g' | head -1)"
+fi
+if [ -z "$aws_access_key_id" -o -z "$aws_secret_access_key" ]; then
+  echo 'WARNING: not configuring jenkins - could not extract secrets from ~/.aws/credentials'
+else
+  kubectl create secret generic jenkins-secret "--from-literal=aws_access_key_id=$aws_access_key_id" "--from-literal=aws_secret_access_key=$aws_secret_access_key"
+  kubectl apply -f services/jenkins/serviceaccount.yaml
+  kubectl apply -f services/jenkins/role-devops.yaml
+  kubectl apply -f services/jenkins/rolebinding-devops.yaml
+  
+  kubectl apply -f services/jenkins/jenkins-deploy.yaml
+  kubectl apply -f services/jenkins/jenkins-service.yaml
+fi

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -14,12 +14,15 @@ spec:
       labels:
         app: jenkins
     spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
       - name: jenkins
         image: quay.io/cdis/jenkins:latest
         livenessProbe:
           httpGet:
-            path: /jenkins/login
+            path: /login
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 60
@@ -32,8 +35,6 @@ spec:
               configMapKeyRef:
                 name: global
                 key: hostname
-          - name: JENKINS_OPTS
-            value: --prefix=/jenkins
           - name: AWS_DEFAULT_REGION
             value: us-east-1
           - name: AWS_ACCESS_KEY_ID
@@ -46,11 +47,17 @@ spec:
               secretKeyRef:
                 name: jenkins-secret
                 key: aws_secret_access_key
-
         readinessProbe:
           httpGet:
-            path: /jenkins/login
+            path: /login
             port: 8080
         imagePullPolicy: Always
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/jenkins_home
+      volumes:
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir-jenkins  
       imagePullSecrets:
         - name: cdis-devservices-pull-secret

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: jenkins-deployment
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -19,7 +20,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: jenkins
-        image: quay.io/cdis/jenkins:latest
+        image: quay.io/cdis/jenkins:1.0.0
         livenessProbe:
           httpGet:
             path: /login

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -56,9 +56,28 @@ spec:
         volumeMounts:
         - name: datadir
           mountPath: /var/jenkins_home
+        - name: "kubeconfig-volume"
+          readOnly: true
+          mountPath: "/var/jenkins_home/.kube/config"
+          subPath: "kubeconfig"
+        - name: "kubeconfig-volume"
+          readOnly: true
+          mountPath: "/var/jenkins_home/.kube/credentials/ca.pem"
+          subPath: "ca.pem"
+        - name: "kubeconfig-volume"
+          readOnly: true
+          mountPath: "/var/jenkins_home/.kube/credentials/jenkins.crt"
+          subPath: "jenkins.crt"
+        - name: "kubeconfig-volume"
+          readOnly: true
+          mountPath: "/var/jenkins_home/.kube/credentials/jenkins.key"
+          subPath: "jenkins.key"
       volumes:
       - name: datadir
         persistentVolumeClaim:
-          claimName: datadir-jenkins  
+          claimName: datadir-jenkins
+      - name: kubeconfig-volume
+        secret:
+          secretName: "jenkins-secret"  
       imagePullSecrets:
         - name: cdis-devservices-pull-secret

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -1,0 +1,56 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jenkins-deployment
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      containers:
+      - name: jenkins
+        image: quay.io/cdis/jenkins:latest
+        livenessProbe:
+          httpGet:
+            path: /jenkins/login
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 30
+        ports:
+        - containerPort: 8080
+        env:
+          - name: HOSTNAME
+            valueFrom:
+              configMapKeyRef:
+                name: global
+                key: hostname
+          - name: JENKINS_OPTS
+            value: --prefix=/jenkins
+          - name: AWS_DEFAULT_REGION
+            value: us-east-1
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-secret
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: jenkins-secret
+                key: aws_secret_access_key
+
+        readinessProbe:
+          httpGet:
+            path: /jenkins/login
+            port: 8080
+        imagePullPolicy: Always
+      imagePullSecrets:
+        - name: cdis-devservices-pull-secret

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         app: jenkins
     spec:
+      serviceAccountName: jenkins-service
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
@@ -56,28 +57,9 @@ spec:
         volumeMounts:
         - name: datadir
           mountPath: /var/jenkins_home
-        - name: "kubeconfig-volume"
-          readOnly: true
-          mountPath: "/var/jenkins_home/.kube/config"
-          subPath: "kubeconfig"
-        - name: "kubeconfig-volume"
-          readOnly: true
-          mountPath: "/var/jenkins_home/.kube/credentials/ca.pem"
-          subPath: "ca.pem"
-        - name: "kubeconfig-volume"
-          readOnly: true
-          mountPath: "/var/jenkins_home/.kube/credentials/jenkins.crt"
-          subPath: "jenkins.crt"
-        - name: "kubeconfig-volume"
-          readOnly: true
-          mountPath: "/var/jenkins_home/.kube/credentials/jenkins.key"
-          subPath: "jenkins.key"
       volumes:
       - name: datadir
         persistentVolumeClaim:
           claimName: datadir-jenkins
-      - name: kubeconfig-volume
-        secret:
-          secretName: "jenkins-secret"  
       imagePullSecrets:
         - name: cdis-devservices-pull-secret

--- a/kube/services/jenkins/jenkins-service.yaml
+++ b/kube/services/jenkins/jenkins-service.yaml
@@ -1,13 +1,19 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: jenkins-service 
+  name: jenkins-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http 
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: $ARN
+    # this is not supported yet
+    service.beta.kubernetes.io/aws-load-balancer-security-policy: "ELBSecurityPolicy-TLS-1-2-2017-01" 
 spec:
   selector:
     app: jenkins
   ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 8080 
-      nodePort: 30005 
-  type: NodePort
+    - protocol: TCP 
+      port: 443 
+      targetPort: 8080
+      name: https
+    type: LoadBalancer 

--- a/kube/services/jenkins/jenkins-service.yaml
+++ b/kube/services/jenkins/jenkins-service.yaml
@@ -1,0 +1,13 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: jenkins-service 
+spec:
+  selector:
+    app: jenkins
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080 
+      nodePort: 30005 
+  type: NodePort

--- a/kube/services/jenkins/role-devops.yaml
+++ b/kube/services/jenkins/role-devops.yaml
@@ -1,0 +1,9 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: devops
+rules:
+- apiGroups: ["", "extensions", "apps"]
+  resources: ["deployments", "replicasets", "pods"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"] # You can also use ["*"]

--- a/kube/services/jenkins/rolebinding-devops.yaml
+++ b/kube/services/jenkins/rolebinding-devops.yaml
@@ -4,8 +4,8 @@ metadata:
   name: devops-binding
   namespace: default
 subjects:
-- kind: User
-  name: jenkins
+- kind: ServiceAccount
+  name: jenkins-service
   apiGroup: ""
 roleRef:
   kind: Role

--- a/kube/services/jenkins/rolebinding-devops.yaml
+++ b/kube/services/jenkins/rolebinding-devops.yaml
@@ -1,0 +1,14 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: devops-binding
+  namespace: default
+subjects:
+- kind: User
+  name: jenkins
+  apiGroup: ""
+roleRef:
+  kind: Role
+  name: devops
+  apiGroup: ""
+

--- a/kube/services/jenkins/serviceaccount.yaml
+++ b/kube/services/jenkins/serviceaccount.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jenkins-service

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: portal-deployment
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kube/services/revproxy/00nginx-config.yaml
+++ b/kube/services/revproxy/00nginx-config.yaml
@@ -11,68 +11,99 @@ data:
       pid /run/nginx.pid;
       
       events {
-      	worker_connections 768;
-      	# multi_accept on;
+        worker_connections 768;
+        # multi_accept on;
       }
       
       http {
+        ##
+        # Basic Settings
+        ##
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        # server_tokens off;
       
-      	##
-      	# Basic Settings
-      	##
+        # server_names_hash_bucket_size 64;
+        # server_name_in_redirect off;
       
-      	sendfile on;
-      	tcp_nopush on;
-      	tcp_nodelay on;
-      	keepalive_timeout 65;
-      	types_hash_max_size 2048;
-      	# server_tokens off;
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
       
-      	# server_names_hash_bucket_size 64;
-      	# server_name_in_redirect off;
+        ##
+        # Logging Settings
+        ##
       
-      	include /etc/nginx/mime.types;
-      	default_type application/octet-stream;
+        access_log /dev/stdout;
+        error_log /dev/stderr;
       
-      	##
-      	# Logging Settings
-      	##
-      
-      	access_log /dev/stdout;
-      	error_log /dev/stderr;
-      
-      	##
-      	# Gzip Settings
-      	##
+        ##
+        # Gzip Settings
+        ##
         gzip on;
         gzip_disable "msie6";
         gzip_types application/javascript;
       
         ##
-      	# Proxy Settings
-      	##
-      	server {
-      		listen 80;
-      		server_tokens off;
-      		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
-      		add_header X-Frame-Options "SAMEORIGIN";
-      		if ($http_x_forwarded_proto = "http") { rewrite ^/(.*)$ https://$host$request_uri permanent; }
-      		location / {
-      		    proxy_pass http://portal-service.default/;
-      		}
-      		location /index {
-      		    proxy_pass http://indexd-service.default/;
-      		}
-      		location /user {
-      		    proxy_pass http://userapi-service.default/;
-      		}
-      		location /api {
-      		    proxy_next_upstream off;
-                    # Forward the host and set Subdir header so api
-                    # knows the original request path for hmac signing
-      		    proxy_set_header   Host $host;
-      		    proxy_set_header   Subdir /api;
-      		    proxy_pass http://gdcapi-service.default/;
-      		}
-      	}
+        # Proxy Settings
+        ##
+        server {
+            listen 80;
+            server_tokens off;
+            add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+            add_header X-Frame-Options "SAMEORIGIN";
+            if ($http_x_forwarded_proto = "http") { rewrite ^/(.*)$ https://$host$request_uri permanent; }
+            location / {
+                proxy_pass http://portal-service.default/;
+            }
+            location /index {
+                proxy_pass http://indexd-service.default/;
+            }
+            location /user {
+                proxy_pass http://userapi-service.default/;
+            }
+            location /api {
+                proxy_next_upstream off;
+                        # Forward the host and set Subdir header so api
+                        # knows the original request path for hmac signing
+                proxy_set_header   Host $host;
+                proxy_set_header   Subdir /api;
+                proxy_pass http://gdcapi-service.default/;
+            }
+            location /jenkins {
+                # From:
+                #    https://wiki.jenkins.io/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy
+                # Convert inbound WAN requests for https://domain.tld/jenkins/ to 
+                # local network requests for http://10.0.0.100:8080/jenkins/
+                proxy_pass http://jenkins-service.default/jenkins/;
+                
+                # Rewrite HTTPS requests from WAN to HTTP requests on LAN
+                proxy_redirect http:// https://;
+        
+                # The following settings from https://wiki.jenkins-ci.org/display/JENKINS/Running+Hudson+behind+Nginx
+                sendfile off;
+        
+                proxy_set_header   Host             $host:$server_port;
+                proxy_set_header   X-Real-IP        $remote_addr;
+                proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
+                proxy_max_temp_file_size 0;
+        
+                #this is the maximum upload size
+                client_max_body_size       10m;
+                client_body_buffer_size    128k;
+        
+                proxy_connect_timeout      90;
+                proxy_send_timeout         90;
+                proxy_read_timeout         90;
+        
+                proxy_temp_file_write_size 64k;
+        
+                # Required for new HTTP-based CLI
+                proxy_http_version 1.1;
+                proxy_request_buffering off;
+                proxy_buffering off; # Required for HTTP-based CLI to work over SSL
+            }
+        }
       }

--- a/kube/services/revproxy/00nginx-config.yaml
+++ b/kube/services/revproxy/00nginx-config.yaml
@@ -11,99 +11,68 @@ data:
       pid /run/nginx.pid;
       
       events {
-        worker_connections 768;
-        # multi_accept on;
+      	worker_connections 768;
+      	# multi_accept on;
       }
       
       http {
-        ##
-        # Basic Settings
-        ##
-        sendfile on;
-        tcp_nopush on;
-        tcp_nodelay on;
-        keepalive_timeout 65;
-        types_hash_max_size 2048;
-        # server_tokens off;
       
-        # server_names_hash_bucket_size 64;
-        # server_name_in_redirect off;
+      	##
+      	# Basic Settings
+      	##
       
-        include /etc/nginx/mime.types;
-        default_type application/octet-stream;
+      	sendfile on;
+      	tcp_nopush on;
+      	tcp_nodelay on;
+      	keepalive_timeout 65;
+      	types_hash_max_size 2048;
+      	# server_tokens off;
       
-        ##
-        # Logging Settings
-        ##
+      	# server_names_hash_bucket_size 64;
+      	# server_name_in_redirect off;
       
-        access_log /dev/stdout;
-        error_log /dev/stderr;
+      	include /etc/nginx/mime.types;
+      	default_type application/octet-stream;
       
-        ##
-        # Gzip Settings
-        ##
+      	##
+      	# Logging Settings
+      	##
+      
+      	access_log /dev/stdout;
+      	error_log /dev/stderr;
+      
+      	##
+      	# Gzip Settings
+      	##
         gzip on;
         gzip_disable "msie6";
         gzip_types application/javascript;
       
         ##
-        # Proxy Settings
-        ##
-        server {
-            listen 80;
-            server_tokens off;
-            add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
-            add_header X-Frame-Options "SAMEORIGIN";
-            if ($http_x_forwarded_proto = "http") { rewrite ^/(.*)$ https://$host$request_uri permanent; }
-            location / {
-                proxy_pass http://portal-service.default/;
-            }
-            location /index {
-                proxy_pass http://indexd-service.default/;
-            }
-            location /user {
-                proxy_pass http://userapi-service.default/;
-            }
-            location /api {
-                proxy_next_upstream off;
-                        # Forward the host and set Subdir header so api
-                        # knows the original request path for hmac signing
-                proxy_set_header   Host $host;
-                proxy_set_header   Subdir /api;
-                proxy_pass http://gdcapi-service.default/;
-            }
-            location /jenkins {
-                # From:
-                #    https://wiki.jenkins.io/display/JENKINS/Jenkins+behind+an+NGinX+reverse+proxy
-                # Convert inbound WAN requests for https://domain.tld/jenkins/ to 
-                # local network requests for http://10.0.0.100:8080/jenkins/
-                proxy_pass http://jenkins-service.default/jenkins/;
-                
-                # Rewrite HTTPS requests from WAN to HTTP requests on LAN
-                proxy_redirect http:// https://;
-        
-                # The following settings from https://wiki.jenkins-ci.org/display/JENKINS/Running+Hudson+behind+Nginx
-                sendfile off;
-        
-                proxy_set_header   Host             $host:$server_port;
-                proxy_set_header   X-Real-IP        $remote_addr;
-                proxy_set_header   X-Forwarded-For  $proxy_add_x_forwarded_for;
-                proxy_max_temp_file_size 0;
-        
-                #this is the maximum upload size
-                client_max_body_size       10m;
-                client_body_buffer_size    128k;
-        
-                proxy_connect_timeout      90;
-                proxy_send_timeout         90;
-                proxy_read_timeout         90;
-        
-                proxy_temp_file_write_size 64k;
-        
-                # Required for new HTTP-based CLI
-                proxy_http_version 1.1;
-                proxy_request_buffering off;
-                proxy_buffering off; # Required for HTTP-based CLI to work over SSL
-            }
-        }
+      	# Proxy Settings
+      	##
+      	server {
+      		listen 80;
+      		server_tokens off;
+      		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
+      		add_header X-Frame-Options "SAMEORIGIN";
+      		if ($http_x_forwarded_proto = "http") { rewrite ^/(.*)$ https://$host$request_uri permanent; }
+      		location / {
+      		    proxy_pass http://portal-service.default/;
+      		}
+      		location /index {
+      		    proxy_pass http://indexd-service.default/;
+      		}
+      		location /user {
+      		    proxy_pass http://userapi-service.default/;
+      		}
+      		location /api {
+      		    proxy_next_upstream off;
+                    # Forward the host and set Subdir header so api
+                    # knows the original request path for hmac signing
+      		    proxy_set_header   Host $host;
+      		    proxy_set_header   Subdir /api;
+      		    proxy_pass http://gdcapi-service.default/;
+      		}
+      	}
       }

--- a/kube/services/revproxy/apply_service
+++ b/kube/services/revproxy/apply_service
@@ -1,10 +1,10 @@
 #!/bin/bash
+
 scriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 
 export ARN=$(kubectl get configmap global --output=jsonpath='{.data.revproxy_arn}')
 if [[ ! -z $ARN ]]; then
   envsubst <$scriptDir/revproxy-service.yaml | kubectl apply -f -
-
 else
   echo "Global configmap not configured"
 fi

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: revproxy-deployment
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kube/services/userapi/userapi-deploy.yaml
+++ b/kube/services/userapi/userapi-deploy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: userapi-deployment
 spec:
   replicas: 2
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/setup_kube_aws.bash
+++ b/setup_kube_aws.bash
@@ -21,8 +21,8 @@ fi
 cp ../../bin/kube-aws $OUTPUT_DIR/.
 
 set -e
-scp -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" -r $OUTPUT_DIR ubuntu@kube.internal.io:/home/ubuntu/.
-ssh -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && chmod +x kube-up.sh && ./kube-up.sh"
-ssh -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && mv cdis-devservices-secret.yml ../$VPC_NAME/. && chmod +x kube-services.sh && ./kube-services.sh"
+scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" -r $OUTPUT_DIR ubuntu@kube.internal.io:/home/ubuntu/.
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && chmod +x kube-up.sh && ./kube-up.sh"
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && mv cdis-devservices-secret.yml ../$VPC_NAME/. && chmod +x kube-services.sh && ./kube-services.sh"
 
 set +e

--- a/tf_files/aws/cloud.tf
+++ b/tf_files/aws/cloud.tf
@@ -280,10 +280,10 @@ data "aws_ami" "public_login_ami" {
 
   filter {
     name   = "name"
-    values = ["ubuntu16-client-1.0.0-*"]
+    values = ["ubuntu16-client-1.0.1-*"]
   }
 
-  owners     = ["707767160287"]
+  owners     = ["${var.ami_account_id}"]
 }
 
 data "aws_ami" "public_squid_ami" {
@@ -291,10 +291,10 @@ data "aws_ami" "public_squid_ami" {
 
   filter {
     name   = "name"
-    values = ["ubuntu16-squid-1.0.0-*"]
+    values = ["ubuntu16-squid-1.0.1-*"]
   }
 
-  owners     = ["707767160287"]
+  owners     = ["${var.ami_account_id}"]
 }
 
 resource "aws_ami_copy" "login_ami" {

--- a/tf_files/aws/cloud.tf
+++ b/tf_files/aws/cloud.tf
@@ -275,8 +275,55 @@ resource "aws_db_subnet_group" "private_group" {
     description = "Private subnet group"
 }
 
+data "aws_ami" "public_login_ami" {
+  most_recent      = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu16-client-1.0.0-*"]
+  }
+
+  owners     = ["707767160287"]
+}
+
+data "aws_ami" "public_squid_ami" {
+  most_recent      = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu16-squid-1.0.0-*"]
+  }
+
+  owners     = ["707767160287"]
+}
+
+resource "aws_ami_copy" "login_ami" {
+  name              = "ub16-client-crypt-${var.vpc_name}-1.0.0"
+  description       = "A copy of ubuntu16-client-1.0.0"
+  source_ami_id     = "${data.aws_ami.public_login_ami.id}"
+  source_ami_region = "us-east-1"
+  encrypted = true
+
+  tags {
+    Name = "login"
+  }
+}
+
+resource "aws_ami_copy" "squid_ami" {
+  name              = "ub16-squid-crypt-${var.vpc_name}-1.0.0"
+  description       = "A copy of ubuntu16-squid-1.0.0"
+  source_ami_id     = "${data.aws_ami.public_squid_ami.id}"
+  source_ami_region = "us-east-1"
+  encrypted = true
+
+  tags {
+    Name = "login"
+  }
+}
+
+
 resource "aws_instance" "login" {
-    ami = "${var.login_ami}"
+    ami = "${aws_ami_copy.login_ami.id}"
     subnet_id = "${aws_subnet.public.id}"
     instance_type = "t2.micro"
     monitoring = true
@@ -286,10 +333,13 @@ resource "aws_instance" "login" {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
     }
+    lifecycle {
+        ignore_changes = ["ami"]
+    }
 }
 
 resource "aws_instance" "proxy" {
-    ami = "${var.proxy_ami}"
+    ami = "${aws_ami_copy.squid_ami.id}"
     subnet_id = "${aws_subnet.public.id}"
     instance_type = "t2.micro"
     monitoring = true
@@ -300,7 +350,6 @@ resource "aws_instance" "proxy" {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
     }
-
 }
 
 resource "aws_route53_zone" "main" {

--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -53,6 +53,9 @@ resource "aws_db_instance" "db_userapi" {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
     }
+    lifecycle {
+        ignore_changes = ["identifier", "name"]
+    }
 }
 
 resource "aws_db_instance" "db_gdcapi" {
@@ -73,6 +76,9 @@ resource "aws_db_instance" "db_gdcapi" {
         Organization = "Basic Service"
     }
     vpc_security_group_ids = ["${aws_security_group.local.id}"]
+    lifecycle {
+        ignore_changes = ["identifier", "name"]
+    }
 }
 
 resource "aws_db_instance" "db_indexd" {
@@ -92,6 +98,9 @@ resource "aws_db_instance" "db_indexd" {
     tags {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
+    }
+    lifecycle {
+        ignore_changes = ["identifier", "name"]
     }
 }
 

--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -189,7 +189,7 @@ data "template_file" "aws_creds" {
     }
 }
 resource "aws_instance" "kube_provisioner" {
-    ami = "${var.kube_ami}"
+    ami = "${aws_ami_copy.login_ami.id}"
     subnet_id = "${aws_subnet.private_kube.id}"
     instance_type = "t2.micro"
     monitoring = true
@@ -198,6 +198,9 @@ resource "aws_instance" "kube_provisioner" {
         Name = "Kube Provisioner"
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
+    }
+    lifecycle {
+        ignore_changes = ["ami"]
     }
 }
 

--- a/tf_files/aws/variables.tf
+++ b/tf_files/aws/variables.tf
@@ -72,3 +72,7 @@ variable "gdcapi_oauth2_client_id" {
 # gdcapi's oauth2 client secret
 variable "gdcapi_oauth2_client_secret" {
 }
+# id of AWS account that owns the public AMI's
+variable "ami_account_id" {
+    default = "707767160287"
+}

--- a/tf_files/configs/kube-services.sh
+++ b/tf_files/configs/kube-services.sh
@@ -2,7 +2,7 @@
 set -e
 export http_proxy=http://cloud-proxy.internal.io:3128
 export https_proxy=http://cloud-proxy.internal.io:3128
-export no_proxy=.internal.io
+export no_proxy=localhost,127.0.0.1,169.254.169.254,.internal.io
 export DEBIAN_FRONTEND=noninteractive
 
 sudo -E apt-get update
@@ -26,6 +26,7 @@ kubectl create configmap userapi --from-file=apis_configs/user.yaml
 kubectl create secret generic userapi-secret --from-file=local_settings.py=./apis_configs/userapi_settings.py
 kubectl create secret generic indexd-secret --from-file=local_settings.py=./apis_configs/indexd_settings.py
 
+
 kubectl apply -f 00configmap.yaml
 kubectl apply -f services/portal/portal-deploy.yaml
 kubectl apply -f services/userapi/userapi-deploy.yaml
@@ -34,15 +35,18 @@ kubectl apply -f services/revproxy/00nginx-config.yaml
 kubectl apply -f services/revproxy/revproxy-deploy.yaml
 
 if [ -z "${userapi_snapshot}" ]; then
-cd ~/${vpc_name}_output; python render_creds.py userapi_db
-python render_creds.py  secrets
+  cd ~/${vpc_name}_output; 
+  python render_creds.py userapi_db
+  python render_creds.py  secrets
 fi
 
-cd ~/${vpc_name}; kubectl create secret generic gdcapi-secret --from-file=wsgi.py=./apis_configs/gdcapi_settings.py
+cd ~/${vpc_name};
+kubectl create secret generic gdcapi-secret --from-file=wsgi.py=./apis_configs/gdcapi_settings.py
 kubectl apply -f services/gdcapi/gdcapi-deploy.yaml
 
 if [ -z "${gdcapi_snapshot}" ]; then
-cd ~/${vpc_name}_output; python render_creds.py gdcapi_db
+  cd ~/${vpc_name}_output; 
+  python render_creds.py gdcapi_db
 fi
 
 cd ~/${vpc_name}
@@ -52,10 +56,33 @@ kubectl apply -f services/indexd/indexd-service.yaml
 kubectl apply -f services/gdcapi/gdcapi-service.yaml
 ./services/revproxy/apply_service
 
+if [ "$KUBE_JENKINS" = "enabled" ]; then
+  echo "Registering Jenkins with k8s"
+  #
+  # Assume Jenkins should use the credentials harvested by terraform,
+  # then copied into ~/.aws/credentials by kube-up.sh ...
+  #
+  if [ -f ~/.aws/credentials ]; then
+    aws_access_key_id="$(cat ~/.aws/credentials | grep aws_access_key_id | sed 's/.*=//' | sed 's/\s*//g' | head -1)"
+    aws_secret_access_key="$(cat ~/.aws/credentials | grep aws_secret_access_key | sed 's/.*=//' | sed 's/\s*//g' | head -1)"
+  fi
+  if [ -z "$aws_access_key_id" -o -z "$aws_secret_access_key" ]; then
+    echo "WARNING: skipping Jenkins secret generation - not configuring jenkins"
+  else
+    kubectl create secret generic jenkins-secret "--from-literal=aws_access_key_id=$aws_access_key_id" "--from-literal=aws_secret_access_key=$aws_secret_access_key"
+    kubectl apply -f services/jenkins/jenkins-deploy.yaml
+    kubectl apply -f services/jenkins/jenkins-service.yaml
+  fi
+fi
+
 cat >>~/.bashrc << EOF
+export http_proxy=http://cloud-proxy.internal.io:3128
+export https_proxy=http://cloud-proxy.internal.io:3128
+export no_proxy=localhost,127.0.0.1,169.254.169.254,.internal.io
+
 export KUBECONFIG=~/${vpc_name}/kubeconfig
+
 if [ -f ~/cloud-automation/kube/kubes.sh ]; then
     . ~/cloud-automation/kube/kubes.sh
 fi
 EOF
-

--- a/tf_files/configs/kube-services.sh
+++ b/tf_files/configs/kube-services.sh
@@ -67,26 +67,14 @@ if [ "$KUBE_JENKINS" = "enabled" ]; then
     aws_secret_access_key="$(cat ~/.aws/credentials | grep aws_secret_access_key | sed 's/.*=//' | sed 's/\s*//g' | head -1)"
   fi
   if [ -z "$aws_access_key_id" -o -z "$aws_secret_access_key" ]; then
-    echo "WARNING: skipping Jenkins secret generation - not configuring jenkins"
+    echo "WARNING: not configuring jenkins"
   else
-    
-    openssl genrsa -out credentials/jenkins.key 2048
-    openssl req -new -key credentials/jenkins.key -out credentials/jenkins.csr -subj '/CN=jenkins/O=cdis'
-    openssl x509 -req -in credentials/jenkins.csr -CA credentials/ca.pem -CAkey credentials/ca-key.pem -CAcreateserial -out credentials/jenkins.crt -days 500
-    
-    kubectl config set-credentials jenkins --client-certificate=credentials/jenkins.crt --client-key=credentials/jenkins.key 
-    kubectl config set-context jenkins-context --cluster=kube-aws-planxplanetv1-cluster  --namespace=default --user=jenkins
-
-    cp kubeconfig kubeconfig_jenkins
-    sed -i 's/current-context: .*/current-context: jenkins-context/' kubeconfig_jenkins
-    
+    kubectl apply -f services/jenkins/serviceaccount.yaml
     kubectl apply -f services/jenkins/role-devops.yaml
     kubectl apply -f services/jenkins/rolebinding-devops.yaml
     
-    kubectl create secret generic jenkins-secret "--from-literal=aws_access_key_id=$aws_access_key_id" "--from-literal=aws_secret_access_key=$aws_secret_access_key" --from-file=kubeconfig=kubeconfig_jenkins --from-file=ca.pem=credentials/ca.pem --from-file=jenkins.crt=credentials/jenkins.crt --from-file=jenkins.key=credentials/jenkins.key
     kubectl apply -f services/jenkins/jenkins-deploy.yaml
     kubectl apply -f services/jenkins/jenkins-service.yaml
-
   fi
 fi
 

--- a/tf_files/configs/kube-up.sh
+++ b/tf_files/configs/kube-up.sh
@@ -1,19 +1,39 @@
 #!/bin/bash
+
 set -e
+
 export http_proxy=http://cloud-proxy.internal.io:3128
 export https_proxy=http://cloud-proxy.internal.io:3128
+export no_proxy=127.0.0.1,localhost,.internal.io
 export DEBIAN_FRONTEND=noninteractive
+
+cd $(dirname "$0")
 
 sudo -E apt-get update
 sudo -E apt-get install -y git
+sudo -E pip install awscli --upgrade
+
 mkdir -p ~/.aws
 mkdir -p ~/${vpc_name}
 mv credentials ~/.aws
 cp cluster.yaml ~/${vpc_name}
 cp 00configmap.yaml ~/${vpc_name}
 
-chmod +x kube-aws
-sudo mv kube-aws /usr/bin
+wget https://github.com/kubernetes-incubator/kube-aws/releases/download/v0.9.8/kube-aws-linux-amd64.tar.gz
+tar -zxvf kube-aws-linux-amd64.tar.gz
+chmod -R a+rX linux-amd64
+sudo mv linux-amd64/kube-aws /usr/local/bin
+rm kube-aws-linux-amd64.tar.gz
+rm -r linux-amd64
+#chmod +x kube-aws
+#sudo mv kube-aws /usr/bin
+
+wget https://dl.k8s.io/v1.7.10/kubernetes-client-linux-amd64.tar.gz
+tar xvfz kubernetes-client-linux-amd64.tar.gz
+chmod -R a+rX kubernetes/client/bin
+sudo mv kubernetes/client/bin/kube* /usr/local/bin/
+rm kubernetes-client-linux-amd64.tar.gz
+rm -r kubernetes
 
 cd ~
 git clone https://github.com/uc-cdis/cloud-automation.git 2>/dev/null || true
@@ -23,14 +43,10 @@ ln -fs ~/cloud-automation/kube/services ~/${vpc_name}/services
 
 cd ~/${vpc_name}
 
-kube-aws render credentials --generate-ca
-kube-aws render || true
-kube-aws validate --s3-uri s3://${s3_bucket}
-kube-aws up --s3-uri s3://${s3_bucket}
-
-wget https://storage.googleapis.com/kubernetes-release/release/v1.7.4/bin/linux/amd64/kubectl
-chmod +x kubectl
-sudo mv kubectl /usr/local/bin/
+/usr/local/bin/kube-aws render credentials --generate-ca
+/usr/local/bin/kube-aws render || true
+/usr/local/bin/kube-aws validate --s3-uri "s3://${s3_bucket}/${vpc_name}"
+/usr/local/bin/kube-aws up --s3-uri "s3://${s3_bucket}/${vpc_name}"
 
 export no_proxy=.internal.io
 kubectl --kubeconfig=kubeconfig get nodes

--- a/tf_files/configs/kube-up.sh
+++ b/tf_files/configs/kube-up.sh
@@ -9,6 +9,7 @@ export DEBIAN_FRONTEND=noninteractive
 
 sudo -E apt-get update
 sudo -E apt-get install -y git python-pip
+sudo -E pip install --upgrade pip
 sudo -E pip install awscli --upgrade
 
 mkdir -p ~/.aws

--- a/tf_files/configs/kube-up.sh
+++ b/tf_files/configs/kube-up.sh
@@ -7,10 +7,8 @@ export https_proxy=http://cloud-proxy.internal.io:3128
 export no_proxy=127.0.0.1,localhost,.internal.io
 export DEBIAN_FRONTEND=noninteractive
 
-cd $(dirname "$0")
-
 sudo -E apt-get update
-sudo -E apt-get install -y git
+sudo -E apt-get install -y git python-pip
 sudo -E pip install awscli --upgrade
 
 mkdir -p ~/.aws


### PR DESCRIPTION
* setup k8s deployment, public service, persistent volume, secrets, role, and service-account for jenkins, and updated .sh scripts accordingly
* extended jenkins Docker image with packer and kubectl
* setup jenkins startup script to auto-restore from nightly S3 backup if necessary
* add slack posts to Jenkinsfile pipelines
* add POC 'KubeCheck/Jenkinsfile' pipeline that issues kubectl commands
* patch terraform tf_files/aws/ to copy and encrypt the public ubuntu16-*-1.0.0-* AMI's that the packer scripts under uc-cdis/images repository now publish under the 'cdistest' AWS account 
* update README.md with some notes on RBAC and service accounts in k8s
* add Reuben and Rudy Google accounts to list of default logins for commons
* add 'revisionHistoryLimit: 2' to k8s deployments to hint the garbage collector to reclaim old replica sets
* update k8s versions in kube-up.sh

resolve #102 
resolve #103 
resolve #104 
