### PR TITLE
fix(kube-aws): cluster-name and subnet tagging

### DIFF
--- a/tf_files/aws/kube.tf
+++ b/tf_files/aws/kube.tf
@@ -33,7 +33,9 @@ resource "aws_subnet" "public_kube" {
   cidr_block              = "172.${var.vpc_octet2}.${var.vpc_octet3 + 4}.0/24"
   map_public_ip_on_launch = true
   availability_zone       = "${data.aws_availability_zones.available.names[0]}"
-  tags                    = "${map("Name", "public_kube", "Organization", "Basic Service", "Environment", var.vpc_name, "kubernetes.io/cluster/${var.vpc_name}", "shared", "kubernetes.io/role/elb", "")}"
+
+  # Note: KubernetesCluster tag is required by kube-aws to identify the public subnet for ELBs
+  tags = "${map("Name", "public_kube", "Organization", "Basic Service", "Environment", var.vpc_name, "kubernetes.io/cluster/${var.vpc_name}", "shared", "kubernetes.io/role/elb", "", "KubernetesCluster", "${local.cluster_name}")}"
 }
 
 #

--- a/tf_files/aws/outputs.tf
+++ b/tf_files/aws/outputs.tf
@@ -50,7 +50,7 @@ data "template_file" "cluster" {
   template = "${file("${path.module}/../configs/cluster.yaml")}"
 
   vars {
-    cluster_name         = "${var.vpc_name}"
+    cluster_name         = "${local.cluster_name}"
     key_name             = "${aws_key_pair.automation_dev.key_name}"
     aws_region           = "${var.aws_region}"
     kms_key              = "${aws_kms_key.kube_key.arn}"

--- a/tf_files/aws/variables.tf
+++ b/tf_files/aws/variables.tf
@@ -125,3 +125,8 @@ variable "ami_account_id" {
 variable "csoc_vpc_id" {
   default = "vpc-e2b51d99"
 }
+
+locals {
+  # kube-aws does not like '-' in cluster name
+  cluster_name = "${replace(var.vpc_name, "-", "")}"
+}

--- a/tf_files/configs/kube-setup-revproxy.sh
+++ b/tf_files/configs/kube-setup-revproxy.sh
@@ -27,4 +27,15 @@ g3k roll revproxy
 # apply_service deploys the revproxy service after
 # inserting the certificate ARN from a config map
 #
+
+if ! g3kubectl get services revproxy-service > /dev/null 2>&1; then
+  g3kubectl apply -f "${GEN3_HOME}/kube/services/revproxy/revproxy-service.yaml"
+else
+  #
+  # Do not do this automatically as it will trigger an elb
+  # change in existing commons
+  #
+  echo "Ensure the commons DNS references the -elb revproxy which support http proxy protocol"
+fi
+
 bash "${GEN3_HOME}/kube/services/revproxy/apply_service"


### PR DESCRIPTION
also deply revproxy-service if not already deployed