### PR TITLE
fix(aws-es-proxy): pin image to version 0.8

### DIFF
--- a/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
@@ -25,7 +25,7 @@ spec:
             secretName: "aws-es-proxy"
       containers:
       - name: esproxy
-        image: abutaha/aws-es-proxy
+        image: abutaha/aws-es-proxy:0.8
         imagePullPolicy: Always
         ports:
         - containerPort: 9200


### PR DESCRIPTION
fix(aws-es-proxy): pin image to version 0.8

### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

