### PR TITLE
fix/configmap-quoting: allow space in configmap values

### DIFF
--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -45,7 +45,7 @@ g3k_gitops_configmaps() {
       for key2 in $(g3k_config_lookup ".[\"$key\"] | keys[]" "$manifestPath" | grep '^[a-zA-Z]'); do
         value="$(g3k_config_lookup ".[\"$key\"][\"$key2\"]" "$manifestPath")"
         if [[ -n "$value" ]]; then
-          execString+="--from-literal $key2=$value "
+          execString+="--from-literal $key2='$value' "
         fi
       done
       local jsonSection="--from-literal json='$(g3k_config_lookup ".[\"$key\"]" "$manifestPath")'"


### PR DESCRIPTION
Fixes a quoted value in the manifest-to-configmap setup which allows for whitespace (or generally, more sophisticated types) in the manifest, for supporting arrays etc.

Example command executed by `g3k_gitops_configmaps`:
```
g3kubectl create configmap manifest-arranger --from-literal auth_filter_field='gen3_resource_path' --from-literal auth_filter_node_types='[ "subject" ]' --from-literal project_id='dev' --from-literal json='{ "project_id": "dev", "auth_filter_field": "gen3_resource_path", "auth_filter_node_types": [ "subject" ] }'
```
(note how the values now have single-quotes)