### PR TITLE
Chore/jenkins cicd

### DIFF
--- a/Jenkins/Docker/Jenkins/Dockerfile
+++ b/Jenkins/Docker/Jenkins/Dockerfile
@@ -1,10 +1,10 @@
-FROM jenkins/jenkins:2.90
+FROM jenkins/jenkins:2.95
 
 USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 # install python and pip and aws cli
-RUN apt-get update && apt-get install -y apt-utils python python-setuptools python-dev build-essential zip unzip jq && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev build-essential zip unzip jq less && rm -rf /var/lib/apt/lists/*
 RUN easy_install pip
 RUN pip install awscli --upgrade
 

--- a/kube/services/gdcapi/gdcapi-service.yaml
+++ b/kube/services/gdcapi/gdcapi-service.yaml
@@ -9,7 +9,6 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80 
-      nodePort: 30004 
       name: http
     - protocol: TCP 
       port: 443 

--- a/kube/services/indexd/indexd-service.yaml
+++ b/kube/services/indexd/indexd-service.yaml
@@ -9,7 +9,6 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80 
-      nodePort: 30002
       name: http
     - protocol: TCP 
       port: 443 

--- a/kube/services/portal/portal-service.yaml
+++ b/kube/services/portal/portal-service.yaml
@@ -9,7 +9,6 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80 
-      nodePort: 30001
       name: http
     - protocol: TCP 
       port: 443 

--- a/kube/services/revproxy/00nginx-config.yaml
+++ b/kube/services/revproxy/00nginx-config.yaml
@@ -1,3 +1,7 @@
+#
+# Note: apply this file via apply_config to fill in the DNS
+#   resolver required for cookie-based routing to canary/test services
+#
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,8 +23,7 @@ data:
       
       	##
       	# Basic Settings
-      	##
-      
+      	##   
       	sendfile on;
       	tcp_nopush on;
       	tcp_nodelay on;
@@ -57,22 +60,31 @@ data:
       		add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload";
       		add_header X-Frame-Options "SAMEORIGIN";
       		if ($http_x_forwarded_proto = "http") { rewrite ^/(.*)$ https://$host$request_uri permanent; }
-      		location / {
-      		    proxy_pass http://portal-service.default/;
-      		}
-      		location /index {
-      		    proxy_pass http://indexd-service.default/;
-      		}
-      		location /user {
-      		    proxy_pass http://userapi-service.default/;
-      		}
-      		location /api {
-      		    proxy_next_upstream off;
-                    # Forward the host and set Subdir header so api
-                    # knows the original request path for hmac signing
-      		    proxy_set_header   Host $host;
-      		    proxy_set_header   Subdir /api;
-      		    proxy_pass http://gdcapi-service.default/;
-      		}
+          # DNS resolver required to resolve dynamic hostnames, btw - kubedns may not support ipv6
+          resolver kube-dns.kube-system.svc.cluster.local ipv6=off;
+          
+          location / {
+              set $portal_service http://portal-service.default.svc.cluster.local;
+              if ($cookie_portal_service ~ ^[\w-]+$) {
+                  # support accessing portal-service in another k8s namespace
+                  set $portal_service http://portal-service.$cookie_portal_service.svc.cluster.local;
+                  add_header X-debug-portal "$portal_service" always;
+              } 
+              proxy_pass $portal_service;
+          }
+          location /index {
+              proxy_pass http://indexd-service/;
+          }
+          location /user {
+              proxy_pass http://userapi-service/;
+          }
+          location /api {
+              proxy_next_upstream off;
+              # Forward the host and set Subdir header so api
+              # knows the original request path for hmac signing
+              proxy_set_header   Host $host;
+              proxy_set_header   Subdir /api;
+              proxy_pass http://gdcapi-service/;
+          }
       	}
       }

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -34,6 +34,7 @@ spec:
           - 'daemon off;'
         ports:
         - containerPort: 80
+        - containerPort: 443
         volumeMounts:
           - name: "revproxy-conf"
             readOnly: true

--- a/kube/services/userapi/userapi-service.yaml
+++ b/kube/services/userapi/userapi-service.yaml
@@ -9,7 +9,6 @@ spec:
     - protocol: TCP
       port: 80
       targetPort: 80 
-      nodePort: 30003
       name: http
     - protocol: TCP 
       port: 443 

--- a/tf_files/configs/kube-services-body.sh
+++ b/tf_files/configs/kube-services-body.sh
@@ -23,8 +23,8 @@ if [ ! -f ~/"${vpc_name}/cdis-devservices-secret.yml" ]; then
   exit 1
 fi
 
-sudo -E apt-get update
-sudo -E apt-get install -y python-dev python-pip
+sudo -E apt update
+sudo -E apt install -y python-dev python-pip jq
 sudo -E pip install jinja2
 
 mkdir -p ~/${vpc_name}/apis_configs


### PR DESCRIPTION
resolve #109 

Some tweaks to service deployments to support running the same service in different namespaces.
Also wire up the reverse-proxy to dynamically route to data-portal in a namespace based on the value of a 'portal_service' cookie.
Also update the Jenkins Dockerfile to include jq, dnsutils, and less, and version up to Jenkins 2.95.

The actual Jenkins helper function is checked in here (Jenkins loads the code via git):
   https://github.com/uc-cdis/cdis-jenkins-lib
