### PR TITLE
fix(db-names): add quotes around db name to escape the -'s

### DIFF
--- a/gen3/bin/reset.sh
+++ b/gen3/bin/reset.sh
@@ -49,7 +49,7 @@ for serviceCred in ${serviceCreds[@]}; do
         gen3 klock unlock reset-lock gen3-reset
         exit 1
     fi
-    echo "\c template1 \\\ DROP DATABASE $KUBECTL_NAMESPACE; CREATE DATABASE $KUBECTL_NAMESPACE;" | gen3 psql $service
+    echo "\c template1 \\\ DROP DATABASE \"$KUBECTL_NAMESPACE\"; CREATE DATABASE \"$KUBECTL_NAMESPACE\";" | gen3 psql $service
 done
 
 gen3 roll all


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes
- escape -'s in db names for reset.sh script used in integration tests

### Improvements


### Dependency updates


### Deployment changes

