### PR TITLE
Fix/jenkins

### DIFF
--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.135
+FROM jenkins/jenkins:2.138
 
 USER root
 

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -39,7 +39,7 @@ RUN set -xe \
     && rm -rf /var/lib/apt/lists/*
 
 # install terraform
-RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
+RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip
 RUN unzip /tmp/terraform.zip -d /usr/local/bin; /bin/rm /tmp/terraform.zip
 
 # install packer

--- a/gen3/bin/g3k_testsuite.sh
+++ b/gen3/bin/g3k_testsuite.sh
@@ -23,9 +23,13 @@ test_mpath() {
   local mpath=$(g3k_manifest_path test1.manifest.g3k)
   [[ "$mpath" == "${GEN3_MANIFEST_HOME}/test1.manifest.g3k/manifest.json" ]]; 
   because $? "g3k_manifest_path prefers domain/manifest.json if available: $mpath ?= ${GEN3_MANIFEST_HOME}/test1.manifest.g3k/manifest.json"
-  mpath=$(g3k_manifest_path bogus.manifest.g3k)
-  [[ "$mpath" == "${GEN3_MANIFEST_HOME}/default/manifest.json" ]]; 
-  because $? "g3k_manfiest_path falls through to default/manifest.json if domain/manifest.json not present: $mpath"
+  ! mpath=$(g3k_manifest_path bogus.manifest.g3k); because $? "The bogus manifest does not exist: $mpath"
+  [[ "$mpath" == "${GEN3_MANIFEST_HOME}/bogus.manifest.g3k/manifest.json" ]]; 
+  because $? "g3k_manfest_path maps to domain/manifest.json even if it does not exist: $mpath"
+
+  export GEN3_GITOPS_FOLDER="/whatever"
+  [[ "$(g3k_manifest_path)" == "$GEN3_GITOPS_FOLDER/manifest.json" ]]; 
+  because $? "g3k_manifest_path respects the GEN3_GITOPS_FOLDER override variable"
 }
 
 #
@@ -38,8 +42,9 @@ test_mfilter() {
   for name in fence sheepdog; do
     capName=Fence
     if [[ "$name" == "sheepdog" ]]; then capName=Sheepdog; fi
-    for domain in test1.manifest.g3k default.bogus; do
-      local mpath="$(g3k_manifest_path test1.manifest.g3k)"
+    for domain in test1.manifest.g3k default; do
+      local mpath
+      mpath="$(g3k_manifest_path test1.manifest.g3k)"
       # Note: date timestamp will differ between saved snapshot and fresh template processing
       echo "Writing: $testFolder/${name}-${domain}-a.yaml"
       g3k_manifest_filter "${GEN3_HOME}/kube/services/$name/${name}-deploy.yaml" "$mpath" | sed 's/.*date:.*$//' > "$testFolder/${name}-${domain}-a.yaml"
@@ -51,6 +56,29 @@ test_mfilter() {
   g3k_manifest_filter "${GEN3_MANIFEST_HOME}/bogusInput.yaml" "${GEN3_MANIFEST_HOME}/default/manifest.json" "k1" "the value is v1" "k2" "the value is v2" > "$testFolder/bogus-b.yaml"
   diff -w "${GEN3_MANIFEST_HOME}/bogusExpectedResult.yaml" "$testFolder/bogus-b.yaml"
   because $? "Manifest filter processed extra environment values ok"
+}
+
+test_mlookup() {
+  export GEN3_GITOPS_FOLDER="${GEN3_MANIFEST_HOME}/test1.manifest.g3k"
+  [[ "$(g3k_config_lookup .versions.fence)" == "quay.io/cdis/fence:master" ]];
+  because $? "g3k_config_lookup found expected fence version: $(g3k_config_lookup .versions.fence)"
+  ! g3k_manifest_filter '.bogus.whatever';
+  because $? 'g3k_manifest_filter gives non-zero exit code on jq expression failure'
+  g3k_config_lookup '.versions.fence';
+  because $? 'g3k_manifest_filter gives zero exit code on jq expression match'
+  # test with a toy .yaml file
+  testFolder="${XDG_RUNTIME_DIR}/g3kTest/mlookup"
+  /bin/rm -rf "$testFolder"
+  mkdir -p -m 0700 "$testFolder"
+  cat - > "$testFolder/toy.yaml" <<EOM
+bla:
+  foo: frick
+  ugh: doh
+EOM
+  blaFoo=$(g3k_config_lookup '.bla.foo' "$testFolder/toy.yaml")
+  because $? "g3k_config_lookup zero exit code for valid yaml lookup"
+  [[ "$blaFoo" == "frick" ]];
+  because $? "g3k_config_lookup got expected value from yaml: $blaFoo"
 }
 
 test_loader() {
@@ -76,11 +104,28 @@ test_random_alpha() {
   [[ "$r1" != "$r2" ]]; because $? "random_alphanumeric generates random strings"
 }
 
+test_roll() {
+  # Mock g3kubectl
+  function g3kubectl() {
+    echo "MOCK: g3kubectl $@"
+  }
+  local mpath
+  mpath="$(g3k_manifest_path test1.manifest.g3k)"
+  # Mock g3k_manifest_path
+  function g3k_manifest_path() { echo "$mpath"; }
+  g3k_roll sheepdog; because $? "roll sheepdog should be ok"
+  ! g3k_roll frickjack; because $? "roll frickjack should not be ok - no yaml file"
+  ! g3k_roll aws-es-proxy; because $? "roll aws-es-proxy should not be ok - no manifest entry"
+}
+
 shunit_runtest "test_env"
 shunit_runtest "test_mpath"
 shunit_runtest "test_mfilter"
+shunit_runtest "test_mlookup"
 shunit_runtest "test_loader"
 shunit_runtest "test_random_alpha"
+shunit_runtest "test_roll"
+
 if [[ "$G3K_TESTSUITE_SUMMARY" != "no" ]]; then
   # little hook, so gen3 testsuite can call through to this testsuite too ...
   echo "g3k summary"

--- a/gen3/bin/kube-dev-namespace.sh
+++ b/gen3/bin/kube-dev-namespace.sh
@@ -55,6 +55,12 @@ cd /home/$namespace
 mkdir -p /home/$namespace/.ssh
 cp ~/.ssh/authorized_keys /home/$namespace/.ssh
 
+# setup ~/.aws
+mkdir -p /home/$namespace/.aws
+if [[ -f ~/.aws/config ]]; then
+  cp ~/.aws/config /home/$namespace/.aws/
+fi
+
 # setup ~/cloud-automation
 if [[ ! -d ./cloud-automation ]]; then
   git clone https://github.com/uc-cdis/cloud-automation.git
@@ -93,9 +99,9 @@ fi
 cp ~/${vpc_name}/creds.json /home/$namespace/${vpc_name}/creds.json
 
 dbname=$(echo $namespace | sed 's/-/_/g')
-# create new databases
+# create new databases - don't break if already exists
 for name in indexd fence sheepdog; do
-  echo "CREATE DATABASE $dbname;" | g3k psql $name 
+  echo "CREATE DATABASE $dbname;" | g3k psql $name || true
 done
 
 # update creds.json
@@ -143,8 +149,7 @@ EOF
 fi
 
 # reset ownership
-sudo chown -R "${namespace}:" /home/$namespace
-sudo chown -R "${namespace}:" /home/$namespace/.ssh
+sudo chown -R "${namespace}:" /home/$namespace /home/$namespace/.ssh /home/$namespace/.aws
 sudo chmod -R 0700 /home/$namespace/.ssh
 sudo chmod go-w /home/$namespace
 

--- a/gen3/bin/kube-setup-networkpolicy.sh
+++ b/gen3/bin/kube-setup-networkpolicy.sh
@@ -56,4 +56,6 @@ if [[ -f "$credsPath" ]]; then # setup netpolicy
   g3kubectl apply -f "${GEN3_HOME}/kube/services/netpolicy/networkpolicy_allowdns_templ.yaml"
   g3kubectl apply -f "${GEN3_HOME}/kube/services/netpolicy/networkpolicy_gen3job_templ.yaml"
   g3kubectl apply -f "${GEN3_HOME}/kube/services/netpolicy/networkpolicy_arranger_templ.yaml"
+  g3kubectl apply -f "${GEN3_HOME}/kube/services/netpolicy/networkpolicy_aws_es_proxy.yaml"
+  g3kubectl apply -f "${GEN3_HOME}/kube/services/netpolicy/networkpolicy_arranger_dashboard_templ.yaml"
 fi

--- a/gen3/bin/kube-setup-workvm.sh
+++ b/gen3/bin/kube-setup-workvm.sh
@@ -18,7 +18,7 @@ gen3_load "gen3/lib/kube-setup-init"
 if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
   # -E passes through *_proxy environment
   sudo -E apt-get update
-  sudo -E apt-get install -y git jq postgresql-client pwgen python-dev python-pip unzip
+  sudo -E apt-get install -y git jq pwgen python-dev python-pip unzip
   sudo -E XDG_CACHE_HOME=/var/cache python -m pip install --upgrade pip
   sudo -E XDG_CACHE_HOME=/var/cache python -m pip install awscli --upgrade
   # jinja2 needed by render_creds.py
@@ -43,6 +43,19 @@ if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
     if which gcloud > /dev/null 2>&1; then
       sudo -E apt-get remove -y google-cloud-sdk
     fi
+  fi
+  if ! which psql > /dev/null 2>&1; then
+    (
+      # use the postgres dpkg server
+      # https://www.postgresql.org/download/linux/ubuntu/
+      DISTRO="$(lsb_release -c -s)"  # ex - xenial
+      if [[ ! -f /etc/apt/sources.list.d/pgdg.list ]]; then
+        sudo -E echo "deb http://apt.postgresql.org/pub/repos/apt/ ${DISTRO}-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+      fi
+      wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+      sudo -E apt-get update
+      sudo -E apt-get install -y postgresql-client-9.6
+    )
   fi
   if ! which gcloud > /dev/null 2>&1; then
     (

--- a/gen3/bin/kube-setup-workvm.sh
+++ b/gen3/bin/kube-setup-workvm.sh
@@ -76,7 +76,7 @@ if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
   sudo chown -R "${USER}:" ~/.config
       
   if ! which terraform > /dev/null 2>&1; then
-    curl -o "${XDG_RUNTIME_DIR}/terraform.zip" https://releases.hashicorp.com/terraform/0.11.7/terraform_0.11.7_linux_amd64.zip
+    curl -o "${XDG_RUNTIME_DIR}/terraform.zip" https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip
     sudo unzip "${XDG_RUNTIME_DIR}/terraform.zip" -d /usr/local/bin;
     /bin/rm "${XDG_RUNTIME_DIR}/terraform.zip"
   fi

--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -4,8 +4,18 @@
 # via the `g3k/gen3` cli
 #
 
+#
+# Root manifest folder where the `cdis-manifest` git repo is checked out
+#
 GEN3_MANIFEST_HOME="${GEN3_MANIFEST_HOME:-"$(cd "${GEN3_HOME}/.." && pwd)/cdis-manifest"}"
 export GEN3_MANIFEST_HOME
+
+#
+# Override the folder under which to look for
+# manifest.json and other configuration files.
+# If not set, then defaults to GEN3_MANIFEST_HOME/hostname 
+#
+GEN3_GITOPS_FOLDER="${GEN3_GITOPS_FOLDER:""}"
 
 gen3_load "gen3/lib/utils"
 
@@ -68,15 +78,17 @@ g3k_manifest_init() {
 # @param domain commons domain - tries to extract from global configmap if not given
 #
 g3k_manifest_path() {
-  local domain=${1:-$(g3kubectl get configmaps global -ojsonpath='{ .data.hostname }')}
-  if [[ -z "$domain" ]]; then
-    echo -e $(red_color "g3k_manifest_path could not establish commons hostname") 1>&2
-    return 1
-  fi
-  g3k_manifest_init
-  local mpath="${GEN3_MANIFEST_HOME}/${domain}/manifest.json"
-  if [[ ! -f "$mpath" ]]; then
-    mpath="${GEN3_MANIFEST_HOME}/default/manifest.json"
+  local mpath
+  if [[ -z "$GEN3_GITOPS_FOLDER" ]]; then
+    local domain=${1:-$(g3kubectl get configmaps global -ojsonpath='{ .data.hostname }')}
+    if [[ -z "$domain" ]]; then
+      echo -e $(red_color "g3k_manifest_path could not establish commons hostname") 1>&2
+      return 1
+    fi
+    g3k_manifest_init
+    mpath="${GEN3_MANIFEST_HOME}/${domain}/manifest.json"
+  else
+    mpath="${GEN3_GITOPS_FOLDER}/manifest.json"
   fi
   echo "$mpath"
   if [[ -f "$mpath" ]]; then
@@ -174,15 +186,15 @@ g3k_manifest_filter() {
   
   kvList+=('GEN3_DATE_LABEL' "date: \"$(date +%s)\"")
 
-  for key in $(jq -r '.versions | keys[]' < "$manifestPath"); do
-    value="$(jq -r ".versions[\"$key\"]" < "$manifestPath")"
+  for key in $(g3k_config_lookup '.versions | keys[]' "$manifestPath"); do
+    value="$(g3k_config_lookup ".versions[\"$key\"]" "$manifestPath")"
     # zsh friendly upper case
     kvKey=$(echo "GEN3_${key}_IMAGE" | tr '[:lower:]' '[:upper:]')
     kvList+=("$kvKey" "image: $value")
   done
-  for key in $(jq -r '. | keys[]' < "$manifestPath"); do
-    for key2 in $(jq -r ".[\"${key}\"] | keys[]" < "$manifestPath" | grep '^[a-zA-Z]'); do
-      value="$(jq -r ".[\"$key\"][\"$key2\"]" < "$manifestPath")"
+  for key in $(g3k_config_lookup '. | keys[]' "$manifestPath"); do
+    for key2 in $(g3k_config_lookup ".[\"${key}\"] | keys[]" "$manifestPath" | grep '^[a-zA-Z]'); do
+      value="$(g3k_config_lookup ".[\"$key\"][\"$key2\"]" "$manifestPath")"
       if [[ -n "$value" ]]; then
         # zsh friendly upper case
         kvKey=$(echo "GEN3_${key}_${key2}" | tr '[:lower:]' '[:upper:]')
@@ -206,6 +218,36 @@ g3k_manifest_filter() {
 }
 
 #
+# Little helper evaluates the given jq or yq expression
+# (for .json and .yaml files respectively)
+# against the specified manifest
+#
+# @param queryStr like '.versions.sheepdog'
+# @param configPath optional - otherwise defaults to
+#      g3k_manifest_path
+#
+g3k_config_lookup() {
+  local queryStr
+  local configPath
+  queryStr="$1"
+  shift
+  if [[ -z "$1" ]]; then
+    configPath=$(g3k_manifest_path)
+  else
+    configPath="$1"
+  fi
+  if [[ "$configPath" =~ .json$ ]]; then
+    jq -r -e "$queryStr" < "$configPath"
+  elif [[ "$configPath" =~ .yaml ]]; then
+    yq -r -e "$queryStr" < "$configPath"
+  else
+    echo "$(red_color ERROR: file is not .json or .yaml: $configPath)" 1>&2
+    return 1
+  fi
+}
+
+
+#
 # Roll the given deployment
 #
 # @param deploymentName
@@ -216,9 +258,10 @@ g3k_roll() {
   depName="$1"
   shift
   if [[ -z "$depName" ]]; then
-    echo -e "$(red_color "Use: g3k roll deployment-name")"
+    echo -e "$(red_color "Use: g3k roll deployment-name")" 1>&2
     return 1
   fi
+
   local templatePath=""
   if [[ -f "$depName" ]]; then
     # we were given the path to a file - fine
@@ -228,12 +271,29 @@ g3k_roll() {
     templatePath="${GEN3_HOME}/kube/services/${cleanName}/${cleanName}-deploy.yaml"
   fi
 
+  local manifestPath
+  manifestPath="$(g3k_manifest_path)"
+  if [[ ! -f "$manifestPath" ]]; then
+    echo -e "$(red_color "ERROR: manifest does not exist - $manifestPath")" 1>&2
+    return 1
+  fi
+
   if [[ -f "$templatePath" ]]; then
-    g3k_manifest_filter "$templatePath" "" "$@" | g3kubectl apply -f -
+    # Get the service name, so we can verify it's in the manifest
+    local serviceName
+    serviceName="$(basename "$templatePath" | sed 's/-deploy.yaml$//')"
+    
+    if g3k_config_lookup ".versions.$serviceName" < "$manifestPath" > /dev/null 2>&1; then
+      g3k_manifest_filter "$templatePath" "" "$@" | g3kubectl apply -f -
+    else
+      echo "Not rolling $serviceName - no manifest entry in $manifestPath" 1>&2
+      return 1
+    fi
   elif [[ "$depName" == "all" ]]; then
     echo bash "${GEN3_HOME}/gen3/bin/kube-roll-all.sh"
     bash "${GEN3_HOME}/gen3/bin/kube-roll-all.sh"
   else
     echo -e "$(red_color "ERROR: could not find deployment template: $templatePath")"
+    return 1
   fi
 }

--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -31,7 +31,7 @@ g3kubectl() {
   # without causing an infinite loop ...
   #
   if [[ ${CURRENT_SHELL} == "zsh" ]]; then
-    theKubectl=$(whence -p kubectl)
+    theKubectl=$(bash which kubectl)
   else
     theKubectl=$(which kubectl)
   fi

--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -11,11 +11,11 @@ GEN3_MANIFEST_HOME="${GEN3_MANIFEST_HOME:-"$(cd "${GEN3_HOME}/.." && pwd)/cdis-m
 export GEN3_MANIFEST_HOME
 
 #
+# GEN3_GITOPS_FOLDER environment variable:
 # Override the folder under which to look for
 # manifest.json and other configuration files.
 # If not set, then defaults to GEN3_MANIFEST_HOME/hostname 
 #
-GEN3_GITOPS_FOLDER="${GEN3_GITOPS_FOLDER:""}"
 
 gen3_load "gen3/lib/utils"
 
@@ -283,7 +283,7 @@ g3k_roll() {
     local serviceName
     serviceName="$(basename "$templatePath" | sed 's/-deploy.yaml$//')"
     
-    if g3k_config_lookup ".versions.$serviceName" < "$manifestPath" > /dev/null 2>&1; then
+    if g3k_config_lookup ".versions[\"$serviceName\"]" < "$manifestPath" > /dev/null 2>&1; then
       g3k_manifest_filter "$templatePath" "" "$@" | g3kubectl apply -f -
     else
       echo "Not rolling $serviceName - no manifest entry in $manifestPath" 1>&2

--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -54,7 +54,8 @@ g3k_manifest_init() {
     # This will fail if proxy is not set correctly
     git clone "https://github.com/uc-cdis/cdis-manifest.git" "${GEN3_MANIFEST_HOME}" 1>&2
   fi
-  if [[ -d "$GEN3_MANIFEST_HOME/.git" ]]; then
+  if [[ -d "$GEN3_MANIFEST_HOME/.git" && -z "$JENKINS_HOME" ]]; then
+    # Don't do this when running tests in Jenkins ...
     echo "INFO: git fetch in $GEN3_MANIFEST_HOME" 1>&2
     (cd "$GEN3_MANIFEST_HOME" && git pull; git status) 1>&2
   fi

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -7,6 +7,7 @@ export XDG_DATA_HOME=${XDG_DATA_HOME:-~/.local/share}
 export XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR:-"/tmp/gen3-$USER"}
 export GEN3_CACHE_DIR="${XDG_DATA_HOME}/gen3/cache"
 export GEN3_ETC_FOLDER="${XDG_DATA_HOME}/gen3/etc"
+CURRENT_SHELL="$(echo $SHELL | awk -F'/' '{print $NF}')"
 
 (
   for filePath in "$GEN3_CACHE_DIR" "$GEN3_ETC_FOLDER/gcp"; do

--- a/kube/services/arranger-dashboard/README.md
+++ b/kube/services/arranger-dashboard/README.md
@@ -1,0 +1,30 @@
+# TL;DR
+
+Arranger dashboard deployment - access via port-forwarding through the CSOC admin VM.
+
+## Port forwarding
+
+* Login to the admin vm, then:
+    - launch the arranger-dashboard if it's not already running: 
+       `gen3 roll arranger-dashboard`
+    - forward the dashboard ports to the admin vm
+```
+g3kubectl port-forward deployment/arranger-dashboard-deployment 6060 5050 &
+g3kubectl port-forward deployment/aws-es-proxy-deployment 9200 &
+
+```
+
+[port-forward details](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/)
+
+* then forward the ports on the admin-vm to your local machine with ssh
+
+```
+ssh -L 6060:localhost:6060 -L 5050:localhost:5050 -L 9200:localhost:9200 cdistest.csoc
+```
+
+* finally - connect to the dashboard: http://localhost:6060
+* can also interact with the ES cluster via http://localhost:9200 
+```
+source gen3-arranger/Docker/Stacks/esearch/indexSetup.sh
+es_indices
+```

--- a/kube/services/arranger-dashboard/arranger-dashboard-deploy.yaml
+++ b/kube/services/arranger-dashboard/arranger-dashboard-deploy.yaml
@@ -1,0 +1,61 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: arranger-dashboard-deployment
+spec:
+  selector:
+    # Only select pods based on the 'app' label
+    matchLabels:
+      app: arranger-dashboard
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: arranger-dashboard
+        GEN3_DATE_LABEL
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - arranger
+              topologyKey: "kubernetes.io/hostname"
+      automountServiceAccountToken: false
+      containers:
+        - name: arranger-dashboard
+          GEN3_ARRANGER_DASHBOARD_IMAGE|-image: quay.io/cdis/arranger-dashboard:master-|
+          ports:
+          - containerPort: 6060
+          env:
+          - name: ARRANGER_API
+            value: localhost:5050
+          - name: ES_HOST
+            value: esproxy-service:9200
+          imagePullPolicy: Always
+          #resources:
+          #  limits:
+          #    cpu: 0.2
+          #    memory: 412Mi
+        - name: arranger-adminapi
+          GEN3_ARRANGER_ADMINAPI_IMAGE|-image: quay.io/cdis/arranger-server:master-|
+          ports:
+          - containerPort: 5050
+          env:
+          - name: ES_HOST
+            value: esproxy-service:9200
+          imagePullPolicy: Always
+          #resources:
+          #  limits:
+          #    cpu: 0.2
+          #    memory: 412Mi

--- a/kube/services/arranger-dashboard/arranger-dashboard-deploy.yaml
+++ b/kube/services/arranger-dashboard/arranger-dashboard-deploy.yaml
@@ -34,7 +34,7 @@ spec:
       automountServiceAccountToken: false
       containers:
         - name: arranger-dashboard
-          GEN3_ARRANGER_DASHBOARD_IMAGE|-image: quay.io/cdis/arranger-dashboard:master-|
+          GEN3_ARRANGER-DASHBOARD_IMAGE|-image: quay.io/cdis/arranger-dashboard:master-|
           ports:
           - containerPort: 6060
           env:
@@ -48,7 +48,7 @@ spec:
           #    cpu: 0.2
           #    memory: 412Mi
         - name: arranger-adminapi
-          GEN3_ARRANGER_ADMINAPI_IMAGE|-image: quay.io/cdis/arranger-server:master-|
+          GEN3_ARRANGER-ADMINAPI_IMAGE|-image: quay.io/cdis/arranger-server:master-|
           ports:
           - containerPort: 5050
           env:

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   revisionHistoryLimit: 2
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    #
+    # rolling update does not work, since
+    # persistent volume claim cannot be shared
+    #
+    type: Recreate
   template:
     metadata:
       labels:

--- a/kube/services/netpolicy/networkpolicy_arranger_dashboard_templ.yaml
+++ b/kube/services/netpolicy/networkpolicy_arranger_dashboard_templ.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: networkpolicy-arranger-dashboard
+spec:
+  podSelector:
+    matchLabels:
+      app: fence
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app: arranger-dashboard
+      ports:
+         - port: 80
+         - port: 443
+  egress:
+    - to:
+      - podSelector:
+          matchLabels:
+            app: esproxy
+  policyTypes:
+   - Ingress
+   - Egress

--- a/kube/services/netpolicy/networkpolicy_arranger_dashboard_templ.yaml
+++ b/kube/services/netpolicy/networkpolicy_arranger_dashboard_templ.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      app: fence
+      app: arranger-dashboard
   ingress:
     - from:
       - podSelector:

--- a/kube/services/netpolicy/networkpolicy_aws_es_proxy.yaml
+++ b/kube/services/netpolicy/networkpolicy_aws_es_proxy.yaml
@@ -11,6 +11,15 @@ spec:
       - podSelector:
           matchLabels:
             app: arranger
+      - podSelector:
+          matchLabels:
+            app: spark
+      - podSelector:
+          matchLabels:
+            app: tube
+      - podSelector:
+          matchLabels:
+            app: arranger-dashboard
       ports:
          - port: 9200
   egress:

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -47,7 +47,7 @@ spec:
             secretName: "service-ca"
       containers:
       - name: revproxy
-        image: nginx:1.13.9-perl
+        GEN3_REVPROXY_IMAGE|-image: nginx:1.13.9-perl-|
         command:
           - /usr/sbin/nginx
           - -g


### PR DESCRIPTION
* update jenkins
* flip jenkins deployment over to `replace` instead of `rolling` to avoid issues with persistent volume
* do not `git pull` cdis-manifest when running a Jenkins job - the job sets up cdis-manifest in the way it wants
* update psql client install on admin VM's - `pg_dump` wants client and server versions to match
* `kube-dev-namespace` - script to setup new dev environment - include `~/.aws/` folder setup
* `gen3 roll` refuses to deploy if a manifest file is not present or if the specified service does not have an entry in the manifest's `versions` block
* add `kube/services/arranger-dashboard` to support running the dashboard on the cluster - access via admin-vm with port forwarding - see the readme - plus supporting network policy updates