### PR TITLE
fix(tls-arn): do not require tls arn for VPC

### DIFF
--- a/kube/services/jenkins/apply_service.sh
+++ b/kube/services/jenkins/apply_service.sh
@@ -11,8 +11,8 @@
 scriptDir=$(dirname -- "$(readlink -f -- "${BASH_SOURCE:-$0}")")
 
 export ARN=$(kubectl get configmap global --output=jsonpath='{.data.revproxy_arn}')
-if [[ ! -z $ARN ]]; then
+if [[ "$ARN" =~ ^arn ]]; then
   envsubst <$scriptDir/jenkins-service.yaml | kubectl apply -f -
 else
-  echo "Global configmap not configured"
+  echo "Global configmap not configured with TLS certifcate ARN"
 fi

--- a/kube/services/revproxy/apply_service
+++ b/kube/services/revproxy/apply_service
@@ -38,7 +38,7 @@ fi
 LOGGING_CONFIG=""
 
 export ARN=$(g3kubectl get configmap global --output=jsonpath='{.data.revproxy_arn}')
-if [[ -n "$ARN" ]]; then
+if [[ "$ARN" =~ ^arn ]]; then
   if [[ -z "$DRY_RUN" ]]; then
     envsubst <$scriptDir/revproxy-service-elb.yaml | g3kubectl apply -f -
   else
@@ -47,7 +47,7 @@ if [[ -n "$ARN" ]]; then
     echo "DRY RUN"
   fi
 else
-  echo "Global configmap not configured"
+  echo "ERROR: Global configmap not configured with TLS certificate ARN"
 fi
 
 # Don't automatically apply this right now

--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -165,11 +165,6 @@ resource "aws_db_parameter_group" "rds-cdis-pg" {
   }
 }
 
-data "aws_acm_certificate" "api" {
-  domain   = "${var.aws_cert_name}"
-  statuses = ["ISSUED"]
-}
-
 resource "aws_kms_key" "kube_key" {
   description         = "encryption/decryption key for kubernete"
   enable_key_rotation = true

--- a/tf_files/aws/outputs.tf
+++ b/tf_files/aws/outputs.tf
@@ -129,7 +129,7 @@ data "template_file" "configmap" {
     hostname       = "${var.hostname}"
     kube_bucket    = "${aws_s3_bucket.kube_bucket.id}"
     logs_bucket    = "${module.elb_logs.log_bucket_name}"
-    revproxy_arn   = "${data.aws_acm_certificate.api.arn}"
+    revproxy_arn   = "AWS-CERT-MANAGER-ARN-HERE"
     dictionary_url = "${var.dictionary_url}"
     portal_app     = "${var.portal_app}"
   }


### PR DESCRIPTION
should be able to bootstrap a VPC without
specifying the TLS ARN