### PR TITLE
fix(cronjobs): use tagged fence image for cronjobs, don't try to pull…

### DIFF
--- a/kube/services/jobs/google-delete-expired-service-account-cronjob-monitored.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-cronjob-monitored.yaml
@@ -43,7 +43,7 @@ spec:
               emptyDir: {}
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
                 name: config-helper
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-delete-expired-service-account-job.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-job.yaml
@@ -34,7 +34,7 @@ spec:
             name: config-helper
       containers:
       - name: fence
-        image: quay.io/cdis/fence:master
+        GEN3_FENCE_IMAGE
         imagePullPolicy: Always
         env:
           - name: PYTHONPATH

--- a/kube/services/jobs/google-init-proxy-groups-cronjob-monitored.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-cronjob-monitored.yaml
@@ -46,7 +46,7 @@ spec:
               emptyDir: {}
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
@@ -44,7 +44,7 @@ spec:
                 name: config-helper
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-init-proxy-groups-job.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-job.yaml
@@ -37,7 +37,7 @@ spec:
             name: config-helper
       containers:
       - name: fence
-        image: quay.io/cdis/fence:master
+        GEN3_FENCE_IMAGE
         imagePullPolicy: Always
         env:
           - name: PYTHONPATH

--- a/kube/services/jobs/google-manage-account-access-cronjob-monitored.yaml
+++ b/kube/services/jobs/google-manage-account-access-cronjob-monitored.yaml
@@ -43,7 +43,7 @@ spec:
               emptyDir: {}
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-manage-account-access-cronjob.yaml
+++ b/kube/services/jobs/google-manage-account-access-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
                 name: config-helper
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-manage-account-access-job.yaml
+++ b/kube/services/jobs/google-manage-account-access-job.yaml
@@ -34,7 +34,7 @@ spec:
             name: config-helper
       containers:
       - name: fence
-        image: quay.io/cdis/fence:master
+        GEN3_FENCE_IMAGE
         imagePullPolicy: Always
         env:
           - name: PYTHONPATH

--- a/kube/services/jobs/google-manage-keys-cronjob-monitored.yaml
+++ b/kube/services/jobs/google-manage-keys-cronjob-monitored.yaml
@@ -8,7 +8,7 @@ spec:
   schedule: "@hourly"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
-  jobTemplate: 
+  jobTemplate:
     spec:
       # not yet supported - backOffLimit: 3
       template:
@@ -43,7 +43,7 @@ spec:
               emptyDir: {}
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-manage-keys-cronjob.yaml
+++ b/kube/services/jobs/google-manage-keys-cronjob.yaml
@@ -8,7 +8,7 @@ spec:
   schedule: "@hourly"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
-  jobTemplate: 
+  jobTemplate:
     spec:
       # not yet supported - backOffLimit: 3
       template:
@@ -41,7 +41,7 @@ spec:
                 name: config-helper
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-manage-keys-job.yaml
+++ b/kube/services/jobs/google-manage-keys-job.yaml
@@ -34,7 +34,7 @@ spec:
             name: config-helper
       containers:
       - name: fence
-        image: quay.io/cdis/fence:master
+        GEN3_FENCE_IMAGE
         imagePullPolicy: Always
         env:
           - name: PYTHONPATH

--- a/kube/services/jobs/google-verify-bucket-access-group-cronjob-monitored.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-cronjob-monitored.yaml
@@ -43,7 +43,7 @@ spec:
               emptyDir: {}
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
@@ -41,7 +41,7 @@ spec:
                 name: config-helper
           containers:
           - name: fence
-            image: quay.io/cdis/fence:master
+            GEN3_FENCE_IMAGE
             imagePullPolicy: Always
             env:
               - name: PYTHONPATH

--- a/kube/services/jobs/google-verify-bucket-access-group-job.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-job.yaml
@@ -34,7 +34,7 @@ spec:
             name: config-helper
       containers:
       - name: fence
-        image: quay.io/cdis/fence:master
+        GEN3_FENCE_IMAGE
         imagePullPolicy: Always
         env:
           - name: PYTHONPATH


### PR DESCRIPTION
use tagged fence image for cronjobs, don't try to pull master

### New Features


### Breaking Changes


### Bug Fixes
- use tagged fence image for cronjobs, don't try to pull master


### Improvements


### Dependency updates


### Deployment changes

