### PR TITLE
Feat/upload data bucket PXD-2215

### DIFF
--- a/tf_files/aws/commons/outputs.tf
+++ b/tf_files/aws/commons/outputs.tf
@@ -44,6 +44,21 @@ output "gdcapi_rds_id" {
   value = "${aws_db_instance.db_gdcapi.id}"
 }
 
+output "fence-bot_user_secret" {
+  value = "${module.cdis_vpc.fence-bot_secret}"
+#  value = "${module.fence-bot-user.fence-bot_secret}"
+}
+
+output "fence-bot_user_id" {
+#  value = "${module.fence-bot-user.fence-bot_id}"
+  value = "${module.cdis_vpc.fence-bot_id}"
+}
+
+output "data-bucket_name" {
+  value = "${module.cdis_vpc.data-bucket_name}"
+}
+
+
 #-----------------------------
 
 data "template_file" "cluster" {

--- a/tf_files/aws/modules/fence-bot-user/data.tf
+++ b/tf_files/aws/modules/fence-bot-user/data.tf
@@ -1,0 +1,5 @@
+
+## Get the bucket by its name 
+data "aws_s3_bucket" "data-bucket" {
+  bucket = "${var.bucket_name}"
+}

--- a/tf_files/aws/modules/fence-bot-user/iam.tf
+++ b/tf_files/aws/modules/fence-bot-user/iam.tf
@@ -1,0 +1,37 @@
+
+
+# Fence bot
+
+## Fence bot user
+resource "aws_iam_user" "fence-bot" {
+  name = "${var.vpc_name}_fence-bot"
+}
+
+## Fence bot key/secret
+resource "aws_iam_access_key" "fence-bot_user_key" {
+  user = "${aws_iam_user.fence-bot.name}"
+}
+
+## Fence bot access policy
+resource "aws_iam_user_policy" "fence-bot_policy" {
+  name = "${var.vpc_name}_fence-bot_policy"
+  user = "${aws_iam_user.fence-bot.name}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:DeleteObject"
+      ],
+      "Effect": "Allow",
+      "Resource": ["${data.aws_s3_bucket.data-bucket.arn}/*"]
+    }
+  ]
+}
+EOF
+}
+

--- a/tf_files/aws/modules/fence-bot-user/output.tf
+++ b/tf_files/aws/modules/fence-bot-user/output.tf
@@ -1,0 +1,9 @@
+
+output "fence-bot_secret" {
+  value = "${aws_iam_access_key.fence-bot_user_key.secret}"
+}
+
+output "fence-bot_id" {
+  value = "${aws_iam_access_key.fence-bot_user_key.id}"
+}
+

--- a/tf_files/aws/modules/fence-bot-user/variables.tf
+++ b/tf_files/aws/modules/fence-bot-user/variables.tf
@@ -1,0 +1,6 @@
+
+variable "vpc_name" {
+}
+
+variable "bucket_name" {
+}

--- a/tf_files/aws/modules/upload-data-bucket/README.md
+++ b/tf_files/aws/modules/upload-data-bucket/README.md
@@ -1,0 +1,19 @@
+# TL;DR
+
+Terraform module that creates an S3 data bucket:
+ 
+* a single private S3 bucket with encryption enabled
+* a policy that can read from that bucket
+* a policy that can read from and write to that bucket
+* a read role 
+* a read+write role
+* a read instance-profile
+* a read+write instance profile
+* a `cdis-s3-logs` access logs bucket
+
+As of 06/21/2018, buckets created this way must be tied to a common in specific. 
+
+In the config.tfvars, the environment variable should be set to a CloudWatch Log group already existing, otherwise this might error out.
+
+![FlowChart](data-explorer.svg)
+[lucichart link](https://www.lucidchart.com/invitations/accept/04b7cce8-de11-45e1-aaba-b77258276319)

--- a/tf_files/aws/modules/upload-data-bucket/cloud-trail.tf
+++ b/tf_files/aws/modules/upload-data-bucket/cloud-trail.tf
@@ -1,0 +1,32 @@
+
+
+resource "aws_cloudtrail" "logger_trail" {
+  name                          = "${var.vpc_name}-data-bucket-trail"
+  s3_bucket_name                = "${aws_s3_bucket.log_bucket.id}"
+  s3_key_prefix                 = "trail-logs"
+  include_global_service_events = false
+  cloud_watch_logs_role_arn     = "${aws_iam_role.cloudtrail_to_clouodwatch_writer.arn}"
+  #cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.main_log_group.arn}"
+  #cloud_watch_logs_group_arn    = "${var.cloudwatchlogs_group_arn}"
+  #cloud_watch_logs_group_arn    = "${data.aws_cloudwatch_log_group.logs_destination.arn}"
+  cloud_watch_logs_group_arn    = "${var.cloudwatchlogs_group}"
+  #cloud_watch_logs_group_arn    = "fauziv1"
+
+  event_selector {
+    read_write_type = "All"
+    include_management_events = false
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      # Make sure to append a trailing '/' to your ARN if you want
+      # to monitor all objects in a bucket.
+      values = ["${aws_s3_bucket.data_bucket.arn}/"]
+    }
+  }
+  tags {
+    Name        = "${var.vpc_name}_data-bucket"
+    Environment = "${var.environment}"
+    Purpose     = "trail_for_${var.vpc_name}_data_bucket"
+  }
+}
+

