### PR TITLE
chore(squidnlb): enabling csoc squid for commons

### DIFF
--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -195,10 +195,10 @@ resource "aws_vpc_endpoint" "squid-nlb" {
 }
 
 
-#resource "aws_route53_record" "squid-nlb" {
- # zone_id = "${module.cdis_vpc.zone_id}"
-  #name    = "cloud-proxy.${module.cdis_vpc.zone_name}"
-  #type    = "CNAME"
-  #ttl     = "300"
-  #records = ["${lookup(aws_vpc_endpoint.squid-nlb.dns_entry[0], "dns_name")}"]
-#}
+resource "aws_route53_record" "squid-nlb" {
+  zone_id = "${module.cdis_vpc.zone_id}"
+  name    = "csoc-cloud-proxy.${module.cdis_vpc.zone_name}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["${lookup(aws_vpc_endpoint.squid-nlb.dns_entry[0], "dns_name")}"]
+}


### PR DESCRIPTION
This basically creates a DNS entry for csoc-cloud-proxy.internal.io to point to the endpoint in the VPC which is pointing to the endpoint service in CSOC (corresponding to the squid NLB set-up).


### New Features
Commons VPC will be able to use the squid NLB set-up in the CSOC.

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes




