### PR TITLE
fix(fluentd.yaml): new and updated image to be used

### DIFF
--- a/kube/services/fluentd/fluentd.yaml
+++ b/kube/services/fluentd/fluentd.yaml
@@ -20,7 +20,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:cloudwatch
+        image: fluent/fluentd-kubernetes-daemonset:v1.1-debian-cloudwatch
         env:
           # Deploy with kube-setup-fluentd.sh ...
           - name:  LOG_GROUP_NAME


### PR DESCRIPTION
This should solve the issue we've been experiencing lately about a few logs being missing for unknown reasons.