--- a/tf_files/aws/modules/upload-data-bucket/iam.tf
+++ b/tf_files/aws/modules/upload-data-bucket/iam.tf
@@ -1,0 +1,180 @@
+
+## Role and Policies for the bucket
+
+resource "aws_iam_role" "data_bucket" {
+  name = "${var.vpc_name}-data-bucket-access"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "ec2.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+
+## Policies data 
+
+data "aws_iam_policy_document" "data_bucket_reader" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*"
+    ]
+
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.data_bucket.arn}", "${aws_s3_bucket.data_bucket.arn}/*"]
+  }
+}
+
+data "aws_iam_policy_document" "data_bucket_writer" {
+  statement {
+    actions = [
+      "s3:PutObject"
+    ]
+
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.data_bucket.arn}", "${aws_s3_bucket.data_bucket.arn}/*"]
+  }
+}
+
+
+
+## Polcies
+
+resource "aws_iam_policy" "data_bucket_reader" {
+  name        = "data_bucket_read_${var.vpc_name}"
+  description = "Data Bucket access for ${var.vpc_name}"
+  policy      = "${data.aws_iam_policy_document.data_bucket_reader.json}"
+}
+
+resource "aws_iam_policy" "data_bucket_writer" {
+  name        = "data_bucket_write_${var.vpc_name}"
+  description = "Data Bucket access for ${var.vpc_name}"
+  policy      = "${data.aws_iam_policy_document.data_bucket_reader.json}"
+}
+
+
+
+## Policies attached to roles
+
+resource "aws_iam_role_policy_attachment" "data_bucket_reader" {
+  role       = "${aws_iam_role.data_bucket.name}"
+  policy_arn = "${aws_iam_policy.data_bucket_reader.arn}"
+}
+
+resource "aws_iam_role_policy_attachment" "data_bucket_writer" {
+  role       = "${aws_iam_role.data_bucket.name}"
+  policy_arn = "${aws_iam_policy.data_bucket_writer.arn}"
+}
+
+
+
+
+
+## Role and policies for the log bucket
+
+data "aws_iam_policy_document" "log_bucket_writer" {
+  statement {
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+    ]
+
+    effect    = "Allow"
+    resources = ["${aws_s3_bucket.log_bucket.arn}", "${aws_s3_bucket.log_bucket.arn}/*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = ["${aws_s3_bucket.log_bucket.arn}/*"]
+  }
+
+}
+
+resource "aws_iam_policy" "log_bucket_writer" {
+  name        = "bucket_writer_${aws_s3_bucket.log_bucket.id}"
+  description = "Read or write ${aws_s3_bucket.log_bucket.id}"
+  policy      = "${data.aws_iam_policy_document.log_bucket_writer.json}"
+}
+
+
+
+
+
+## Fence bot user
+#resource "aws_iam_user" "fence-bot" {
+#  name = "${var.vpc_name}_fence-bot"
+#}
+
+#resource "aws_iam_access_key" "fence-bot_user_key" {
+#  user = "${aws_iam_user.fence-bot.name}"
+#}
+
+
+
+## CloudwatchLog access
+
+resource "aws_iam_role" "cloudtrail_to_clouodwatch_writer" {
+  name = "${var.vpc_name}_data-bucket_ct_to_cwl_writer"
+  path = "/"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+               "Service": "cloudtrail.amazonaws.com"
+            },
+            "Effect": "Allow",
+            "Sid": ""
+        }
+    ]
+}
+EOF
+}
+
+data "aws_iam_policy_document" "trail_policy" {
+  statement {
+    effect    = "Allow"
+
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    #resources = ["${data.aws_cloudwatch_log_group.logs_destination.arn}"]
+    resources = ["${var.cloudwatchlogs_group}"]
+  }
+
+}
+
+resource "aws_iam_policy" "trail_writer" {
+  name        = "trail_write_to_cwl_${var.environment}"
+  description = "Put logs in CWL ${var.environment}"
+  policy      = "${data.aws_iam_policy_document.trail_policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "trail_writer_role" {
+  role       = "${aws_iam_role.cloudtrail_to_clouodwatch_writer.name}"
+  policy_arn = "${aws_iam_policy.trail_writer.arn}"
+}

--- a/tf_files/aws/modules/upload-data-bucket/outputs.tf
+++ b/tf_files/aws/modules/upload-data-bucket/outputs.tf
@@ -1,0 +1,8 @@
+output "data-bucket_name" {
+  value = "${aws_s3_bucket.data_bucket.id}"
+}
+
+output "log_bucket_name" {
+  value = "${aws_s3_bucket.log_bucket.id}"
+}
+

--- a/tf_files/aws/modules/upload-data-bucket/s3.tf
+++ b/tf_files/aws/modules/upload-data-bucket/s3.tf
@@ -1,0 +1,107 @@
+
+## The actual data bucket
+
+resource "aws_s3_bucket" "data_bucket" {
+  bucket = "${var.vpc_name}-data-bucket"
+  acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  logging {
+    target_bucket = "${aws_s3_bucket.log_bucket.id}"
+    target_prefix = "log/${var.vpc_name}-data-bucket"
+  }
+
+  tags {
+    Name        = "${var.vpc_name}-data-bucket"
+    Environment = "${var.environment}"
+    Purpose     = "data bucket"
+  }
+}
+
+
+
+## Log bucket, where access to the avobe bucket will be logged 
+
+
+resource "aws_s3_bucket" "log_bucket" {
+  bucket = "${var.vpc_name}-data-bucket-logs"
+  acl    = "bucket-owner-full-control" #log-delivery-write
+  acl    = "log-delivery-write"
+
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  lifecycle_rule {
+    id      = "log"
+    enabled = true
+
+    prefix = "/"
+
+    tags {
+      "rule"      = "log"
+      "autoclean" = "true"
+    }
+
+    expiration {
+      days = 120
+    }
+  }
+
+  tags {
+    Name        = "${var.vpc_name}"
+    Environment = "${var.environment}"
+    Purpose     = "logs bucket"
+  }
+}
+
+
+
+
+## We want could trail to put additional logs in this log bucket 
+resource "aws_s3_bucket_policy" "log_bucket_writer_by_ct" {
+  bucket = "${aws_s3_bucket.log_bucket.id}"
+  policy =<<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AWSCloudTrailAclCheck20150319",
+      "Effect": "Allow",
+      "Principal": {
+         "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "s3:GetBucketAcl",
+      "Resource": "${aws_s3_bucket.log_bucket.arn}"
+    },
+
+    {
+      "Sid": "AWSCloudTrailWrite20150319",
+     "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudtrail.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "${aws_s3_bucket.log_bucket.arn}/*",
+      "Condition": {
+         "StringEquals": {
+         "s3:x-amz-acl": "bucket-owner-full-control"
+         }
+      }
+    }
+  ]
+}
+POLICY
+}

--- a/tf_files/aws/modules/upload-data-bucket/variables.tf
+++ b/tf_files/aws/modules/upload-data-bucket/variables.tf
@@ -1,0 +1,16 @@
+
+variable "vpc_name" {
+  # default "something"
+}
+
+variable "environment" {
+  # value for 'Environment' key to tag the new resources with
+}
+
+#variable "cloudwatchlogs_group_arn" {
+#  value "something"
+#}
+
+variable "cloudwatchlogs_group" {
+  #value 
+}

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -33,6 +33,10 @@ resource "aws_vpc" "main" {
     Environment  = "${var.vpc_name}"
     Organization = "Basic Service"
   }
+
+  lifecycle {
+    ignore_changes = ["tags"]
+  }
 }
 
 data "aws_vpc_endpoint_service" "s3" {

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -10,6 +10,20 @@ module "squid_proxy" {
   env_log_group        = "${aws_cloudwatch_log_group.main_log_group.name}"
 }
 
+module "data-bucket" {
+  source               = "../upload-data-bucket"
+  vpc_name             = "${var.vpc_name}"
+#  cloudwatchlogs_group = "${module.cdis_vpc.cwlogs}"
+  cloudwatchlogs_group = "${aws_cloudwatch_log_group.main_log_group.arn}"
+  environment          = "${var.vpc_name}"
+}
+
+module "fence-bot-user" {
+  source               = "../fence-bot-user"
+  vpc_name             = "${var.vpc_name}"
+  bucket_name          = "${module.data-bucket.data-bucket_name}"
+}
+
 resource "aws_vpc" "main" {
   cidr_block           = "172.${var.vpc_octet2}.${var.vpc_octet3}.0/20"
   enable_dns_hostnames = true

--- a/tf_files/aws/modules/vpc/outputs.tf
+++ b/tf_files/aws/modules/vpc/outputs.tf
@@ -72,3 +72,19 @@ output "es_user_key" {
 output "es_user_key_id" {
   value = "${aws_iam_access_key.es_user_key.id}"
 }
+
+output "cwlogs" {
+  value = "${aws_cloudwatch_log_group.main_log_group.arn}"
+}
+
+output "fence-bot_id" {
+  value = "${module.fence-bot-user.fence-bot_id}"
+}
+
+output "fence-bot_secret" {
+  value = "${module.fence-bot-user.fence-bot_secret}"
+}
+
+output "data-bucket_name" {
+  value = "${module.data-bucket.data-bucket_name}"
+}


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- New databucket creation (<vpc_name>-data-bucket) when the commons resources are initially spun up, right before deploying the kubernetes cluster (EKS). Also a new fence-bot (<vpc_name>-fence-bot) user is created, i can be used or just ignored if there is already an active user. 

Additionally, actions against the databucket are stored in another bucket (<vpc_name>-data-bucket-logs) and in cloudwatch, which would also send them over to CSOC through the kinesis stream.


### Breaking Changes
N/A

### Bug Fixes
N/A

### Improvements
No manually created users for databucket should be done from now on

### Dependency updates


### Deployment changes

