### PR TITLE
fix(jenkins): do not git pull cdis-manifest

### DIFF
--- a/gen3/bin/kube-dev-namespace.sh
+++ b/gen3/bin/kube-dev-namespace.sh
@@ -55,6 +55,12 @@ cd /home/$namespace
 mkdir -p /home/$namespace/.ssh
 cp ~/.ssh/authorized_keys /home/$namespace/.ssh
 
+# setup ~/.aws
+mkdir -p /home/$namespace/.aws
+if [[ -f ~/.aws/config ]]; then
+  cp ~/.aws/config /home/$namespace/.aws/
+fi
+
 # setup ~/cloud-automation
 if [[ ! -d ./cloud-automation ]]; then
   git clone https://github.com/uc-cdis/cloud-automation.git
@@ -93,9 +99,9 @@ fi
 cp ~/${vpc_name}/creds.json /home/$namespace/${vpc_name}/creds.json
 
 dbname=$(echo $namespace | sed 's/-/_/g')
-# create new databases
+# create new databases - don't break if already exists
 for name in indexd fence sheepdog; do
-  echo "CREATE DATABASE $dbname;" | g3k psql $name 
+  echo "CREATE DATABASE $dbname;" | g3k psql $name || true
 done
 
 # update creds.json
@@ -143,8 +149,7 @@ EOF
 fi
 
 # reset ownership
-sudo chown -R "${namespace}:" /home/$namespace
-sudo chown -R "${namespace}:" /home/$namespace/.ssh
+sudo chown -R "${namespace}:" /home/$namespace /home/$namespace/.ssh /home/$namespace/.aws
 sudo chmod -R 0700 /home/$namespace/.ssh
 sudo chmod go-w /home/$namespace
 

--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -54,7 +54,8 @@ g3k_manifest_init() {
     # This will fail if proxy is not set correctly
     git clone "https://github.com/uc-cdis/cdis-manifest.git" "${GEN3_MANIFEST_HOME}" 1>&2
   fi
-  if [[ -d "$GEN3_MANIFEST_HOME/.git" ]]; then
+  if [[ -d "$GEN3_MANIFEST_HOME/.git" && -z "$JENKINS_HOME" ]]; then
+    # Don't do this when running tests in Jenkins ...
     echo "INFO: git fetch in $GEN3_MANIFEST_HOME" 1>&2
     (cd "$GEN3_MANIFEST_HOME" && git pull; git status) 1>&2
   fi


### PR DESCRIPTION
do not git-pull cdis-manifest when running
a Jenkins test which checks out the manifest
in a screwy way and manipulates manifests for testing