### PR TITLE
Feat/google sa - add google sa validation service

### DIFF
--- a/gen3/bin/kube-setup-cronjobs.sh
+++ b/gen3/bin/kube-setup-cronjobs.sh
@@ -29,6 +29,6 @@ if ! g3kubectl get cronjob google-verify-bucket-access-group > /dev/null 2>&1; t
    g3kubectl create -f "${GEN3_HOME}/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml"
 fi
 
-if ! g3kubectl get cronjob google-manage-user-registrations > /dev/null 2>&1; then
-   g3kubectl create -f "${GEN3_HOME}/kube/services/jobs/google-manage-user-registrations-cronjob.yaml"
-fi
+gen3 roll google-sa-validation
+g3kubectl apply -f "${GEN3_HOME}/kube/services/google-sa-validation/google-sa-validation-service.yaml"
+

--- a/kube/services/google-sa-validation/google-sa-validation-deploy.yaml
+++ b/kube/services/google-sa-validation/google-sa-validation-deploy.yaml
@@ -1,0 +1,118 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: google-sa-validation
+spec:
+  selector:
+    # Only select pods based on the 'app' label
+    matchLabels:
+      app: google-sa-validation
+  revisionHistoryLimit: 2
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: google-sa-validation
+        GEN3_DATE_LABEL
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+        - name: logo-volume
+          configMap:
+            name: "logo-config"
+        - name: config-volume
+          secret:
+            secretName: "fence-secret"
+        - name: creds-volume
+          secret:
+            secretName: "fence-creds"
+        - name: config-helper
+          configMap:
+            name: config-helper
+        - name: json-secret-volume
+          secret:
+            secretName: "fence-json-secret"
+        - name: fence-google-app-creds-secret-volume
+          secret:
+            secretName: "fence-google-app-creds-secret"
+        - name: fence-google-storage-creds-secret-volume
+          secret:
+            secretName: "fence-google-storage-creds-secret"
+        - name: fence-jwt-keys
+          secret:
+            secretName: "fence-jwt-keys"
+        - name: fence-yaml
+          configMap:
+            name: fence
+        - name: cert-volume
+          secret:
+            secretName: "cert-fence-service"
+        - name: ca-volume
+          secret:
+            secretName: "service-ca"
+      containers:
+      - name: fence
+        GEN3_FENCE_IMAGE
+        env:
+        - name: PYTHONPATH
+          value: /var/www/fence
+        - name: GEN3_DEBUG
+          GEN3_DEBUG_FLAG|-value: "False"-|
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 80
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - "/fence/bin/google-user-sa-validation.sh"
+        volumeMounts:
+          - name: "logo-volume"
+            readOnly: true
+            mountPath: "/fence/fence/static/img/logo.svg"
+            subPath: "logo.svg"
+          - name: "config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/local_settings.py"
+            subPath: local_settings.py
+          - name: "creds-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/creds.json"
+            subPath: creds.json
+          - name: "config-helper"
+            readOnly: true
+            mountPath: "/var/www/fence/config_helper.py"
+            subPath: config_helper.py
+          - name: "json-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_credentials.json"
+            subPath: fence_credentials.json
+          - name: "fence-yaml"
+            mountPath: "/var/www/fence/user.yaml"
+            subPath: user.yaml
+          - name: "fence-google-app-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_app_creds_secret.json"
+            subPath: fence_google_app_creds_secret.json
+          - name: "fence-google-storage-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_storage_creds_secret.json"
+            subPath: fence_google_storage_creds_secret.json
+          - name: "cert-volume"
+            readOnly: true
+            mountPath: "/mnt/ssl/service.crt"
+            subPath: "service.crt"
+          - name: "cert-volume"
+            readOnly: true
+            mountPath: "/mnt/ssl/service.key"
+            subPath: "service.key"
+          - name: "ca-volume"
+            # See https://askubuntu.com/questions/645818/how-to-install-certificates-for-command-line
+            readOnly: true
+            mountPath: "/usr/local/share/ca-certificates/cdis/cdis-ca.crt"
+            subPath: "ca.pem"
+          - name: "fence-jwt-keys"
+            readOnly: true
+            mountPath: "/fence/jwt-keys.tar"
+            subPath: "jwt-keys.tar"

--- a/kube/services/google-sa-validation/google-sa-validation-service.yaml
+++ b/kube/services/google-sa-validation/google-sa-validation-service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: google-sa-validation-service
+spec:
+  selector:
+    app: google-sa-validation
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+      name: http

--- a/kube/services/revproxy/gen3.nginx.conf/google-sa-validation-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/google-sa-validation-service.conf
@@ -1,0 +1,6 @@
+          location /google-sa-validation-status/ {
+
+              set $upstream_sa http://google-sa-validation-service.$namespace.svc.cluster.local;
+              rewrite ^/google-sa-validation-status/(.*) /$1 break;
+              proxy_pass $upstream_sa;
+          }


### PR DESCRIPTION
add google sa validation service to replace the previous cronjob

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- add google sa validation service to replace the previous cronjob

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- remove previous cronjob in dcf prod and run `gen3 kube-setup-cronjob` to setup new service, then `gen3 kube-setup-revproxy` to update revproxy with new endpoint
