### PR TITLE
add(ifconfig.io): to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -51,6 +51,7 @@ git.bionimbus.org
 git.io
 http.us.debian.org
 internet2.edu
+ifconfig.io
 keyservice.opensciencedatacloud.org
 ks.osdc.io
 lib.stat.cmu.edu


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- ifconfig.io is now whitelisted, easy to check which public IP you are using to go out to the Interntet.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

