### PR TITLE
fix(creds.tpl): missing a comma on line 69

### DIFF
--- a/tf_files/configs/creds.tpl
+++ b/tf_files/configs/creds.tpl
@@ -65,7 +65,7 @@
         "db_host": "${indexd_host}",
         "db_username": "${indexd_user}",
         "db_password": "${indexd_pwd}",
-        "db_database": "${indexd_db}"
+        "db_database": "${indexd_db}",
         "user_db": {
         }
     }


### PR DESCRIPTION
Small bug impeding kube-service.sh to run properly 