### PR TITLE
fix(logs): default LOGHOST to https://kibana...

### DIFF
--- a/gen3/bin/logs.sh
+++ b/gen3/bin/logs.sh
@@ -6,7 +6,7 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/gen3setup"
 
-LOGHOST="${LOGHOST:-kibana.planx-pla.net}"
+LOGHOST="${LOGHOST:-https://kibana.planx-pla.net}"
 LOGUSER="${LOGUSER:-kibanaadmin}"
 LOGPASSWORD="${LOGPASSWORD:-""}"
 


### PR DESCRIPTION
### New Features

### Breaking Changes


### Bug Fixes
- default `gen3 logs` host changed to new https endpoint

### Improvements


### Dependency updates


### Deployment changes

