### PR TITLE
Chore/kubejobs

### DIFF
--- a/Jenkins/Pipelines/Backup/Jenkinsfile
+++ b/Jenkins/Pipelines/Backup/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     stage('BuildArchive'){
       steps {
         echo "BuildArchive $env.JENKINS_HOME"
-        sh "tar cvJf backup.tar.xz --exclude '$env.JENKINS_HOME/jobs/[^/]*/builds/*' --exclude '$env.JENKINS_HOME/jobs/[^/]*/last*' --exclude '$env.JENKINS_HOME/workspace' --exclude '$env.JENKINS_HOME/war' --exclude '$env.JENKINS_HOME/logs' --exclude '$env.JENKINS_HOME/jobs/[^/]*/workspace/'  $env.JENKINS_HOME"
+        sh "tar cvJf backup.tar.xz --exclude '$env.JENKINS_HOME/jobs/[^/]*/builds/*' --exclude '$env.JENKINS_HOME/jobs/[^/]*/last*' --exclude '$env.JENKINS_HOME/workspace' --exclude '$env.JENKINS_HOME/war' --exclude '$env.JENKINS_HOME/logs' --exclude '$env.JENKINS_HOME/queue.xml' --exclude '$env.JENKINS_HOME/org.jenkinsci.plugins.workflow.flow.FlowExecutionList.xml' --exclude '$env.JENKINS_HOME/nodes' --exclude '$env.JENKINS_HOME/jobs/[^/]*/workspace/'  $env.JENKINS_HOME || [ -f backup.tar.xz ]"
       }
     }
     stage('UploadToS3') {

--- a/Jenkins/Pipelines/Backup/Jenkinsfile
+++ b/Jenkins/Pipelines/Backup/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
     stage('BuildArchive'){
       steps {
         echo "BuildArchive $env.JENKINS_HOME"
-        sh "tar cvJf backup.tar.xz --exclude '$env.JENKINS_HOME/jobs/[^/]*/builds/*' --exclude '$env.JENKINS_HOME/jobs/[^/]*/last*' --exclude '$env.JENKINS_HOME/workspace' --exclude '$env.JENKINS_HOME/war' --exclude '$env.JENKINS_HOME/jobs/[^/]*/workspace/'  $env.JENKINS_HOME"
+        sh "tar cvJf backup.tar.xz --exclude '$env.JENKINS_HOME/jobs/[^/]*/builds/*' --exclude '$env.JENKINS_HOME/jobs/[^/]*/last*' --exclude '$env.JENKINS_HOME/workspace' --exclude '$env.JENKINS_HOME/war' --exclude '$env.JENKINS_HOME/logs' --exclude '$env.JENKINS_HOME/jobs/[^/]*/workspace/'  $env.JENKINS_HOME"
       }
     }
     stage('UploadToS3') {

--- a/gen3/README.md
+++ b/gen3/README.md
@@ -145,7 +145,7 @@ The tasks performed include:
        * assumes ~/.ssh/id_rsa.pub
           is the user a good key to access the bastion host
 * fi
-* setup the *cdis-terraform-state.profile-name.gen3* S3 bucket if necessary
+* setup the *cdis-state-ac{ACCOUNTID}-gen3* S3 bucket if necessary
 * run `terraform init` if necessary
    
 ### gen3 status
@@ -158,7 +158,7 @@ GEN3_PROFILE=cdistest
 GEN3_WORKSPACE=planxplanetv1
 GEN3_WORKDIR=/home/reuben/.local/share/gen3/cdistest/planxplanetv1
 GEN3_HOME=/home/reuben/Code/PlanX/cloud-automation
-GEN3_S3_BUCKET=cdis-terraform-state.cdistest.gen3
+GEN3_S3_BUCKET=cdis-state-ac23212121-gen3
 AWS_PROFILE=cdistest
 ```
 
@@ -266,7 +266,7 @@ Here is one strategy for migration:
 
 This will create a local workspace with config.tfvars and backend.tfvars
 files generated from a template that auto-generates new passwords, etc.
-It will also auto-create the GEN3_S3_BUCKET (defaults to cdis-terraform-state.profile-name.gen3)
+It will also auto-create the GEN3_S3_BUCKET (defaults to cdis-state-ac{ACCOUNTID}-gen3)
 S3 bucket if it does not yet exist.
 
 * `gen3 cd`
@@ -283,7 +283,7 @@ The tfapply will automatically backup the local config.tfvars, backend.tfvars, a
 * Optionally - update backend.tfvars, so that terraform stores its S3 state in the same folder as config.tfvars, then run `terraform init` to move the state, and gen3 tfplan; gen3 tfapply; to sync everything up with s3 - ex:
 ```
 $ cat backend.tfvars 
-bucket = "cdis-terraform-state.cdistest.gen3"
+bucket = "cdis-state-ac3333-gen3"
 encrypt = "true"
 key = "gen3test"
 region = "us-east-1"

--- a/gen3/bin/testsuite.sh
+++ b/gen3/bin/testsuite.sh
@@ -55,7 +55,7 @@ test_workspace() {
   gen3 workon $TEST_PROFILE $TEST_WORKSPACE; because $? "Calling gen3 workon multiple times should be harmless"
   [[ $GEN3_PROFILE = $TEST_PROFILE ]]; because $? "gen3 workon sets the GEN3_PROFILE env variable: $GEN3_PROFILE"
   [[ $GEN3_WORKSPACE = $TEST_WORKSPACE ]]; because $? "gen3 workon sets the GEN3_WORKSPACE env variable: $GEN3_WORKSPACE"
-  [[ $GEN3_S3_BUCKET = "cdis-state-ac${TEST_ACCOUNT}-gen3" ]]; because $? "gen3 workon sets the GEN3_S3_BUCKET env variable: $GEN3_S3_BUCKET"
+  [[ $GEN3_S3_BUCKET = "cdis-state-ac${TEST_ACCOUNT}-gen3" || $GEN3_S3_BUCKET = "cdis-terraform-state.account-${TEST_ACCOUNT}.gen3" ]]; because $? "gen3 workon sets the GEN3_S3_BUCKET env variable: $GEN3_S3_BUCKET"
   [[ (! -z $GEN3_WORKDIR) && -d $GEN3_WORKDIR ]]; because $? "gen3 workon sets the GEN3_WORKDIR env variable, and initializes the folder: $GEN3_WORKDIR"
   [[ $(file_mode $GEN3_WORKDIR) =~ 700$ ]]; because $? "gen3 workon sets the GEN3_WORKDIR to mode 0700, because secrets are in there"
   gen3 cd && [[ $(pwd) = "$GEN3_WORKDIR" ]]; because $? "gen3 cd should take us to the workspace by default: $(pwd) =? $GEN3_WORKDIR"

--- a/gen3/bin/testsuite.sh
+++ b/gen3/bin/testsuite.sh
@@ -55,7 +55,7 @@ test_workspace() {
   gen3 workon $TEST_PROFILE $TEST_WORKSPACE; because $? "Calling gen3 workon multiple times should be harmless"
   [[ $GEN3_PROFILE = $TEST_PROFILE ]]; because $? "gen3 workon sets the GEN3_PROFILE env variable: $GEN3_PROFILE"
   [[ $GEN3_WORKSPACE = $TEST_WORKSPACE ]]; because $? "gen3 workon sets the GEN3_WORKSPACE env variable: $GEN3_WORKSPACE"
-  [[ $GEN3_S3_BUCKET = "cdis-terraform-state.account-${TEST_ACCOUNT}.gen3" ]]; because $? "gen3 workon sets the GEN3_S3_BUCKET env variable: $GEN3_S3_BUCKET"
+  [[ $GEN3_S3_BUCKET = "cdis-state-ac${TEST_ACCOUNT}-gen3" ]]; because $? "gen3 workon sets the GEN3_S3_BUCKET env variable: $GEN3_S3_BUCKET"
   [[ (! -z $GEN3_WORKDIR) && -d $GEN3_WORKDIR ]]; because $? "gen3 workon sets the GEN3_WORKDIR env variable, and initializes the folder: $GEN3_WORKDIR"
   [[ $(file_mode $GEN3_WORKDIR) =~ 700$ ]]; because $? "gen3 workon sets the GEN3_WORKDIR to mode 0700, because secrets are in there"
   gen3 cd && [[ $(pwd) = "$GEN3_WORKDIR" ]]; because $? "gen3 cd should take us to the workspace by default: $(pwd) =? $GEN3_WORKDIR"
@@ -113,6 +113,20 @@ test_semver() {
   semver_ge "2.0.0" "1.10.22"; because $? "2.0.0 -ge 1.10.22"
 }
 
+test_colors() {
+  expected="red red red"
+  redTest=$(red_color "$expected")
+  
+  echo -e "red test: $redTest"
+  [[ "$redTest" ==  "${RED_COLOR}${expected}${DEFAULT_COLOR}" ]]; because $? "Calling red_color returns red-escaped string: $redTest ?= $expected";
+
+  expected="green green green"
+  greenTest=$(red_color "$expected")
+  echo -e "green test: $greenTest"
+  echo "green test: $greenTest"
+  [[ "$greenTest" == "$RED_COLOR${expected}$DEFAULT_COLOR" ]]; because $? "Calling green_color returns green-escaped string: $greenTest ?= $expected";
+}
+
 test_refresh() {
   gen3 --dryrun refresh; because $? "--dryrun refresh should be harmless in test workspace"
   gen3 refresh; because $? "refresh should be harmless in test workspace"
@@ -142,6 +156,7 @@ test_tfoutput() {
 }
 
 shunit_runtest "test_semver"
+shunit_runtest "test_colors"
 shunit_runtest "test_workspace"
 shunit_runtest "test_user_workspace"
 shunit_runtest "test_snapshot_workspace"

--- a/gen3/bin/workon.sh
+++ b/gen3/bin/workon.sh
@@ -142,7 +142,7 @@ EOM
   if [[ "$GEN3_WORKSPACE" =~ _databucket$ ]]; then
     # rds snapshot vpc is simpler ...
     cat - <<EOM
-bucket_name="$(echo "$GEN3_WORKSPACE" | sed 's/_/-/g').gen3"
+bucket_name="$(echo "$GEN3_WORKSPACE" | sed 's/[_\.]/-/g')-gen3"
 environment="$(echo "$GEN3_WORKSPACE" | sed 's/_databucket$//')"
 EOM
     return 0

--- a/gen3/gen3setup.sh
+++ b/gen3/gen3setup.sh
@@ -50,7 +50,7 @@ gen3_workon() {
     echo "Error: unable to determine AWS_ACCOUNT_ID via: aws sts get-caller-identity | jq -r .Account"
     export GEN3_S3_BUCKET=""
   else
-    export GEN3_S3_BUCKET="cdis-terraform-state.account-${AWS_ACCOUNT_ID}.gen3"
+    export GEN3_S3_BUCKET="cdis-state-ac${AWS_ACCOUNT_ID}-gen3"
   fi
 
   # terraform stack - based on VPC name

--- a/gen3/gen3setup.sh
+++ b/gen3/gen3setup.sh
@@ -50,7 +50,19 @@ gen3_workon() {
     echo "Error: unable to determine AWS_ACCOUNT_ID via: aws sts get-caller-identity | jq -r .Account"
     export GEN3_S3_BUCKET=""
   else
+    #
+    # This is the new bucket name, which we prefer if data doesn't already exist in the old bucket ...
+    #    https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
+    #
     export GEN3_S3_BUCKET="cdis-state-ac${AWS_ACCOUNT_ID}-gen3"
+    
+    OLD_S3_BUCKET="cdis-terraform-state.account-${AWS_ACCOUNT_ID}.gen3"
+    if (! aws s3 ls "s3://${GEN3_S3_BUCKET}/${GEN3_WORKSPACE}" > /dev/null 2>&1) &&
+      (aws s3 ls "s3://${OLD_S3_BUCKET}/${GEN3_WORKSPACE}" > /dev/null 2>&1)
+    then
+      # Use the old bucket ... 
+      export GEN3_S3_BUCKET="${OLD_S3_BUCKET}"
+    fi
   fi
 
   # terraform stack - based on VPC name

--- a/gen3/lib/common.sh
+++ b/gen3/lib/common.sh
@@ -3,44 +3,8 @@
 # that other bin/ scripts can 'source'
 #
 
-#
-# Little semver tester - returns true if a -gt b
-# @param a semver str
-# @param b semver str
-# @return 0 if a >= b
-#
-semver_ge() {
-  local aStr
-  local bStr
-  local aMajor
-  local aMinor
-  local aPatch
-  local bMajor
-  local bMinor
-  local bPatch
-  aStr=$1
-  bStr=$2
-  if [[ "$aStr" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    let aMajor=${BASH_REMATCH[1]}
-    let aMinor=${BASH_REMATCH[2]}
-    let aPatch=${BASH_REMATCH[3]}
-  else
-    echo "ERROR: invalid semver $aStr"
-  fi
-  if [[ "$bStr" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    let bMajor=${BASH_REMATCH[1]}
-    let bMinor=${BASH_REMATCH[2]}
-    let bPatch=${BASH_REMATCH[3]}
-  else
-    echo "ERROR: invalid semver $bStr"
-  fi
 
-  if [[ $aMajor -gt $bMajor || ($aMajor -eq $bMajor && $aMinor -gt $bMinor) || ($aMajor -eq $bMajor && $aMinor -eq $bMinor && $aPatch -ge $bPatch) ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
+source "$GEN3_HOME/gen3/lib/utils.sh"
 
 AWS_VERSION=$(aws --version 2>&1 | awk '{ print $1 }' | sed 's@^.*/@@')
 if ! semver_ge "$AWS_VERSION" "1.14.0"; then
@@ -62,10 +26,6 @@ if [[ -z "$GEN3_PROFILE" || -z "$GEN3_WORKSPACE" || -z "$GEN3_WORKDIR" || -z "$G
   exit 1
 fi
 
-# vt100 escape sequences - don't forget to pass -e to 'echo -e'
-RED_COLOR="\x1B[31m"
-DEFAULT_COLOR="\x1B[39m"
-GREEN_COLOR="\x1B[32m"
 
 #
 # This folder holds secrets, so lock it down permissions wise ...
@@ -75,12 +35,6 @@ umask 0077
 if [[ $1 =~ ^-*help$ ]]; then
   help
   exit 0
-fi
-
-# MacOS has 'md5', linux has 'md5sum'
-MD5=md5
-if [[ $(uname -s) == "Linux" ]]; then
-  MD5=md5sum
 fi
 
 # Little string to prepend to info messages

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -1,0 +1,68 @@
+#
+# Helpers for both `gen3` and `g3k`.
+# Test with `gen3 testsuite` - see ../bin/testsuite.sh 
+#
+
+#
+# Little semver tester - returns true if a -gt b
+# @param a semver str
+# @param b semver str
+# @return 0 if a >= b
+#
+semver_ge() {
+  local aStr
+  local bStr
+  local aMajor
+  local aMinor
+  local aPatch
+  local bMajor
+  local bMinor
+  local bPatch
+  aStr=$1
+  bStr=$2
+  if [[ "$aStr" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    let aMajor=${BASH_REMATCH[1]}
+    let aMinor=${BASH_REMATCH[2]}
+    let aPatch=${BASH_REMATCH[3]}
+  else
+    echo "ERROR: invalid semver $aStr"
+  fi
+  if [[ "$bStr" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    let bMajor=${BASH_REMATCH[1]}
+    let bMinor=${BASH_REMATCH[2]}
+    let bPatch=${BASH_REMATCH[3]}
+  else
+    echo "ERROR: invalid semver $bStr"
+  fi
+
+  if [[ $aMajor -gt $bMajor || ($aMajor -eq $bMajor && $aMinor -gt $bMinor) || ($aMajor -eq $bMajor && $aMinor -eq $bMinor && $aPatch -ge $bPatch) ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+# vt100 escape sequences - don't forget to pass -e to 'echo -e'
+RED_COLOR="\x1B[31m"
+DEFAULT_COLOR="\x1B[39m"
+GREEN_COLOR="\x1B[32m"
+
+#
+# Return red-escaped string suitable for passing to 'echo -e'
+#
+red_color() {
+  echo "${RED_COLOR}$1${DEFAULT_COLOR}"
+}
+
+#
+# Return green-escaped string suitable for passing to 'echo -e'
+#
+green_color() {
+  echo "${GREEN_COLOR}$1${DEFAULT_COLOR}"
+}
+
+# MacOS has 'md5', linux has 'md5sum'
+MD5=md5
+if [[ $(uname -s) == "Linux" ]]; then
+  MD5=md5sum
+fi

--- a/kube/kubes.sh
+++ b/kube/kubes.sh
@@ -169,8 +169,10 @@ g3k_joblogs(){
     echo "g3k joblogs JOB-NAME"
     return 1
   fi
+  kubectl get jobs
   podlist=$(g3k_jobpods "$jobName")
   for podname in $podlist; do
+    echo "Scanning pod: $podname"
     for container in $(kubectl get pods "$podname" -o json | jq -r '.spec.containers|map(.name)|join( " " )'); do
       echo "------------------"
       echo "kubectl logs $podname $container"

--- a/kube/kubes.sh
+++ b/kube/kubes.sh
@@ -4,7 +4,12 @@ g3kScriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
 source "${g3kScriptDir}/../gen3/lib/utils.sh"
 
 patch_kube() {
-    kubectl patch deployment $1 -p   "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
+  local depName="$1"
+  if [[ ! "$depName" =~ _deployment$ ]] && ! kubectl get deployments "$depName" > /dev/null 2>&1; then
+    # allow 'g3k roll portal' in addition to 'g3k roll portal-deployment'
+    depName="${depName}-deployment"
+  fi
+  kubectl patch deployment "$depName" -p   "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
 }
 
 # 

--- a/kube/kubes.sh
+++ b/kube/kubes.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 g3kScriptDir=$(dirname -- "$(readlink -f -- "$BASH_SOURCE")")
+source "${g3kScriptDir}/../gen3/lib/utils.sh"
 
 patch_kube() {
     kubectl patch deployment $1 -p   "{\"spec\":{\"template\":{\"metadata\":{\"labels\":{\"date\":\"`date +'%s'`\"}}}}}"
@@ -10,7 +11,7 @@ patch_kube() {
 # Patch replicas
 g3k_replicas() {
   if [[ -z "$1" || -z "$2" ]]; then
-    echo "g3k replicas deployment-name replica-count"
+    echo -e $(red_color "g3k replicas deployment-name replica-count")
     return 1
   fi
   kubectl patch deployment $1 -p  '{"spec":{"replicas":'$2'}}'
@@ -43,6 +44,8 @@ g3k_help() {
     joblogs JOBNAME - get logs from first result of jobpods
     pod PATTERN - grep for the first pod name matching PATTERN
     pods PATTERN - grep for all pod names matching PATTERN
+    psql SERVICE 
+       - where SERVICE is one of sheepdog, indexd, fence
     replicas DEPLOYMENT-NAME REPLICA-COUNT
     roll DEPLOYMENT-NAME
       Apply a superfulous metadata change to a deployment to trigger
@@ -51,6 +54,58 @@ g3k_help() {
      - JOBNAME also maps to cloud-automation/kube/services/JOBNAME-job.yaml
     update_config CONFIGMAP-NAME YAML-FILE
 EOM
+}
+
+#
+# Open a psql connection to the specified database
+#
+# @param serviceName should be one of indexd, fence, sheepdog
+#
+g3k_psql() {
+  local serviceName=$1
+  local key="${serviceName}"
+
+  if [[ -z "$serviceName" ]]; then
+    echo -e $(red_color "g3k_psql: No serviceName specified")
+    return 1
+  fi
+  if [[ -z "$vpc_name" ]]; then
+    echo -e $(red_color "g3k_psql: vpc_name variable must be set")
+    return 1
+  fi
+  local credsPath="${HOME}/${vpc_name}_output/creds.json"
+  if [[ ! -f "$credsPath" ]]; then
+    echo -e $(red_color "g3k_psql: could not find $credsPath")
+    return 1
+  fi
+
+  case "$serviceName" in
+  "gdc")
+    key=gdcapi
+    ;;
+  "sheepdog")
+    key=gdcapi
+    ;;
+  "peregrine")
+    key=gdcapi
+    ;;
+  "indexd")
+    key=indexd
+    ;;
+  "fence")
+    key=fence
+    ;;
+  *)
+    echo -e $(red_color "Invalid service: $serviceName")
+    return 1
+    ;;
+  esac
+  local username=$(jq -r ".${key}.db_username" < $credsPath)
+  local password=$(jq -r ".${key}.db_password" < $credsPath)
+  local host=$(jq -r ".${key}.db_host" < $credsPath)
+  local database=$(jq -r ".${key}.db_database" < $credsPath)
+  
+  PGPASSWORD="$password" psql -U "$username" -h "$host" -d "$database"
 }
 
 #
@@ -166,6 +221,9 @@ g3k() {
       ;;
     "pods")
       get_pods "$@"
+      ;;
+    "psql")
+      g3k_psql "$@"
       ;;
     "roll")
       patch_kube "$@"

--- a/kube/services/jobs/README.md
+++ b/kube/services/jobs/README.md
@@ -8,6 +8,23 @@ The `cloud-automation/tf_files/configs/kube-setup-roles.sh` scripts sets up the 
 required by these jobs.  It runs automatically as part of the `kube-services` script that
 boots up a commons, but may need to be run manually to setup existing commons to run jobs.
 
+## gdcb-create-job
+
+Initialize the `gdcdb` database used by that backs the sheepdog and peregrine services.
+
+## graph-create-job
+
+Update the `gdcb` database (backing the sheepdog and peregrine services) to incorporate
+changes needed after updating the commons' dictionary.  The usual workflow is:
+```
+update ~/{VPC_NAME}/00configmap.yaml with the new dictionary URL
+kubectl apply -f ~/{VPC_NAME}/00configmap.yaml
+g3k runjob graph-create
+g3k joblogs graph-create
+g3k roll sheepdog-deployment
+g3k roll peregrine-deployment
+```
+
 ## usersync-cronjob
 
 Periodically syncs a user.yaml file from a specified S3 buket into the k8s `fence` configmap,

--- a/kube/services/jobs/gdcdb-create-job.yaml
+++ b/kube/services/jobs/gdcdb-create-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gdcdb-create
+spec:
+  template:
+    spec:
+      # not yet supported - backOffLimit: 3
+      automountServiceAccountToken: false
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: "sheepdog-secret"
+      containers:
+        - name: sheepdog
+          image: quay.io/cdis/sheepdog:master
+          ports:
+          - containerPort: 80
+          - containerPort: 443
+          env:
+          - name: DICTIONARY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: global
+                key: dictionary_url
+          volumeMounts:
+            - name: "config-volume"
+              readOnly: true
+              mountPath: "/var/www/sheepdog/wsgi.py"
+              subPath: "wsgi.py"
+          imagePullPolicy: Always
+          command: ["/bin/bash" ]
+          args: 
+            - "-c" 
+            - |
+              eval $(PYTHONPATH=/sheepdog python 2> /dev/null <<EOM
+              from wsgi import config
+              for key in config['PSQLGRAPH']:
+                print( key + "='" + config['PSQLGRAPH'][key] + "'" )
+              EOM
+              );
+              echo datamodel_postgres_admin create-all -U "${user}" -P "${password}" -H "${host}" -D "${database}"
+              echo python /sheepdog/bin/setup_transactionlogs.py --user "${user}"  --password "${password}" --host "${host}" --database "${database}"
+      restartPolicy: Never

--- a/kube/services/jobs/graph-create-job.yaml
+++ b/kube/services/jobs/graph-create-job.yaml
@@ -1,0 +1,43 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: graph-create
+spec:
+  template:
+    spec:
+      # not yet supported - backOffLimit: 3
+      automountServiceAccountToken: false
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: "sheepdog-secret"
+      containers:
+        - name: sheepdog
+          image: quay.io/cdis/sheepdog:master
+          ports:
+          - containerPort: 80
+          - containerPort: 443
+          env:
+          - name: DICTIONARY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: global
+                key: dictionary_url
+          volumeMounts:
+            - name: "config-volume"
+              readOnly: true
+              mountPath: "/var/www/sheepdog/wsgi.py"
+              subPath: "wsgi.py"
+          imagePullPolicy: Always
+          command: ["/bin/bash" ]
+          args: 
+            - "-c" 
+            - |
+              eval $(PYTHONPATH=/sheepdog python 2> /dev/null <<EOM
+              from wsgi import config
+              for key in config['PSQLGRAPH']:
+                print( key + "='" + config['PSQLGRAPH'][key] + "'" )
+              EOM
+              );
+              echo datamodel_postgres_admin graph-create -U "${user}" -P "${password}" -H "${host}" -D "${database}"
+      restartPolicy: Never

--- a/kube/services/jobs/usersync-cronjob.yaml
+++ b/kube/services/jobs/usersync-cronjob.yaml
@@ -9,6 +9,7 @@ spec:
   failedJobsHistoryLimit: 2
   jobTemplate:
     spec:
+      # not yet supported - backOffLimit: 3
       template:
         spec:
           serviceAccountName: useryaml-job

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: usersync
 spec:
+  # not yet supported - backOffLimit: 3
   template:
     spec:
       serviceAccountName: useryaml-job

--- a/kube/services/jobs/useryaml-job.yaml
+++ b/kube/services/jobs/useryaml-job.yaml
@@ -3,6 +3,7 @@ kind: Job
 metadata:
   name: useryaml
 spec:
+  # not yet supported - backOffLimit: 3
   template:
     spec:
       serviceAccountName: useryaml-job

--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -309,11 +309,11 @@ resource "aws_key_pair" "automation_dev" {
 
 resource "aws_s3_bucket" "kube_bucket" {
   # S3 buckets are in a global namespace, so dns style naming
-  bucket = "kube_bucket.${var.vpc_name}.gen3"
+  bucket = "kube-${replace(var.vpc_name,"_", "-")}-gen3"
   acl    = "private"
 
   tags {
-    Name         = "kube_bucket.${var.vpc_name}.gen3"
+    Name         = "kube-${replace(var.vpc_name,"_", "-")}-gen3"
     Environment  = "${var.vpc_name}"
     Organization = "Basic Service"
   }

--- a/tf_files/aws/outputs.tf
+++ b/tf_files/aws/outputs.tf
@@ -55,22 +55,23 @@ output "gdcapi_rds_id" {
 #-----------------------------
 
 data "template_file" "cluster" {
-    template = "${file("${path.module}/../configs/cluster.yaml")}"
-    vars {
-        cluster_name = "${var.vpc_name}"
-        key_name = "${aws_key_pair.automation_dev.key_name}"
-        aws_region = "${var.aws_region}"
-        kms_key = "${aws_kms_key.kube_key.arn}"
-        route_table_id = "${aws_route_table.private_kube.id}"
-        vpc_id ="${module.cdis_vpc.vpc_id}"
-        vpc_cidr = "${module.cdis_vpc.vpc_cidr_block}"
-        subnet_id = "${aws_subnet.private_kube.id}"
-        subnet_cidr = "${aws_subnet.private_kube.cidr_block}"
-        subnet_zone = "${aws_subnet.private_kube.availability_zone}"
-        security_group_id = "${aws_security_group.kube-worker.id}"
-        kube_additional_keys = "${var.kube_additional_keys}"
-        hosted_zone = "${module.cdis_vpc.zone_id}"
-    }
+  template = "${file("${path.module}/../configs/cluster.yaml")}"
+
+  vars {
+    cluster_name         = "${var.vpc_name}"
+    key_name             = "${aws_key_pair.automation_dev.key_name}"
+    aws_region           = "${var.aws_region}"
+    kms_key              = "${aws_kms_key.kube_key.arn}"
+    route_table_id       = "${aws_route_table.private_kube.id}"
+    vpc_id               = "${module.cdis_vpc.vpc_id}"
+    vpc_cidr             = "${module.cdis_vpc.vpc_cidr_block}"
+    subnet_id            = "${aws_subnet.private_kube.id}"
+    subnet_cidr          = "${aws_subnet.private_kube.cidr_block}"
+    subnet_zone          = "${aws_subnet.private_kube.availability_zone}"
+    security_group_id    = "${aws_security_group.kube-worker.id}"
+    kube_additional_keys = "${var.kube_additional_keys}"
+    hosted_zone          = "${module.cdis_vpc.zone_id}"
+  }
 }
 
 #
@@ -82,70 +83,72 @@ data "template_file" "cluster" {
 #      https://github.com/hashicorp/terraform/issues/11566
 #
 data "template_file" "creds" {
-    template = "${file("${path.module}/../configs/creds.tpl")}"
-    vars {
-        fence_host = "${join(" ", coalescelist(aws_db_instance.db_fence.*.address, aws_db_instance.db_userapi.*.address))}"
-        fence_user = "${var.db_password_fence != "" ? "fence_user" : "userapi_user"}"
-        fence_pwd = "${var.db_password_fence != "" ? var.db_password_fence : var.db_password_userapi}"
-        fence_db = "${join(" ", coalescelist(aws_db_instance.db_fence.*.name, aws_db_instance.db_userapi.*.name))}"
-        userapi_host = "${join(" ", coalescelist(aws_db_instance.db_userapi.*.address, aws_db_instance.db_fence.*.address))}"
-        userapi_user = "${var.db_password_userapi != "" ? "userapi_user" : "fence_user"}"
-        userapi_pwd = "${var.db_password_userapi != "" ? var.db_password_userapi : var.db_password_fence}"
-        userapi_db = "${join(" ", coalescelist(aws_db_instance.db_userapi.*.name, aws_db_instance.db_fence.*.name))}"
-        gdcapi_host = "${aws_db_instance.db_gdcapi.address}"
-        gdcapi_user = "${aws_db_instance.db_gdcapi.username}"
-        gdcapi_pwd = "${aws_db_instance.db_gdcapi.password}"
-        gdcapi_db = "${aws_db_instance.db_gdcapi.name}"
-        peregrine_user = "peregrine"
-        peregrine_pwd = "${var.db_password_peregrine}"
-        sheepdog_user = "sheepdog"
-        sheepdog_pwd = "${var.db_password_sheepdog}"
-        indexd_host = "${aws_db_instance.db_indexd.address}"
-        indexd_user = "${aws_db_instance.db_indexd.username}"
-        indexd_pwd = "${aws_db_instance.db_indexd.password}"
-        indexd_db = "${aws_db_instance.db_indexd.name}"
-        hostname = "${var.hostname}"
-        google_client_secret = "${var.google_client_secret}"
-        google_client_id = "${var.google_client_id}"
-        hmac_encryption_key = "${var.hmac_encryption_key}"
-        gdcapi_secret_key = "${var.gdcapi_secret_key}"
-        gdcapi_indexd_password = "${var.gdcapi_indexd_password}"
-        gdcapi_oauth2_client_id = "${var.gdcapi_oauth2_client_id}"
-        gdcapi_oauth2_client_secret = "${var.gdcapi_oauth2_client_secret}"
-    }
+  template = "${file("${path.module}/../configs/creds.tpl")}"
+
+  vars {
+    fence_host                  = "${join(" ", coalescelist(aws_db_instance.db_fence.*.address, aws_db_instance.db_userapi.*.address))}"
+    fence_user                  = "${var.db_password_fence != "" ? "fence_user" : "userapi_user"}"
+    fence_pwd                   = "${var.db_password_fence != "" ? var.db_password_fence : var.db_password_userapi}"
+    fence_db                    = "${join(" ", coalescelist(aws_db_instance.db_fence.*.name, aws_db_instance.db_userapi.*.name))}"
+    userapi_host                = "${join(" ", coalescelist(aws_db_instance.db_userapi.*.address, aws_db_instance.db_fence.*.address))}"
+    userapi_user                = "${var.db_password_userapi != "" ? "userapi_user" : "fence_user"}"
+    userapi_pwd                 = "${var.db_password_userapi != "" ? var.db_password_userapi : var.db_password_fence}"
+    userapi_db                  = "${join(" ", coalescelist(aws_db_instance.db_userapi.*.name, aws_db_instance.db_fence.*.name))}"
+    gdcapi_host                 = "${aws_db_instance.db_gdcapi.address}"
+    gdcapi_user                 = "${aws_db_instance.db_gdcapi.username}"
+    gdcapi_pwd                  = "${aws_db_instance.db_gdcapi.password}"
+    gdcapi_db                   = "${aws_db_instance.db_gdcapi.name}"
+    peregrine_user              = "peregrine"
+    peregrine_pwd               = "${var.db_password_peregrine}"
+    sheepdog_user               = "sheepdog"
+    sheepdog_pwd                = "${var.db_password_sheepdog}"
+    indexd_host                 = "${aws_db_instance.db_indexd.address}"
+    indexd_user                 = "${aws_db_instance.db_indexd.username}"
+    indexd_pwd                  = "${aws_db_instance.db_indexd.password}"
+    indexd_db                   = "${aws_db_instance.db_indexd.name}"
+    hostname                    = "${var.hostname}"
+    google_client_secret        = "${var.google_client_secret}"
+    google_client_id            = "${var.google_client_id}"
+    hmac_encryption_key         = "${var.hmac_encryption_key}"
+    gdcapi_secret_key           = "${var.gdcapi_secret_key}"
+    gdcapi_indexd_password      = "${var.gdcapi_indexd_password}"
+    gdcapi_oauth2_client_id     = "${var.gdcapi_oauth2_client_id}"
+    gdcapi_oauth2_client_secret = "${var.gdcapi_oauth2_client_secret}"
+  }
 }
 
 data "template_file" "kube_vars" {
-    template = "${file("${path.module}/../configs/kube-vars.sh.tpl")}"
-    vars {
-        vpc_name = "${var.vpc_name}"
-        s3_bucket = "kube_bucket.${var.vpc_name}.gen3"
-        fence_snapshot = "${var.fence_snapshot}"
-        gdcapi_snapshot = "${var.gdcapi_snapshot}"
-    }
+  template = "${file("${path.module}/../configs/kube-vars.sh.tpl")}"
+
+  vars {
+    vpc_name        = "${var.vpc_name}"
+    s3_bucket       = "${aws_s3_bucket.kube_bucket.id}"
+    fence_snapshot  = "${var.fence_snapshot}"
+    gdcapi_snapshot = "${var.gdcapi_snapshot}"
+  }
 }
 
 data "template_file" "ssh_config" {
-    template = "${file("${path.module}/../configs/ssh_config.tpl")}"
-    vars {
-        vpc_name = "${var.vpc_name}"
-        login_public_ip = "${module.cdis_vpc.login_ip}"
-        k8s_ip = "${aws_instance.kube_provisioner.private_ip}"
-    }
+  template = "${file("${path.module}/../configs/ssh_config.tpl")}"
+
+  vars {
+    vpc_name        = "${var.vpc_name}"
+    login_public_ip = "${module.cdis_vpc.login_ip}"
+    k8s_ip          = "${aws_instance.kube_provisioner.private_ip}"
+  }
 }
 
 data "template_file" "configmap" {
-    template = "${file("${path.module}/../configs/00configmap.yaml")}"
-    vars {
-        vpc_name = "${var.vpc_name}"
-        hostname = "${var.hostname}"
-        revproxy_arn = "${data.aws_acm_certificate.api.arn}"
-        dictionary_url = "${var.dictionary_url}"
-        portal_app = "${var.portal_app}"
-    }
+  template = "${file("${path.module}/../configs/00configmap.yaml")}"
+
+  vars {
+    vpc_name       = "${var.vpc_name}"
+    hostname       = "${var.hostname}"
+    revproxy_arn   = "${data.aws_acm_certificate.api.arn}"
+    dictionary_url = "${var.dictionary_url}"
+    portal_app     = "${var.portal_app}"
+  }
 }
-
-
 
 #--------------------------------------------------------------
 # Legacy stuff ...
@@ -153,30 +156,30 @@ data "template_file" "configmap" {
 # instead just publish output variables
 #
 resource "null_resource" "config_setup" {
-    triggers {
-      creds_change = "${data.template_file.creds.rendered}"
-      vars_change = "${data.template_file.kube_vars.rendered}"
-      config_change = "${data.template_file.configmap.rendered}"
-      cluster_change = "${data.template_file.cluster.rendered}"
-    }
+  triggers {
+    creds_change   = "${data.template_file.creds.rendered}"
+    vars_change    = "${data.template_file.kube_vars.rendered}"
+    config_change  = "${data.template_file.configmap.rendered}"
+    cluster_change = "${data.template_file.cluster.rendered}"
+  }
 
-    provisioner "local-exec" {
-        command = "mkdir ${var.vpc_name}_output; echo '${data.template_file.creds.rendered}' >${var.vpc_name}_output/creds.json"
-    }
+  provisioner "local-exec" {
+    command = "mkdir ${var.vpc_name}_output; echo '${data.template_file.creds.rendered}' >${var.vpc_name}_output/creds.json"
+  }
 
-    provisioner "local-exec" {
-        command = "echo '${data.template_file.cluster.rendered}' > ${var.vpc_name}_output/cluster.yaml"
-    }
-    provisioner "local-exec" {
-        command = "echo \"${data.template_file.kube_vars.rendered}\" | cat - \"${path.module}/../configs/kube-up-body.sh\" > ${var.vpc_name}_output/kube-up.sh"
-    }
+  provisioner "local-exec" {
+    command = "echo '${data.template_file.cluster.rendered}' > ${var.vpc_name}_output/cluster.yaml"
+  }
 
-    provisioner "local-exec" {
-        command = "echo \"${data.template_file.kube_vars.rendered}\" | cat - \"${path.module}/../configs/kube-services-body.sh\" > ${var.vpc_name}_output/kube-services.sh"
-    }
+  provisioner "local-exec" {
+    command = "echo \"${data.template_file.kube_vars.rendered}\" | cat - \"${path.module}/../configs/kube-up-body.sh\" > ${var.vpc_name}_output/kube-up.sh"
+  }
 
-    provisioner "local-exec" {
-        command = "echo \"${data.template_file.configmap.rendered}\" > ${var.vpc_name}_output/00configmap.yaml"
-    }
+  provisioner "local-exec" {
+    command = "echo \"${data.template_file.kube_vars.rendered}\" | cat - \"${path.module}/../configs/kube-services-body.sh\" > ${var.vpc_name}_output/kube-services.sh"
+  }
+
+  provisioner "local-exec" {
+    command = "echo \"${data.template_file.configmap.rendered}\" > ${var.vpc_name}_output/00configmap.yaml"
+  }
 }
-

--- a/tf_files/configs/kube-setup-workvm.sh
+++ b/tf_files/configs/kube-setup-workvm.sh
@@ -16,14 +16,10 @@ fi
 export DEBIAN_FRONTEND=noninteractive
 
 XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
-vpc_name=${vpc_name:-$1}
-s3_bucket=${s3_bucket:-$2}
+vpc_name="${vpc_name:-$1}"
+s3_bucket="${s3_bucket:-$2}"
 
 if [ -z "${vpc_name}" ]; then
-   echo "Usage: bash kube-setup-workvm.sh vpc_name s3_bucket"
-   exit 1
-fi
-if [ -z "${s3_bucket}" ]; then
    echo "Usage: bash kube-setup-workvm.sh vpc_name s3_bucket"
    exit 1
 fi

--- a/tf_files/modules/cdis-s3-bucket/cloud.tf
+++ b/tf_files/modules/cdis-s3-bucket/cloud.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "log_bucket" {
-  bucket = "s3logs.${var.bucket_name}"
+  bucket = "s3logs-${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   acl    = "log-delivery-write"
 
   server_side_encryption_configuration {
@@ -11,7 +11,7 @@ resource "aws_s3_bucket" "log_bucket" {
   }
 
   tags {
-    Name        = "s3logs.${var.bucket_name}"
+    Name        = "s3logs-${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
     Environment = "${var.environment}"
     Purpose     = "logs bucket"
   }
@@ -20,7 +20,7 @@ resource "aws_s3_bucket" "log_bucket" {
 #-------------------------
 
 resource "aws_s3_bucket" "mybucket" {
-  bucket = "${var.bucket_name}"
+  bucket = "${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   acl    = "private"
 
   server_side_encryption_configuration {
@@ -33,18 +33,18 @@ resource "aws_s3_bucket" "mybucket" {
 
   logging {
     target_bucket = "${aws_s3_bucket.log_bucket.id}"
-    target_prefix = "log/${var.bucket_name}"
+    target_prefix = "log/${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   }
 
   tags {
-    Name        = "${var.bucket_name}"
+    Name        = "${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
     Environment = "${var.environment}"
     Purpose     = "data bucket"
   }
 }
 
 resource "aws_iam_role" "mybucket_reader" {
-  name = "bucket_reader_${var.bucket_name}"
+  name = "bucket_reader_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -76,21 +76,32 @@ data "aws_iam_policy_document" "mybucket_reader" {
   }
 }
 
-resource "aws_iam_role_policy" "mybucket_reader" {
-  name   = "bucket_reader_${var.bucket_name}"
-  policy = "${data.aws_iam_policy_document.mybucket_reader.json}"
-  role   = "${aws_iam_role.mybucket_reader.id}"
+resource "aws_iam_policy" "mybucket_reader" {
+  name        = "bucket_reader_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
+  description = "Read ${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
+  policy      = "${data.aws_iam_policy_document.mybucket_reader.json}"
 }
 
+resource "aws_iam_role_policy_attachment" "mybucket_reader" {
+  role       = "${aws_iam_role.mybucket_reader.name}"
+  policy_arn = "${aws_iam_policy.mybucket_reader.arn}"
+}
+
+#resource "aws_iam_role_policy" "mybucket_reader" {
+#  name   = "bucket_reader_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
+#  policy = "${data.aws_iam_policy_document.mybucket_reader.json}"
+#  role   = "${aws_iam_role.mybucket_reader.id}"
+#}
+
 resource "aws_iam_instance_profile" "mybucket_reader" {
-  name = "bucket_reader_${var.bucket_name}"
+  name = "bucket_reader_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   role = "${aws_iam_role.mybucket_reader.id}"
 }
 
 #----------------------
 
 resource "aws_iam_role" "mybucket_writer" {
-  name = "bucket_writer_${var.bucket_name}"
+  name = "bucket_writer_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   path = "/"
 
   assume_role_policy = <<EOF
@@ -134,13 +145,24 @@ data "aws_iam_policy_document" "mybucket_writer" {
   }
 }
 
-resource "aws_iam_role_policy" "mybucket_writer" {
-  name   = "bucket_writer_${var.bucket_name}"
-  policy = "${data.aws_iam_policy_document.mybucket_writer.json}"
-  role   = "${aws_iam_role.mybucket_writer.id}"
+resource "aws_iam_policy" "mybucket_writer" {
+  name        = "bucket_writer_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
+  description = "Read or write ${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
+  policy      = "${data.aws_iam_policy_document.mybucket_writer.json}"
 }
 
+resource "aws_iam_role_policy_attachment" "mybucket_writer" {
+  role       = "${aws_iam_role.mybucket_writer.name}"
+  policy_arn = "${aws_iam_policy.mybucket_writer.arn}"
+}
+
+#resource "aws_iam_role_policy" "mybucket_writer" {
+#  name   = "bucket_writer_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
+#  policy = "${data.aws_iam_policy_document.mybucket_writer.json}"
+#  role   = "${aws_iam_role.mybucket_writer.id}"
+#}
+
 resource "aws_iam_instance_profile" "mybucket_writer" {
-  name = "bucket_writer_${var.bucket_name}"
+  name = "bucket_writer_${replace(replace(var.bucket_name, "_", "-"),".", "-")}"
   role = "${aws_iam_role.mybucket_writer.id}"
 }


### PR DESCRIPTION
* s3 data-bucket name fixes
* s3 data-bucket create managed policies for read and read-write bucket access that are easy to attach to users and roles
* add `g3k psql` command - ex:
```
g3k psql fence
```

* add `gdcdb-create-job` that initializes the sheepdog database - the sheepdog secrets must be registered - ex:
```
g3k runjob gdcdb-create
g3k joblogs
```

* add `graph-create-job` to run `datamodel_postgres_admin graph-create` after a dictionary update - ex:
```
g3k runjob graph-create
g3k joblogs
```
