### PR TITLE
feat(datamodel): add repl and db jobs

### DIFF
--- a/kube/services/datamodelutils/migrate-graphdb-job.yaml
+++ b/kube/services/datamodelutils/migrate-graphdb-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-graph-db
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: datamodelutils
+        imagePullPolicy: Always
+        image: quay.io/cdis/datamodelutils:feat_admin
+        command: ["datamodel_postgres_admin", "create-graph"]
+        env:
+          - name: PG_HOST
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: host
+          - name: PG_USER
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: username
+          - name: PG_PASS
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: password
+          - name: PG_NAME
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: name
+          - name: DICTIONARY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: global
+                key: dictionary_url
+      restartPolicy: Never

--- a/kube/services/datamodelutils/repl-pod.yaml
+++ b/kube/services/datamodelutils/repl-pod.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: api-repl
+spec:
+  containers:
+  - name: datamodelutils
+    imagePullPolicy: Always
+    image: quay.io/cdis/datamodelutils:feat_admin
+    env:
+      - name: PG_HOST
+        valueFrom:
+          secretKeyRef:
+            name: pggraph-db-creds
+            key: host
+      - name: PG_USER
+        valueFrom:
+          secretKeyRef:
+            name: pggraph-db-creds
+            key: username
+      - name: PG_PASS
+        valueFrom:
+          secretKeyRef:
+            name: pggraph-db-creds
+            key: password
+      - name: PG_NAME
+        valueFrom:
+          secretKeyRef:
+            name: pggraph-db-creds
+            key: name
+      - name: DICTIONARY_URL
+        valueFrom:
+          configMapKeyRef:
+            name: global
+            key: dictionary_url
+
+    command: ["sh", "-c", "tail -f /dev/null"]

--- a/kube/services/datamodelutils/setup-graphdb-job.yaml
+++ b/kube/services/datamodelutils/setup-graphdb-job.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: setup-graph-db
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: datamodelutils
+        imagePullPolicy: Always
+        image: quay.io/cdis/datamodelutils:feat_admin
+        command: ["datamodel_postgres_admin", "create-all"]
+        env:
+          - name: PG_HOST
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: host
+          - name: PG_USER
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: username
+          - name: PG_PASS
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: password
+          - name: PG_NAME
+            valueFrom:
+              secretKeyRef:
+                name: pggraph-db-creds
+                key: name
+          - name: DICTIONARY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: global
+                key: dictionary_url
+      restartPolicy: Never


### PR DESCRIPTION
- setup the graph metadata database creation and migration job
- setup a repl pod that can be used to interact with database via sqlalchemy

TODO:
- require [global](https://github.com/uc-cdis/cloud-automation/blob/master/tf_files/configs/00configmap.yaml) configmap to have a dictionary_url
- require a `pggraph-db-creds` secrets