### PR TITLE
Changing the vpn server VM ; break the vpn set-up

### DIFF
--- a/files/openvpn_management_scripts/templates/network_tweaks.sh.template
+++ b/files/openvpn_management_scripts/templates/network_tweaks.sh.template
@@ -3,12 +3,14 @@
 #iptables -t nat -A FORWARD -p udp --dport 53 -j DNAT -s  192.168.128.0/23 --to localhost:9000
 #iptables -t nat -A FORWARD -p tcp --dport 53 -j DNAT -s  192.168.128.0/23 --to localhost:9000
 
+vpnserver_int=$(route | grep '^default' | grep -o '[^ ]*$')
+
 # Allow traffic initiated from VPN to access LAN
-iptables -I FORWARD -i tun0 -o eth0  -s #VM_SUBNET# -d #VPN_SUBNET# -m conntrack --ctstate NEW -j ACCEPT
+iptables -I FORWARD -i tun0 -o $vpnserver_int  -s #VM_SUBNET# -d #VPN_SUBNET# -m conntrack --ctstate NEW -j ACCEPT
 
 # Allow established traffic to pass back and forth
 iptables -I FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
 # Masquerade
-iptables -t nat -A POSTROUTING -s #VPN_SUBNET#  -d #VM_SUBNET# -o eth0 -j MASQUERADE
+iptables -t nat -A POSTROUTING -s #VPN_SUBNET#  -d #VM_SUBNET# -o $vpnserver_int -j MASQUERADE
 echo 1 > /proc/sys/net/ipv4/ip_forward

--- a/tf_files/aws/modules/vpn_nlb_central_csoc/README.md
+++ b/tf_files/aws/modules/vpn_nlb_central_csoc/README.md
@@ -32,9 +32,9 @@ This launches a NLB with a target group pointing to the VM running  VPN service.
 ```VPN server cluster network at AWS (vpn_server_subnet) - 10.128.5.0/25```
 
 
-## csoc test-vpn
+## csoc dev-vpn
 
-```Hostname (FQDN) - csoctestvpn-planx.pla.net```
+```Hostname (FQDN) - csocdevvpn-planx.pla.net```
 
 ```OpenVPN Network (csoc_vpn_subnet) - 192.168.2.0/24```
 

--- a/tf_files/aws/modules/vpn_nlb_central_csoc/README.md
+++ b/tf_files/aws/modules/vpn_nlb_central_csoc/README.md
@@ -23,7 +23,7 @@ This launches a NLB with a target group pointing to the VM running  VPN service.
 
 ## csoc prod-vpn
 
-```Hostname (FQDN) - csocprodvpn-planx.pla.net```
+```Hostname (FQDN) - csoc-prod-vpn.planx-pla.net```
 
 ```OpenVPN Network (csoc_vpn_subnet) - 192.168.1.0/24```
 
@@ -34,7 +34,7 @@ This launches a NLB with a target group pointing to the VM running  VPN service.
 
 ## csoc dev-vpn
 
-```Hostname (FQDN) - csocdevvpn-planx.pla.net```
+```Hostname (FQDN) - csoc-dev-vpn.planx-pla.net```
 
 ```OpenVPN Network (csoc_vpn_subnet) - 192.168.2.0/24```
 

--- a/tf_files/aws/modules/vpn_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/vpn_nlb_central_csoc/cloud.tf
@@ -309,7 +309,7 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # checkout to the vpn branch for testing purposes
-git checkout fix/vpnnlbflavorint
+# git checkout fix/vpnnlbflavorint
 git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation

--- a/tf_files/aws/modules/vpn_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/vpn_nlb_central_csoc/cloud.tf
@@ -309,7 +309,7 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # checkout to the vpn branch for testing purposes
-git checkout feat/csocvpn_setup
+git checkout fix/vpnnlbflavorint
 git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation


### PR DESCRIPTION
After changing the flavor of the openvpn server  from `t2.medium` to `m5.xlarge` ,  vpn broke.  In the openvpn config files the VM interface were hardcoded, which led to the creation of wrong iptables rules. Generalising the Vm interface fixed the issue.