### PR TITLE
Chore/utility vm

### DIFF
--- a/tf_files/aws/modules/utility-vm/README.md
+++ b/tf_files/aws/modules/utility-vm/README.md
@@ -71,4 +71,6 @@ This variables are not initialized but you can change them if needed.
 * ssh_key_name: this one will most likely be overwriten, but in case something goes wrong with the execution script, you might still be able to access the VM.
 * environment: for tagging purposes.
 * instance_type: t2.micro, t2.medium, etc.
+* proxy: if a literal "yes" is provide, proxy configuration will be added. Default set to yes.
+* authorized_keys: path to file containing ssh keys that will be copied to `/home/ubuntu/.ssh/authorized_keys`. Default is set to `files/authorized_keys/ops_team` (relative to the cloud-automation folder).
 

--- a/tf_files/aws/modules/utility-vm/cloud.tf
+++ b/tf_files/aws/modules/utility-vm/cloud.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_log_group" "csoc_log_group" {
+resource "aws_cloudwatch_log_group" "vm_log_group" {
   name              = "${var.vm_hostname}"
   retention_in_days = 1827
 
@@ -51,7 +51,8 @@ resource "aws_ami_copy" "cdis_ami" {
   }
 }
 
-# Security group to access peered networks from the csoc admin VM
+
+# Allo SSH Access 
 
 resource "aws_security_group" "ssh" {
   name        = "ssh_${var.vm_name}"
@@ -71,6 +72,9 @@ resource "aws_security_group" "ssh" {
     name         = "ssh_${var.vm_name}"
   }
 }
+
+
+# Security group for local traffic
 
 resource "aws_security_group" "local" {
   name        = "local_${var.vm_name}"
@@ -142,15 +146,6 @@ data "aws_iam_policy_document" "vm_policy_document" {
     effect    = "Allow"
     resources = ["*"]
   }
-
-  statement {
-    # see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_permissions-to-switch.html
-    actions = ["sts:AssumeRole"]
-
-    effect    = "Allow"
-    resources = ["arn:aws:iam::${var.aws_account_id}:role/csoc_adminvm"]
-  }
-
 }
 
 resource "aws_iam_role_policy" "vm_policy" {
@@ -162,6 +157,21 @@ resource "aws_iam_role_policy" "vm_policy" {
 resource "aws_iam_instance_profile" "vm_role_profile" {
   name = "${var.vm_name}_role_profile"
   role = "${aws_iam_role.vm_role.id}"
+}
+
+locals {
+
+  proxy_config_environment = <<EOF
+http_proxy=http://cloud-proxy.internal.io:3128
+https_proxy=http://cloud-proxy.internal.io:3128
+no_proxy="localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com" 
+EOF
+
+  proxy_config_apt = <<EOF
+Acquire::http::Proxy "http://cloud-proxy.internal.io:3128";
+Acquire::https::Proxy "http://cloud-proxy.internal.io:3128";
+EOF
+
 }
 
 resource "aws_instance" "utility_vm" {
@@ -183,26 +193,33 @@ resource "aws_instance" "utility_vm" {
     ignore_changes = ["ami", "key_name"]
   }
 
+  provisioner "file" {
+    content     = "${var.proxy == yes ? local.proxy_config_environment : ''}"
+    destination = "/etc/environment"
+  }
+
+  provisioner "file" {
+    content     = "${var.proxy == yes ? local.proxy_config_apt : ''}"
+    destination = "/etc/apt/apt.conf.d/01proxy"
+  }
+
   user_data = <<EOF
 #!/bin/bash 
 
 #Proxy configuration and hostname assigment for the adminVM
-echo http_proxy=http://cloud-proxy.internal.io:3128 >> /etc/environment
-echo https_proxy=http://cloud-proxy.internal.io:3128/ >> /etc/environment
-echo no_proxy="localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com"  >> /etc/environment
-echo 'Acquire::http::Proxy "http://cloud-proxy.internal.io:3128";' >> /etc/apt/apt.conf.d/01proxy
-echo 'Acquire::https::Proxy "http://cloud-proxy.internal.io:3128";' >> /etc/apt/apt.conf.d/01proxy
+#echo http_proxy=http://cloud-proxy.internal.io:3128 >> /etc/environment
+#echo https_proxy=http://cloud-proxy.internal.io:3128/ >> /etc/environment
+#echo no_proxy="localhost,127.0.0.1,localaddress,169.254.169.254,.internal.io,logs.us-east-1.amazonaws.com"  >> /etc/environment
+#echo 'Acquire::http::Proxy "http://cloud-proxy.internal.io:3128";' >> /etc/apt/apt.conf.d/01proxy
+#echo 'Acquire::https::Proxy "http://cloud-proxy.internal.io:3128";' >> /etc/apt/apt.conf.d/01proxy
 
 cd /home/ubuntu
 sudo git clone https://github.com/uc-cdis/cloud-automation.git
 sudo chown -R ubuntu. cloud-automation
 
-#cd cloud-automation
-#git checkout feat/csoc-utility-vm
-#cd /home/ubuntu
-
 #sudo mkdir -p /root/.ssh/
-sudo cat cloud-automation/files/authorized_keys/ops_team | sudo tee --append /home/ubuntu/.ssh/authorized_keys
+#sudo cat cloud-automation/files/authorized_keys/ops_team | sudo tee --append /home/ubuntu/.ssh/authorized_keys
+sudo cat cloud-automation/${var.authorized_keys} | sudo tee --append /home/ubuntu/.ssh/authorized_keys
 
 
 echo '127.0.1.1 ${var.vm_hostname}' | sudo tee --append /etc/hosts

--- a/tf_files/aws/modules/utility-vm/variables.tf
+++ b/tf_files/aws/modules/utility-vm/variables.tf
@@ -63,3 +63,10 @@ variable "vm_hostname" {
   #default = "csoc_nginx_server"
 }
 
+variable "proxy" {
+  default = "yes"
+}
+
+variable "authorized_keys" {
+  default = "files/authorized_keys/ops_team"
+}

--- a/tf_files/aws/utility_vm/root.tf
+++ b/tf_files/aws/utility_vm/root.tf
@@ -22,6 +22,8 @@ module "utility_vm" {
   vm_hostname      = "${var.vm_hostname}"
   image_name_search_criteria = "${var.image_name_search_criteria}"
   extra_vars       = "${var.extra_vars}"
+  proxy            = "${var.proxy}"
+  authorized_keys  = "${var.authorized_keys}"
   
 
   # put other variables here ...

--- a/tf_files/aws/utility_vm/variables.tf
+++ b/tf_files/aws/utility_vm/variables.tf
@@ -63,3 +63,10 @@ variable "vm_hostname" {
   #default = "csoc_nginx_server"
 }
 
+variable "proxy" {
+  default = "yes"
+}
+
+variable "authorized_keys" {
+  default = "files/authorized_keys/ops_team"
+}


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- The utilityVM module is now more generic, meaning that it should be suitable to deploy in any account, not only in our CSOC account. 

### Breaking Changes
- No breaks were found during testing. However it might require the final instance re-deployed. If so, most likely adding a lifecycle to ignore user-data changes would overpass the destroying of the resouce

### Bug Fixes


### Improvements
- We could use this module to deploy a VM in a remote account and use it as adminVM.

### Dependency updates


### Deployment changes

