### PR TITLE
feat(etl): running etl job 1 command

### DIFF
--- a/kube/services/jobs/etl-cronjob.yaml
+++ b/kube/services/jobs/etl-cronjob.yaml
@@ -69,10 +69,7 @@ spec:
               args:
                 - "-c"
                 - |
-                  hdfs dfs -rm /result/*/**
-                  python run_config.py
-                  python run_import.py
-                  python run_spark.py
+                  python run_config.py && python run_etl.py
                   exitcode=$?
                   if [[ $exitcode == 1 && "${slackWebHook}" != 'None' ]]; then
                     curl -X POST --data-urlencode "payload={\"text\": \"JOBFAILED: ETL job on ${gen3Env}\"}" "${slackWebHook}"

--- a/kube/services/jobs/etl-job.yaml
+++ b/kube/services/jobs/etl-job.yaml
@@ -50,7 +50,6 @@ spec:
         args:
           - "-c"
           - |
-            hdfs dfs -rm /result/*/**/
-            python run_config.py && python run_import.py && python run_spark.py
+            python run_config.py && python run_etl.py
             echo "All done - exit status $?"
       restartPolicy: Never


### PR DESCRIPTION
### New Features
- Change to run ETL job in one command with new branch of ETL in master. Use with etl 0.1.9

### Breaking Changes
- cdis-manifest will fail if still use the version smaller than 0.1.9 because `run_etl.py` is not there

### Bug Fixes


### Improvements
- timestamp checking. Only run ETL if there is a new transaction after previous running etl.

### Dependency updates


### Deployment changes

