### PR TITLE
fix(allocations): for the fluentd daemonset PXP-1040

### DIFF
--- a/kube/services/fluentd/fluentd.yaml
+++ b/kube/services/fluentd/fluentd.yaml
@@ -37,10 +37,10 @@ spec:
             value: "gen3.conf"
         resources:
           limits:
-            memory: 200Mi
+            memory: 1Gi
           requests:
             cpu: 100m
-            memory: 200Mi
+            memory: 1Gi
         volumeMounts:
         - name: fluentd-gen3
           mountPath: /fluentd/etc/gen3.conf

--- a/tf_files/aws/modules/common-logging/logging.tf
+++ b/tf_files/aws/modules/common-logging/logging.tf
@@ -361,6 +361,10 @@ resource "aws_lambda_function" "logs_decodeding" {
       stream_name = "${var.common_name}_firehose"
     }
   }
+
+  lifecycle {
+    ignore_changes = ["memory_size"]
+  }
 }
 
 ############################ End Lambda function  ############################


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

### Breaking Changes


### Bug Fixes

-  Fluentd allocations were too low crashing the pods while sending logs to Cloudwatch

### Improvements


### Dependency updates


### Deployment changes

