### PR TITLE
refactor(reset): move delete configmap above roll

### DIFF
--- a/gen3/bin/reset.sh
+++ b/gen3/bin/reset.sh
@@ -54,13 +54,15 @@ for serviceCred in ${serviceCreds[@]}; do
     echo "\c template1 \\\ DROP DATABASE \"${dbName}\"; CREATE DATABASE \"${dbName}\";" | gen3 psql $service
 done
 
-gen3 roll all
-gen3 kube-wait4-pods || true
 # integration tests may muck with user.yaml in fence configmap, so re-sync from S3
 # first clear the configmap, so the usersync job sees a diff between S3 and local user.yaml
 g3kubectl delete configmap fence
 g3kubectl create configmap fence '--from-literal=user.yaml=frickjack:reuben'
 gen3 job run usersync
+
+gen3 roll all
+gen3 kube-wait4-pods || true
+
 # job runs asynchronously ...
 gen3 job run gdcdb-create
 # also go ahead and setup the indexd auth secrets


### PR DESCRIPTION
Moved delete and create fence configmap above roll all.

### Bug Fixes
Fixes bug in Jenkins where killing a build waiting for pods to roll, and build was stopped, the command for deleting the fence configmap was still executed, causing problems for pods to roll in the next build in the same namespace.