### PR TITLE
WIP: Chore/cookies

### DIFF
--- a/kube/services/revproxy/00nginx-config.yaml
+++ b/kube/services/revproxy/00nginx-config.yaml
@@ -39,8 +39,7 @@ data:
       
       	##
       	# Logging Settings
-      	##
-      
+      	##      
       	access_log /dev/stdout;
       	error_log /dev/stderr;
       
@@ -66,6 +65,21 @@ data:
           set $access_token "";
           if ($cookie_access_token) {
               set $access_token "Bearer $cookie_access_token";
+          }
+          
+          #
+          # CSRF check
+          # This block requires a csrftoken for all POST requests.
+          #
+          set $csrf_check "fail";
+          if ($cookie_csrftoken = $http_x_csrf_token) {
+            set $csrf_check "ok-$cookie_csrftoken";
+          }
+          if ($request_method != "POST") {
+            set $csrf_check "ok-$request_method";
+          }
+          if ($csrf_check !~ ^ok-\S.+$) {
+            return 403 "failed csrf check";
           }
 
           #

--- a/kube/services/revproxy/00nginx-config.yaml
+++ b/kube/services/revproxy/00nginx-config.yaml
@@ -63,6 +63,19 @@ data:
           # DNS resolver required to resolve dynamic hostnames, btw - kubedns may not support ipv6
           resolver kube-dns.kube-system.svc.cluster.local ipv6=off;
           
+          set $access_token "";
+          if ($cookie_access_token) {
+              set $access_token "Bearer $cookie_access_token";
+          }
+
+          #
+          # Note - need to repeat this line in location blocks that call proxy_set_header,
+          #   as nginx proxy module inherits proxy_set_header if and only if current level does
+          #   not set headers ... http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
+          #
+          proxy_set_header   Authorization "$access_token";
+          #add_header X-debug-auth "$access_token"; #- only do this for quick and dirty client-side debugging
+          
           location / {
               set $portal_service http://portal-service.default.svc.cluster.local;
               if ($cookie_portal_service ~ ^[\w-]+$) {
@@ -88,6 +101,7 @@ data:
               # knows the original request path for hmac signing
               proxy_set_header   Host $host;
               proxy_set_header   Subdir /api;
+              proxy_set_header   Authorization "$access_token";
               proxy_connect_timeout 300;
               proxy_send_timeout 300;
               proxy_read_timeout 300;
@@ -100,6 +114,7 @@ data:
               # knows the original request path for hmac signing
               proxy_set_header   Host $host;
               proxy_set_header   Subdir /api;
+              proxy_set_header   Authorization "$access_token";
               proxy_connect_timeout 300;
               proxy_send_timeout 300;
               proxy_read_timeout 300;

--- a/tf_files/aws/variables.tf
+++ b/tf_files/aws/variables.tf
@@ -84,14 +84,10 @@ variable "gdcapi_indexd_password" {
 }
 # gdcapi's oauth2 client id(fence as oauth2 provider)
 variable "gdcapi_oauth2_client_id" {
-  # oauth handshake should not be necessary - uses fence access token
-  default = ""
 }
 
 # gdcapi's oauth2 client secret
 variable "gdcapi_oauth2_client_secret" {
-  # oauth handshake should not be necessary - uses fence access token
-  default = ""
 }
 
 # id of AWS account that owns the public AMI's

--- a/tf_files/aws/variables.tf
+++ b/tf_files/aws/variables.tf
@@ -84,10 +84,14 @@ variable "gdcapi_indexd_password" {
 }
 # gdcapi's oauth2 client id(fence as oauth2 provider)
 variable "gdcapi_oauth2_client_id" {
+  # oauth handshake should not be necessary - uses fence access token
+  default = ""
 }
 
 # gdcapi's oauth2 client secret
 variable "gdcapi_oauth2_client_secret" {
+  # oauth handshake should not be necessary - uses fence access token
+  default = ""
 }
 
 # id of AWS account that owns the public AMI's


### PR DESCRIPTION
Patch revproxy nginx config to:

* copy access_token head to Authorization header
* CSRF check on POST requests

Note - this is currently based on the feat/sheepdog_deployment branch - will rebase after PR #134 is merged.

Note - the CSRF check kicks in on all POST requests, so non-web clients (Francisco's python library, whatever) will have to fake it by adding an x-csrf-token header and a csrftoken cookie that equal each other ...
Or ... we could disable the check if:
* user-agent header is set to something like 'script'
* csrftoken cookie is not set

resolves #132 