### PR TITLE
Chore/migrate fixes

### DIFF
--- a/gen3/bin/workon.sh
+++ b/gen3/bin/workon.sh
@@ -165,6 +165,10 @@ EOM
   cat - <<EOM
 # VPC name is also used in DB name, so only alphanumeric characters
 vpc_name="$GEN3_VPC"
+#
+# for vpc_octet see https://github.com/uc-cdis/cdis-wiki/blob/master/ops/AWS-Accounts.md
+#  CIDR becomes 172.24.{vpc_octet}.0/20
+#
 vpc_octet=GET_A_UNIQUE_VPC_172_OCTET
 dictionary_url="https://s3.amazonaws.com/dictionary-artifacts/YOUR/DICTIONARY/schema.json"
 

--- a/gen3/bin/workon.sh
+++ b/gen3/bin/workon.sh
@@ -143,7 +143,12 @@ config.tfvars() {
     # user vpc is simpler ...
     cat - <<EOM
 vpc_name="$GEN3_VPC"
+#
+# for vpc_octet see https://github.com/uc-cdis/cdis-wiki/blob/master/ops/AWS-Accounts.md
+#  CIDR becomes 172.24.{vpc_octet}.0/20
+#
 vpc_octet=GET_A_UNIQUE_VPC_172_OCTET
+ssh_public_key="$(sed 's/\s*$//' ~/.ssh/id_rsa.pub)"
 EOM
     return 0
   fi
@@ -205,7 +210,7 @@ fence_snapshot=""
 gdcapi_snapshot=""
 indexd_snapshot=""
 
-# ssh key to be added to kube nodes
+# ssh key to be added to VMs and kube nodes
 kube_ssh_key="$(sed 's/\s*$//' ~/.ssh/id_rsa.pub)"
 
 kube_additional_keys = <<EOB

--- a/kube/README.md
+++ b/kube/README.md
@@ -1,17 +1,11 @@
 # Configuration for setting up a kubernete cluster inside an existing VPC private subnet
 
-## Manual Prerequisites
-
-- need to have at least 1 eips
-- need to get the credential from quay.io for [cdis-devservices robot](https://quay.io/organization/cdis?tab=robots)
-
 ## Steps to start all services on a new k8s cluster in AWS
 1. Copy the ${cluster}_output folder to the kube.internal.io (Kubernete provisioner)
 2. ssh to kube.internal.io (gen3 tfoutput ssh_config or terraform output gives the `~/.ssh/config` entries), and `$ cd ~/${cluster}_output`
 3. Run kube-up.sh
-4. Get quay creds in prerequisites 2 to ${cluster}/cdis-devservices-secret.yml
-5. Run kube-services.sh
-6. Optional - register your kubernete worker nodes as `kubenode.internal.io` in your route53
+4. Run kube-services.sh
+5. Optional - register your kubernete worker nodes as `kubenode.internal.io` in your route53
 
 
 ## Steps to start a new service in an existing commons

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -69,5 +69,3 @@ spec:
           - name: "fence-jwt-keys"
             readOnly: true
             mountPath: "/fence/keys"
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret

--- a/kube/services/gdcapi/gdcapi-deploy.yaml
+++ b/kube/services/gdcapi/gdcapi-deploy.yaml
@@ -61,6 +61,4 @@ spec:
             limits:
               cpu: 0.8
               memory: 512Mi
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret
 

--- a/kube/services/indexd/indexd-deploy.yaml
+++ b/kube/services/indexd/indexd-deploy.yaml
@@ -57,6 +57,4 @@ spec:
             readOnly: true
             mountPath: "/mnt/ssl/cdis-ca.crt"
             subPath: "ca.pem"
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret
-
+      

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -79,5 +79,3 @@ spec:
       - name: ca-volume
         secret:
           secretName: "service-ca"
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret

--- a/kube/services/peregrine/peregrine-deploy.yaml
+++ b/kube/services/peregrine/peregrine-deploy.yaml
@@ -60,5 +60,3 @@ spec:
             limits:
               cpu: 0.8
               memory: 2048Mi
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -62,5 +62,3 @@ spec:
             path: /
             port: 80
         imagePullPolicy: Always
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -53,6 +53,4 @@ spec:
             readOnly: true
             mountPath: "/mnt/ssl/cdis-ca.crt"
             subPath: "ca.pem"
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret
 

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -67,6 +67,4 @@ spec:
             limits:
               cpu: 0.8
               memory: 512Mi
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret
 

--- a/kube/services/userapi/userapi-deploy.yaml
+++ b/kube/services/userapi/userapi-deploy.yaml
@@ -63,6 +63,4 @@ spec:
             readOnly: true
             mountPath: "/mnt/ssl/cdis-ca.crt"
             subPath: "ca.pem"
-      imagePullSecrets:
-        - name: cdis-devservices-pull-secret
 

--- a/setup_kube_aws.bash
+++ b/setup_kube_aws.bash
@@ -13,16 +13,11 @@ echo "Working with Login Node: $LOGIN_NODE"
 OUTPUT_DIR=${VPC_NAME}_output
 echo "Working with $OUTPUT_DIR"
 
-if [ ! -f $OUTPUT_DIR/cdis-devservices-secret.yml ]; then
-    echo "Please provide cdis-devservices-secret.yml in tf_files/aws/$OUTPUT_DIR before proceeding"
-    exit
-fi
-
 cp ../../bin/kube-aws $OUTPUT_DIR/.
 
 set -e
 scp -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" -r $OUTPUT_DIR ubuntu@kube.internal.io:/home/ubuntu/.
 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && chmod +x kube-up.sh && ./kube-up.sh"
-ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && mv cdis-devservices-secret.yml ../$VPC_NAME/. && chmod +x kube-services.sh && ./kube-services.sh"
+ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o "ProxyCommand ssh ubuntu@$LOGIN_NODE nc %h %p" ubuntu@kube.internal.io "cd $OUTPUT_DIR && chmod +x kube-services.sh && ./kube-services.sh"
 
 set +e

--- a/tf_files/aws/cloud.tf
+++ b/tf_files/aws/cloud.tf
@@ -15,6 +15,7 @@ module "cdis_vpc" {
   source = "../modules/cdis-aws-vpc"
   vpc_octet = "${var.vpc_octet}"
   vpc_name = "${var.vpc_name}"
+  ssh_key_name = "${aws_key_pair.automation_dev.key_name}"
 }
 
 

--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -44,7 +44,6 @@ resource "aws_db_instance" "db_fence" {
     identifier           = "${var.vpc_name}-fencedb"
     storage_type         = "gp2"
     engine               = "postgres"
-    skip_final_snapshot  = true
     engine_version       = "9.6.6"
     parameter_group_name = "${aws_db_parameter_group.rds-cdis-pg.name}"
     instance_class       = "${var.db_instance}"
@@ -54,6 +53,8 @@ resource "aws_db_instance" "db_fence" {
     snapshot_identifier  = "${var.fence_snapshot}"
     db_subnet_group_name = "${aws_db_subnet_group.private_group.id}"
     vpc_security_group_ids = ["${module.cdis_vpc.security_group_local_id}"]
+    allow_major_version_upgrade = true
+    final_snapshot_identifier = "${var.vpc_name}-fencedb"
     tags {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
@@ -73,7 +74,6 @@ resource "aws_db_instance" "db_userapi" {
     identifier           = "${var.vpc_name}-userapidb"
     storage_type         = "gp2"
     engine               = "postgres"
-    skip_final_snapshot  = true
     engine_version       = "9.6.6"
     parameter_group_name = "${aws_db_parameter_group.rds-cdis-pg.name}"
     instance_class       = "${var.db_instance}"
@@ -82,6 +82,8 @@ resource "aws_db_instance" "db_userapi" {
     password             = "${var.db_password_userapi}"
     db_subnet_group_name = "${aws_db_subnet_group.private_group.id}"
     vpc_security_group_ids = ["${module.cdis_vpc.security_group_local_id}"]
+    allow_major_version_upgrade = true
+    final_snapshot_identifier = "${var.vpc_name}-userapidb"
     tags {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
@@ -96,7 +98,6 @@ resource "aws_db_instance" "db_gdcapi" {
     identifier           = "${var.vpc_name}-gdcapidb"
     storage_type         = "gp2"
     engine               = "postgres"
-    skip_final_snapshot  = true
     engine_version       = "9.6.6"
     parameter_group_name = "${aws_db_parameter_group.rds-cdis-pg.name}"
     instance_class       = "${var.db_instance}"
@@ -105,11 +106,13 @@ resource "aws_db_instance" "db_gdcapi" {
     password             = "${var.db_password_sheepdog}"
     snapshot_identifier  = "${var.gdcapi_snapshot}"
     db_subnet_group_name = "${aws_db_subnet_group.private_group.id}"
+    vpc_security_group_ids = ["${module.cdis_vpc.security_group_local_id}"]
+    allow_major_version_upgrade = true
+    final_snapshot_identifier = "${var.vpc_name}-gdcapidb"
     tags {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
     }
-    vpc_security_group_ids = ["${module.cdis_vpc.security_group_local_id}"]
     lifecycle {
         ignore_changes = ["identifier", "name", "engine_version", "username", "password"]
     }
@@ -120,7 +123,6 @@ resource "aws_db_instance" "db_indexd" {
     identifier           = "${var.vpc_name}-indexddb"
     storage_type         = "gp2"
     engine               = "postgres"
-    skip_final_snapshot  = true
     engine_version       = "9.6.6"
     parameter_group_name = "${aws_db_parameter_group.rds-cdis-pg.name}"
     instance_class       = "${var.db_instance}"
@@ -130,6 +132,8 @@ resource "aws_db_instance" "db_indexd" {
     snapshot_identifier  = "${var.indexd_snapshot}"
     db_subnet_group_name = "${aws_db_subnet_group.private_group.id}"
     vpc_security_group_ids = ["${module.cdis_vpc.security_group_local_id}"]
+    allow_major_version_upgrade = true
+    final_snapshot_identifier = "${var.vpc_name}-indexddb"
     tags {
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"

--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -228,13 +228,14 @@ resource "aws_instance" "kube_provisioner" {
     monitoring = true
     vpc_security_group_ids = ["${module.cdis_vpc.security_group_local_id}"]
     iam_instance_profile = "${aws_iam_instance_profile.kube_provisioner.name}"
+    key_name = "${module.cdis_vpc.ssh_key_name}"
     tags {
         Name = "${var.vpc_name} Kube Provisioner"
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
     }
     lifecycle {
-        ignore_changes = ["ami"]
+        ignore_changes = ["ami", "key_name"]
     }
 }
 

--- a/tf_files/aws/outputs.tf
+++ b/tf_files/aws/outputs.tf
@@ -171,7 +171,7 @@ resource "null_resource" "config_setup" {
     }
 
     provisioner "local-exec" {
-        command = "echo \"${data.template_file.kube_vars.rendered}\" | cat - \"${path.module}/../configs/kube-setup-certs.sh\" \"${path.module}/../configs/kube-services-body.sh\" \"${path.module}/../configs/kube-setup-fence.sh\" \"${path.module}/../configs/kube-setup-sheepdog.sh\" \"${path.module}/../configs/kube-setup-peregrine.sh\" > ${var.vpc_name}_output/kube-services.sh"
+        command = "echo \"${data.template_file.kube_vars.rendered}\" | cat - \"${path.module}/../configs/kube-setup-certs.sh\" \"${path.module}/../configs/kube-services-body.sh\" \"${path.module}/../configs/kube-setup-fence.sh\" \"${path.module}/../configs/kube-setup-sheepdog.sh\" \"${path.module}/../configs/kube-setup-peregrine.sh\" \"${path.module}/../configs/kube-setup-revproxy.sh\" > ${var.vpc_name}_output/kube-services.sh"
     }
 
     provisioner "local-exec" {

--- a/tf_files/aws_user_vpc/root.tf
+++ b/tf_files/aws_user_vpc/root.tf
@@ -10,9 +10,15 @@ provider "aws" {
     region = "${var.aws_region}"
 }
 
+resource "aws_key_pair" "automation_dev" {
+    key_name = "${var.vpc_name}_automation_dev"
+    public_key = "${var.ssh_public_key}"
+}
+
 module "cdis_vpc" {
   ami_account_id = "${var.ami_account_id}"
   source = "../modules/cdis-aws-vpc"
   vpc_octet = "${var.vpc_octet}"
   vpc_name = "${var.vpc_name}"
+  ssh_key_name = "${aws_key_pair.automation_dev.key_name}"
 }

--- a/tf_files/aws_user_vpc/variables.tf
+++ b/tf_files/aws_user_vpc/variables.tf
@@ -7,6 +7,8 @@ variable "vpc_octet" {
 variable "aws_region" {
     default = "us-east-1"
 }
+variable "ssh_public_key" {
+}
 variable "aws_access_key" {
 }
 variable "aws_secret_key" {

--- a/tf_files/configs/kube-extract-config.sh
+++ b/tf_files/configs/kube-extract-config.sh
@@ -55,6 +55,7 @@ function random_alphanumeric() {
 }
 
 kubectl get configmaps/global -o yaml > 00configmap.yaml
+  
 # Note that legacy commons may not have the dictonary_url set ...
 hostname=$(kubectl get configmaps/global -o=jsonpath='{.data.hostname}')
 dictionaryUrl=$(kubectl get configmaps/global -o=jsonpath='{.data.dictionary_url}')
@@ -69,6 +70,12 @@ if kubectl get secrets/jwt-keys > /dev/null 2>&1; then
 fi
 
 mkdir -p -m 0700 apis_configs
+if kubectl get configmaps/fence > /dev/null 2>&1; then
+  kubectl get configmaps/fence -o yaml > apis_configs/user.yaml
+else
+  kubectl get configmaps/userapi -o yaml > apis_configs/user.yaml
+fi
+
 if kubectl get secrets/indexd-secret > /dev/null 2>&1; then
   kubectl get secrets/indexd-secret -o json | jq -r '.data["local_settings.py"]' | base64 --decode > apis_configs/indexd_settings.py
   indexdDbPassword=$(grep ^psw apis_configs/indexd_settings.py | awk '{ print $3 }' | sed "s/^'//" | sed "s/'\$//")
@@ -79,7 +86,7 @@ fencePyFile=""
 if kubectl get secrets/fence-secret > /dev/null 2>&1; then
   fencePyFile=apis_configs/fence_settings.py
   kubectl get secrets/fence-secret -o json | jq -r '.data["local_settings.py"]' | base64 --decode > "${fencePyFile}"
-elif kubectl get secrets/userapi-secret 2>&1 /dev/null; then
+elif kubectl get secrets/userapi-secret > /dev/null 2>&1; then
   fencePyFile=apis_configs/userapi_settings.py
   kubectl get secrets/userapi-secret -o json | jq -r '.data["local_settings.py"]' | base64 --decode > "${fencePyFile}"
 fi

--- a/tf_files/configs/kube-services-body.sh
+++ b/tf_files/configs/kube-services-body.sh
@@ -42,19 +42,6 @@ cd ~/${vpc_name}
 
 export KUBECONFIG=~/${vpc_name}/kubeconfig
 
-if ! kubectl get secrets/cdis-devservices-pull-secret 2>&1 > /dev/null; then
-  echo "Creating k8s quay secret"
-
-  if [ ! -f ~/"${vpc_name}/cdis-devservices-secret.yml" ]; then
-    echo "ERROR: you forgot to setup ~/${vpc_name}/cdis-devservices-secret.yml - doh!"
-    exit 1
-  fi
-
-  kubectl create -f cdis-devservices-secret.yml
-  # don't leave this file laying around ...
-  rm cdis-devservices-secret.yml
-fi
-
 # Note: look into 'kubectl replace' if you need to replace a secret
 if ! kubectl get secrets/indexd-secret > /dev/null 2>&1; then
   kubectl create secret generic indexd-secret --from-file=local_settings.py=./apis_configs/indexd_settings.py
@@ -64,14 +51,11 @@ kubectl apply -f 00configmap.yaml
 
 kubectl apply -f services/portal/portal-deploy.yaml
 kubectl apply -f services/indexd/indexd-deploy.yaml
-kubectl apply -f services/revproxy/00nginx-config.yaml
-kubectl apply -f services/revproxy/revproxy-deploy.yaml
 
 cd ~/${vpc_name};
 
 kubectl apply -f services/portal/portal-service.yaml
 kubectl apply -f services/indexd/indexd-service.yaml
-./services/revproxy/apply_service
 
 if ! grep kubes.sh ~/.bashrc > /dev/null; then
   echo "Adding variables to ~/.bashrc"

--- a/tf_files/configs/kube-setup-revproxy.sh
+++ b/tf_files/configs/kube-setup-revproxy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Reverse proxy needs to deploy last in order for nginx
+# to be able to resolve the DNS domains of all the services
+# at startup.  
+# Unfortunately - the data-portal wants to connect to the reverse-proxy
+# at startup time, so there's a chicken-egg thing going on, so
+# will probably need to restart the data-portal pods first time
+# the commons comes up.
+#
+
+set -e
+
+vpc_name=${vpc_name:-$1}
+if [ -z "${vpc_name}" ]; then
+   echo "Usage: bash kube-setup-revproxy.sh vpc_name"
+   exit 1
+fi
+if [ ! -d ~/"${vpc_name}" ]; then
+  echo "~/${vpc_name} does not exist"
+  exit 1
+fi
+
+cd ~/${vpc_name}
+kubectl apply -f services/revproxy/00nginx-config.yaml
+kubectl apply -f services/revproxy/revproxy-deploy.yaml
+#
+# apply_service deploys the revproxy service after
+# inserting the certificate ARN from a config map
+#
+./services/revproxy/apply_service

--- a/tf_files/configs/kube-setup-sheepdog.sh
+++ b/tf_files/configs/kube-setup-sheepdog.sh
@@ -65,7 +65,7 @@ for user in sheepdog peregrine; do
       psql -t -U $gdcapi_db_user -h $gdcapi_db_host -d $gdcapi_db_database -c "CREATE USER $new_db_user WITH PASSWORD '$new_db_password';"
       psql -t -U $gdcapi_db_user -h $gdcapi_db_host -d $gdcapi_db_database -c "GRANT SELECT ON ALL TABLES IN SCHEMA public TO $new_db_user;"
       if [[ "$new_db_user" =~ ^sheepdog ]]; then
-        psql -t -U $gdcapi_db_user -h $gdcapi_db_host -d $gdcapi_db_database -c "GRANT ALL ON ALL TABLES IN SCHEMA pubic TO $new_db_user;"
+        psql -t -U $gdcapi_db_user -h $gdcapi_db_host -d $gdcapi_db_database -c "GRANT ALL ON ALL TABLES IN SCHEMA public TO $new_db_user;"
       fi
     fi
   fi

--- a/tf_files/modules/cdis-aws-vpc/cloud.tf
+++ b/tf_files/modules/cdis-aws-vpc/cloud.tf
@@ -162,6 +162,7 @@ resource "aws_instance" "login" {
     subnet_id = "${aws_subnet.public.id}"
     instance_type = "t2.micro"
     monitoring = true
+    key_name = "${var.ssh_key_name}"
     vpc_security_group_ids = ["${aws_security_group.ssh.id}", "${aws_security_group.local.id}"]
     tags {
         Name = "${var.vpc_name} Login Node"
@@ -169,7 +170,7 @@ resource "aws_instance" "login" {
         Organization = "Basic Service"
     }
     lifecycle {
-        ignore_changes = ["ami"]
+        ignore_changes = ["ami", "key_name"]
     }
 }
 
@@ -179,11 +180,15 @@ resource "aws_instance" "proxy" {
     instance_type = "t2.micro"
     monitoring = true
     source_dest_check = false
+    key_name = "${var.ssh_key_name}"
     vpc_security_group_ids = ["${aws_security_group.proxy.id}","${aws_security_group.login-ssh.id}", "${aws_security_group.out.id}"]
     tags {
         Name = "${var.vpc_name} HTTP Proxy"
         Environment = "${var.vpc_name}"
         Organization = "Basic Service"
+    }
+    lifecycle {
+        ignore_changes = ["ami", "key_name"]
     }
 }
 

--- a/tf_files/modules/cdis-aws-vpc/outputs.tf
+++ b/tf_files/modules/cdis-aws-vpc/outputs.tf
@@ -43,6 +43,10 @@ output "ssh_config" {
   value = "${data.template_file.ssh_config.rendered}"
 }
 
+output "ssh_key_name" {
+  value = "${var.ssh_key_name}"
+}
+
 #-------------------------------------------
 
 data "template_file" "ssh_config" {

--- a/tf_files/modules/cdis-aws-vpc/variables.tf
+++ b/tf_files/modules/cdis-aws-vpc/variables.tf
@@ -9,3 +9,7 @@ variable "vpc_name" {
 variable "vpc_octet" {
     default = 17
 }
+
+# name of aws_key_pair ssh key to attach to VM's
+variable "ssh_key_name" {
+}


### PR DESCRIPTION
some post bhcv2 fixes and tweaks ...

* small bugs that popped up deploying bhcprodv2
    - SQL typo
    - deploy reverse proxy last
   - allow major postgres upgrade from snapshot
* remove quay secrets - docker registries are now public
* terraform adds kube-ssh-key to ec2 VM's
