### PR TITLE
removing trailing '/' for cleanup

### DIFF
--- a/kube/services/jobs/etl-job.yaml
+++ b/kube/services/jobs/etl-job.yaml
@@ -50,7 +50,7 @@ spec:
         args:
           - "-c"
           - |
-            hdfs dfs -rm /result/*/**/
+            hdfs dfs -rm /result/*/**
             python run_config.py
             python run_import.py
             python run_spark.py


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes
etl-job.yaml had a trailing '/' in the job for hdfs cleanup removing it so the job runs correctly

### Improvements


### Dependency updates


### Deployment changes

