### PR TITLE
fix(gen3 logs): no_proxy kibana, statsmin/max

### DIFF
--- a/doc/logs.md
+++ b/doc/logs.md
@@ -23,6 +23,8 @@ The following variables are also available when search `revproxy` service logs:
 * `user=uid:number,email` - ex: `user=uid:5,frickjack@uchicago.edu` - see `gen3 logs user` below
 * `visitor=visitor_id` - corresponding to the `visitor` cookie
 * `session=session_id` - corresponding to the `session` cookie
+* `statusmin=0` - minimum http status, default 0
+* `statusmax=1000` - max http status, default 100
 
 Ex:
 ```
@@ -31,6 +33,13 @@ $ gen3 logs raw page=0-1
 $ gen3 logs raw page=all
 $ gen3 logs raw vpc=devplanetv1 service=fence format=json start=2018/10/01
 $ gen3 logs raw "user=$(gen3 logs user | grep reubenonrye)"
+$ gen3 logs raw statusmin=400
+```
+
+Note: the reverse proxy's logs are json format - which lends itself well
+to post-query processing - ex:
+```
+cat /tmp/bla | (echo '['; while read -r line; do echo "$line" | jq -r .; echo ','; done; echo '{}]') | jq -r '. | map(select(.http_status_code > 100))'
 ```
 
 ### `gen3 logs vpc`

--- a/gen3/bin/kube-dev-namespace.sh
+++ b/gen3/bin/kube-dev-namespace.sh
@@ -130,7 +130,7 @@ if ! grep GEN3_HOME /home/${namespace}/.bashrc > /dev/null 2>&1; then
   cat >> /home/${namespace}/.bashrc << EOF
 export http_proxy=http://cloud-proxy.internal.io:3128
 export https_proxy=http://cloud-proxy.internal.io:3128
-export no_proxy='localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com,,kibana.planx-pla.net'
+export no_proxy='localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com,kibana.planx-pla.net'
 
 export KUBECONFIG=~/${vpc_name}/kubeconfig
 export GEN3_HOME=~/cloud-automation

--- a/gen3/bin/kube-dev-namespace.sh
+++ b/gen3/bin/kube-dev-namespace.sh
@@ -15,7 +15,7 @@ gen3_load "gen3/gen3setup"
 if [[ -z "$GEN3_NOPROXY" ]]; then
   export http_proxy=${http_proxy:-'http://cloud-proxy.internal.io:3128'}
   export https_proxy=${https_proxy:-'http://cloud-proxy.internal.io:3128'}
-  export no_proxy=${no_proxy:-'localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com'}
+  export no_proxy=${no_proxy:-'localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com,kibana.planx-pla.net'}
 fi
 
 
@@ -130,7 +130,7 @@ if ! grep GEN3_HOME /home/${namespace}/.bashrc > /dev/null 2>&1; then
   cat >> /home/${namespace}/.bashrc << EOF
 export http_proxy=http://cloud-proxy.internal.io:3128
 export https_proxy=http://cloud-proxy.internal.io:3128
-export no_proxy='localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com'
+export no_proxy='localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com,,kibana.planx-pla.net'
 
 export KUBECONFIG=~/${vpc_name}/kubeconfig
 export GEN3_HOME=~/cloud-automation

--- a/gen3/bin/logs.sh
+++ b/gen3/bin/logs.sh
@@ -100,6 +100,8 @@ gen3_logs_rawlog_query() {
   local userId
   local sessionId
   local visitorId
+  local statusMin
+  local statusMax
 
   vpcName="$(gen3_logs_get_arg vpc "${vpc_name:-"all"}" "$@")"
   userId="$(gen3_logs_get_arg user "" "$@")"
@@ -109,7 +111,9 @@ gen3_logs_rawlog_query() {
   endDate="$(gen3_logs_fix_date "$(gen3_logs_get_arg end "$(gen3_logs_fix_date 'tomorrow 00:00')" "$@")")"
   pageNum="$(gen3_logs_get_arg page 0 "$@")"
   serviceName="$(gen3_logs_get_arg service revproxy "$@")"
-
+  statusMin="$(gen3_logs_get_arg statusmin 0 "$@")"
+  statusMax="$(gen3_logs_get_arg statusmax 1000 "$@")"
+  
   queryFile=$(mktemp -p "$XDG_RUNTIME_DIR" "esLogsQuery.json_XXXXXX")
   fromNum=$(($pageNum * 1000))
   cat - > "$queryFile" <<EOM
@@ -160,10 +164,18 @@ ENESTED
         )
         { 
           "range": {
-            "timestamp" : {
+            "timestamp": {
               "gte": "$startDate",
               "lte": "$endDate",
               "format": "yyyy/MM/dd HH:mm"
+            }
+          }
+        },
+        { 
+          "range": {
+            "message.http_status_code": {
+              "gte": $statusMin,
+              "lte": $statusMax
             }
           }
         }

--- a/gen3/lib/kube-setup-init.sh
+++ b/gen3/lib/kube-setup-init.sh
@@ -13,7 +13,7 @@ gen3_load "gen3/gen3setup"
 if [[ -z "$GEN3_NOPROXY" ]]; then
   export http_proxy=${http_proxy:-'http://cloud-proxy.internal.io:3128'}
   export https_proxy=${https_proxy:-'http://cloud-proxy.internal.io:3128'}
-  export no_proxy=${no_proxy:-'localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com'}
+  export no_proxy=${no_proxy:-'localhost,127.0.0.1,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com,kibana.planx-pla.net'}
 fi
 
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

- add `statsmin` and `statsmax` filters to `gen3 logs` - ex:
```
gen3 logs raw statsmin=400
```

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

* add `kibana.planx-pla.net` to `no_proxy` environment variable