### PR TITLE
fix(gen3 gitops dotag): forgot to git pull

### DIFF
--- a/gen3/bin/g3k_testsuite.sh
+++ b/gen3/bin/g3k_testsuite.sh
@@ -1,6 +1,10 @@
 #
 # Run with: bash g3k_testsuite.sh
-# Assume we're running in the directory for now ...
+#
+# NOTE: The tests in this testsuite.sh require a particular test environment
+# that can run terraform and interact with kubernetes.
+# The tests in g3k_testsuite.sh should run anywhere.
+#
 #
 source "$GEN3_HOME/gen3/lib/utils.sh"
 
@@ -8,6 +12,28 @@ export GEN3_MANIFEST_HOME="${GEN3_HOME}/gen3/lib/testData"
 
 gen3_load "gen3/lib/shunit"
 gen3_load "gen3/gen3setup"
+
+test_semver() {
+  semver_ge "1.1.1" "1.1.0"; because $? "1.1.1 -ge 1.1.0"
+  ! semver_ge "1.1.0" "1.1.1"; because $? "! 1.1.0 -ge 1.1.1"
+  semver_ge "2.0.0" "1.10.22"; because $? "2.0.0 -ge 1.10.22"
+}
+
+test_colors() {
+  expected="red red red"
+  redTest=$(red_color "$expected")
+  
+  echo -e "red test: $redTest"
+  # test does not work in zsh
+  [[  -z "${BASH_VERSION}" || "$redTest" ==  "${RED_COLOR}${expected}${DEFAULT_COLOR}" ]]; because $? "Calling red_color returns red-escaped string: $redTest ?= $expected";
+
+  expected="green green green"
+  greenTest=$(red_color "$expected")
+  echo -e "green test: $greenTest"
+  echo "green test: $greenTest"
+  # test does not work in zsh
+  [[ -z "${BASH_VERSION}" || "$greenTest" == "$RED_COLOR${expected}$DEFAULT_COLOR" ]]; because $? "Calling green_color returns green-escaped string: $greenTest ?= $expected";
+}
 
 test_env() {
   [[ ! -z $GEN3_HOME ]]; because $? "kubes.sh defines the GEN3_HOME environment variable"
@@ -167,6 +193,8 @@ test_gitops_logs() {
   gen3 logs vpc | grep -E '^devplanetv1 '; because $? "gen3 logs vpc should include the devplanetv1 vpc environment/log group"
 }
 
+shunit_runtest "test_semver"
+shunit_runtest "test_colors"
 shunit_runtest "test_env"
 shunit_runtest "test_mpath"
 shunit_runtest "test_mfilter"

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -246,6 +246,10 @@ gen3_gitops_repo_dotag() {
     echo -e "$(red_color "ERROR: invalid repo name: $repoName")" 1>&2
     return 1
   fi
+  if [[ ! -d "$cacheDir" ]]; then
+    echo -e "$(red_color "ERROR: $cacheDir does not exist")"
+    return 1
+  fi
   # taglist guarantees tags of form #.#.#(-...)?
   nextVer="$(gen3 gitops taglist | grep "$repoName" | awk '{ print $2 }')"
   if [[ -z "$nextVer" ]]; then
@@ -259,6 +263,10 @@ gen3_gitops_repo_dotag() {
   fi
   (
     cd "$cacheDir"
+    if ! git pull --prune; then
+      echo -e "$(red_color "ERROR: failed to pull latest code from github")"
+      return 1
+    fi
     echo "New tag: $nextVer" 1>&2
     sleep 5   # give the user a couple seconds to see the current tag list, etc
     git tag -d "$nextVer" > /dev/null 2>&1 || true

--- a/gen3/bin/testsuite.sh
+++ b/gen3/bin/testsuite.sh
@@ -1,5 +1,11 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 
+#
+# NOTE: The tests in this file require a particular test environment
+# that can run terraform and interact with kubernetes.
+# The tests in g3k_testsuite.sh should run anywhere.
+#
+
 help() {
   cat - <<EOM
   gen3 testsuite [--profile profilename]:
@@ -128,27 +134,6 @@ test_ls() {
   gen3 ls | grep -e "${TEST_PROFILE} \s*${TEST_WORKSPACE}"; because $? "gen3 ls should include test workspace in result: $TEST_PROFILE $TEST_WORKSPACE"
 }
 
-test_semver() {
-  semver_ge "1.1.1" "1.1.0"; because $? "1.1.1 -ge 1.1.0"
-  ! semver_ge "1.1.0" "1.1.1"; because $? "! 1.1.0 -ge 1.1.1"
-  semver_ge "2.0.0" "1.10.22"; because $? "2.0.0 -ge 1.10.22"
-}
-
-test_colors() {
-  expected="red red red"
-  redTest=$(red_color "$expected")
-  
-  echo -e "red test: $redTest"
-  # test does not work in zsh
-  [[  -z "${BASH_VERSION}" || "$redTest" ==  "${RED_COLOR}${expected}${DEFAULT_COLOR}" ]]; because $? "Calling red_color returns red-escaped string: $redTest ?= $expected";
-
-  expected="green green green"
-  greenTest=$(red_color "$expected")
-  echo -e "green test: $greenTest"
-  echo "green test: $greenTest"
-  # test does not work in zsh
-  [[ -z "${BASH_VERSION}" || "$greenTest" == "$RED_COLOR${expected}$DEFAULT_COLOR" ]]; because $? "Calling green_color returns green-escaped string: $greenTest ?= $expected";
-}
 
 test_refresh() {
   gen3 --dryrun refresh; because $? "--dryrun refresh should be harmless in test workspace"
@@ -180,10 +165,17 @@ test_tfoutput() {
 }
 
 test_kube_lock() {
+  # Setup - acquire test runner lock - running concurrent tests in the same env won't work
+  if ! gen3 klock lock testrunner testuser 240 -w 240; then
+    because $? "Failed to acquire testrunner lock"
+    return 1
+  fi
+
   gen3 klock lock | grep -e "gen3 klock lock lock-name owner max-age [--wait wait-time]"; because $? "calling klock lock without arguments should show the help documentation"
   gen3 klock lock testlock testuser not-a-number | grep -e "ERROR: max-age is not-a-number, must be an integer"; because $? "calling klock lock without a number for max-age should show this error message"
   gen3 klock lock testlock testuser 60 -w not-a-number | grep -e "ERROR: wait-time is not-a-number, must be an integer"; because $? "calling klock lock without a number for wait-time should show this error message"
-  g3kubectl delete configmap locks
+  # Do not do this - it break any klock's active in the test environment! :-(
+  #g3kubectl delete configmap locks
   gen3 klock lock testlock testuser 60; because $? "calling klock lock for the first time for a lock should successfully lock it, and it should create the configmap locks if it does not exist already"
   gen3 klock lock testlock testuser 60; because !$? "calling klock lock for the second time in a row for a lock should fail to lock it"
   gen3 klock lock testlock2 testuser 60; because $? "klock lock should be able to handle multiple locks"
@@ -196,23 +188,42 @@ test_kube_lock() {
   gen3 klock lock testlock5 testuser2 10 -w 2; because !$? "wait is too short, so klock lock should fail to acquire lock"
   gen3 klock lock testlock6 testuser 10
   gen3 klock lock testlock6 testuser2 10 -w 20; because $? "wait is longer than expiry time on the first user, so klock lock should succeed to acquire lock"
-  g3kubectl delete configmap locks
+  
+  # cleanup
+  for lock in testlock testlock2 testlock3 testlock4 testlock5 testlock6; do
+    for user in testuser testuser2; do
+      gen3 klock unlock $lock $user
+    done
+  done
+
+  gen3 klock unlock testrunner testuser
+
+  # Do not do this - it break any klock's active in the test environment! :-(
+  #g3kubectl delete configmap locks
 }
 
 test_kube_unlock() {
+  # Setup - acquire test runner lock - running concurrent tests in the same env won't work
+  if ! gen3 klock lock testrunner testuser 240 -w 240; then
+    because $? "Failed to acquire testrunner lock"
+    return 1
+  fi
+  # Do not do this - it break any klock's active in the test environment! :-(
+  #g3kubectl delete configmap locks
+  
   gen3 klock unlock | grep -e "gen3 klock unlock lock-name owner"; because $? "calling klock unlock without arguments should show the help documentation"
-  g3kubectl delete configmap locks
-  gen3 klock unlock testlock testuser; because !$? "calling klock unlock for the first time without a lock should fail"
   gen3 klock lock testlock testuser 60
   gen3 klock unlock testlock2 testuser; because !$? "calling klock unlock for the first time on a lock that does not exist should fail"
   gen3 klock unlock testlock testuser2; because !$? "calling klock unlock for the first time on a lock the user does not own should fail"
   gen3 klock unlock testlock testuser; because $? "calling klock unlock for the first time on a lock the user owns should succeed"
   gen3 klock unlock testlock testuser; because !$? "calling klock unlock for the second time on a lock the user owns should fail because the lock is already unlocked"
-  g3kubectl delete configmap locks
+  
+  # teardown
+  # Do not do this - it break any klock's active in the test environment! :-(
+  #g3kubectl delete configmap locks
+  gen3 klock unlock testrunner testuser
 }
 
-shunit_runtest "test_semver"
-shunit_runtest "test_colors"
 shunit_runtest "test_workspace"
 shunit_runtest "test_user_workspace"
 shunit_runtest "test_snapshot_workspace"


### PR DESCRIPTION
### New Features

### Breaking Changes


### Bug Fixes

* `gen3 gitops dotag` was not pulling the latest revision from github
* fix issue where the `klock` testsuite could fail if multiple jobs run simultaneously

### Improvements


### Dependency updates


### Deployment changes

