### PR TITLE
Chore/nodepool improvement 1

### DIFF
--- a/flavors/eks/bootstrap-2.0.0.sh
+++ b/flavors/eks/bootstrap-2.0.0.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -xe
+
+# User data for our EKS worker nodes basic arguments to call the bootstrap script for EKS images 
+# More info https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
+ 
+sudo sysctl fs.inotify.max_user_watches=12000
+
+KUBELET_EXTRA_ARGUMENTS="--node-labels=role=${nodepool}"
+
+if [[ ${nodepool} == jupyter ]];
+then
+    KUBELET_EXTRA_ARGUMENTS="$KUBELET_EXTRA_ARGUMENTS --register-with-taints=role=${nodepool}:NoSchedule"
+fi
+/etc/eks/bootstrap.sh --kubelet-extra-args "$KUBELET_EXTRA_ARGUMENTS" ${vpc_name}
+
+cat > /home/ec2-user/.ssh/authorized_keys <<EFO
+${ssh_keys}
+EFO
+
+sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/authorized_keys

--- a/kube/services/jupyterhub/jupyterhub-deploy.yaml
+++ b/kube/services/jupyterhub/jupyterhub-deploy.yaml
@@ -15,6 +15,8 @@ spec:
         app: jupyter-hub
         GEN3_DATE_LABEL
     spec:
+      nodeSelector:
+        role: jupyter
       tolerations:
       - key: "role"
         operator: "Equal"

--- a/tf_files/aws/commons/kube-up-body.sh
+++ b/tf_files/aws/commons/kube-up-body.sh
@@ -62,11 +62,11 @@ if kubectl get nodes > /dev/null 2>&1; then
   exit 1
 fi
 
-if [[ -f cluster.yaml ]]; then # setup a kube-aws cluster
-  if [[ ! -d ./credentials ]]; then
-    kube-aws render credentials --generate-ca
-  fi
-  kube-aws render || true
+#if [[ -f cluster.yaml ]]; then # setup a kube-aws cluster
+#  if [[ ! -d ./credentials ]]; then
+#    kube-aws render credentials --generate-ca
+#  fi
+#  kube-aws render || true
 
   #
   # When running on the adminvm - we need to assume the role
@@ -83,20 +83,20 @@ if [[ -f cluster.yaml ]]; then # setup a kube-aws cluster
   #
 
   # New kube-aws version doesn't need the s3-uri argument
-  gen3 arun kube-aws validate #--s3-uri "s3://${s3_bucket}/${vpc_name}"
-  gen3 arun kube-aws up #--s3-uri "s3://${s3_bucket}/${vpc_name}"
+  #gen3 arun kube-aws validate #--s3-uri "s3://${s3_bucket}/${vpc_name}"
+  #gen3 arun kube-aws up #--s3-uri "s3://${s3_bucket}/${vpc_name}"
 
-  cat - <<EOM
-The kube-aws cluster is up; now add an entry in route53 for the CSOC account.
-Ask Renuka or Fauzi to add k8s-${vpc_name}.internal.io as CNAME for
-the k8s controller load balancer:
-    aws elb describe-load-balancers | grep DNSName | grep ${vpc_name}
+#  cat - <<EOM
+#The kube-aws cluster is up; now add an entry in route53 for the CSOC account.
+#Ask Renuka or Fauzi to add k8s-${vpc_name}.internal.io as CNAME for
+#the k8s controller load balancer:
+#    aws elb describe-load-balancers | grep DNSName | grep ${vpc_name}
 
-$(aws elb describe-load-balancers | grep DNSName | grep ${vpc_name})
+#$(aws elb describe-load-balancers | grep DNSName | grep ${vpc_name})
 
-EOM
+#EOM
 
-fi
+#fi
 # else running some other k8s flavor (EKS, GKE, ...)
 
 if [[ -n "${s3_bucket}" ]]; then

--- a/tf_files/aws/eks/root.tf
+++ b/tf_files/aws/eks/root.tf
@@ -16,5 +16,6 @@ module "eks" {
   users_policy      = "${var.users_policy}"
   worker_drive_size = "${var.worker_drive_size}"
   eks_version       = "${var.eks_version}"
+  deploy_jupyter_pool = "${var.deploy_jupyter_pool}"
 }
 

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -23,3 +23,7 @@ variable "worker_drive_size" {
 variable "eks_version" {
   default = "1.10"
 }
+
+variable "deploy_jupyter_pool" {
+  default = "no"
+}

--- a/tf_files/aws/modules/eks-nodepool/README.md
+++ b/tf_files/aws/modules/eks-nodepool/README.md
@@ -40,6 +40,7 @@ All variables in this module are mandatory, however, since it is not intended to
 * `eks_private_subnets` list of cidr for private subneting.
 * `control_plane_sg` security group for the control plane to talk to the workers.
 * `default_nodepool_sg` Security group of the default pool. This hasn't been tested for additional pools other than jupyter, but theoretically you could create as many pools as you want.
+* `deploy_jupyter_pool` If expolicit "yes" provided, then the autoscaling group for the pool will be set for 3 as minimum and desired capasity. Default is no.
 
 
 ## 5. Considerations

--- a/tf_files/aws/modules/eks-nodepool/cloud.tf
+++ b/tf_files/aws/modules/eks-nodepool/cloud.tf
@@ -256,10 +256,10 @@ resource "aws_launch_configuration" "eks_launch_configuration" {
 
 
 resource "aws_autoscaling_group" "eks_autoscaling_group" {
-  desired_capacity     = 2 
+  desired_capacity     = "${var.deploy_jupyter_pool == "yes" ? 3 : 0}"
   launch_configuration = "${aws_launch_configuration.eks_launch_configuration.id}"
   max_size             = 10
-  min_size             = 2 
+  min_size             = "${var.deploy_jupyter_pool == "yes" ? 3 : 0}"
   name                 = "eks-${var.nodepool}worker-node-${var.vpc_name}"
   #vpc_zone_identifier  = ["${data.aws_subnet.eks_private.*.id}"]
   #vpc_zone_identifier  = ["${data.aws_subnet_ids.private.ids}"]
@@ -315,7 +315,7 @@ resource "aws_autoscaling_group" "eks_autoscaling_group" {
 
 # Avoid unnecessary changes for existing commons running on EKS 
   lifecycle {
-    ignore_changes = ["desired_capacity","max_size","min_size"]
+    #ignore_changes = ["desired_capacity","max_size","min_size"]
   }
 }
 

--- a/tf_files/aws/modules/eks-nodepool/cloud.tf
+++ b/tf_files/aws/modules/eks-nodepool/cloud.tf
@@ -273,7 +273,7 @@ resource "aws_autoscaling_group" "eks_autoscaling_group" {
 
   tag {
     key                 = "Name"
-    value               = "eks-${var.vpc_name}"
+    value               = "eks-${var.vpc_name}-jupyter"
     propagate_at_launch = true
   }
 

--- a/tf_files/aws/modules/eks-nodepool/data.tf
+++ b/tf_files/aws/modules/eks-nodepool/data.tf
@@ -53,7 +53,7 @@ data "aws_availability_zones" "available" {
 data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
-    #values = ["amazon-eks-node-*"]
+    values = ["${var.eks_version == "1.10" ? "eks-worker-v*" : "amazon-eks-node-1.11*"}"]
     values = ["eks-worker-v*"]
   }
 

--- a/tf_files/aws/modules/eks-nodepool/templates.tf
+++ b/tf_files/aws/modules/eks-nodepool/templates.tf
@@ -3,7 +3,7 @@ data "template_file" "ssh_keys" {
 }
 
 data "template_file" "bootstrap" {
-  template = "${file("${path.module}/../../../../flavors/eks/bootstrap-1.0.0.sh")}"
+  template = "${file(var.eks_version == "1.10" ? "${path.module}/../../../../flavors/eks/bootstrap-1.0.0.sh" : "${path.module}/../../../../flavors/eks/bootstrap-2.0.0.sh")}"
   vars {
     #eks_ca       = "${data.aws_eks_cluster.eks_cluster.certificate_authority.0.data}"
     #eks_endpoint = "${data.aws_eks_cluster.eks_cluster.endpoint}"

--- a/tf_files/aws/modules/eks-nodepool/variables.tf
+++ b/tf_files/aws/modules/eks-nodepool/variables.tf
@@ -34,3 +34,7 @@ variable "eks_private_subnets" {
 variable "control_plane_sg" {}
 
 variable "default_nodepool_sg" {}
+
+variable "deploy_jupyter_pool" {
+  default = "no"
+}

--- a/tf_files/aws/modules/eks-nodepool/variables.tf
+++ b/tf_files/aws/modules/eks-nodepool/variables.tf
@@ -38,3 +38,5 @@ variable "default_nodepool_sg" {}
 variable "deploy_jupyter_pool" {
   default = "no"
 }
+
+variable "eks_version" {}

--- a/tf_files/aws/modules/eks/README.md
+++ b/tf_files/aws/modules/eks/README.md
@@ -53,7 +53,9 @@ users_policy = "fauziv1"
 
 * `instance_type` By default this is set to t2.medium, but it can be changed if needed.
 * `csoc_cidr` By default set to 10.128.0.0/20.
-
+* `eks_version` Version of kubernetes to deploy for EKS, default is set to 1.10.
+* `worker_drive_size` Size of the root volume for the workers. Default is set to 30 GB.
+* `deploy_jupyter_pool` If you want the jupyter pool. If explicit "yes" is passed, then the autoscaling group would be set to a minimum of three instances, and same value for desired capasity. Default is no.
 
 ## 5. Considerations
 

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -20,6 +20,7 @@ module "jupyter_pool" {
   eks_private_subnets  = "${aws_subnet.eks_private.*.id}"
   control_plane_sg     = "${aws_security_group.eks_control_plane_sg.id}"
   default_nodepool_sg  = "${aws_security_group.eks_nodes_sg.id}"
+  deploy_jupyter_pool  = "${var.deploy_jupyter_pool}"
 }
 
 

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -21,6 +21,7 @@ module "jupyter_pool" {
   control_plane_sg     = "${aws_security_group.eks_control_plane_sg.id}"
   default_nodepool_sg  = "${aws_security_group.eks_nodes_sg.id}"
   deploy_jupyter_pool  = "${var.deploy_jupyter_pool}"
+  eks_version          = "${var.eks_version}"
 }
 
 
@@ -486,7 +487,7 @@ data "aws_ami" "eks_worker" {
   filter {
     name   = "name"
     #values = ["amazon-eks-node-*"]
-    values = ["eks-worker-v*"]
+    values = ["${var.eks_version == "1.10" ? "eks-worker-v*" : "amazon-eks-node-1.11*"}"]
   }
 
   most_recent = true

--- a/tf_files/aws/modules/eks/templates.tf
+++ b/tf_files/aws/modules/eks/templates.tf
@@ -39,7 +39,7 @@ data "template_file" "ssh_keys" {
 # Script to initialize the worker nodes
 
 data "template_file" "bootstrap" {
-  template = "${file("${path.module}/../../../../flavors/eks/bootstrap-1.0.0.sh")}"
+  template = "${file(var.eks_version == "1.10" ? "${path.module}/../../../../flavors/eks/bootstrap-1.0.0.sh" : "${path.module}/../../../../flavors/eks/bootstrap-2.0.0.sh")}"
   vars {
     eks_ca       = "${aws_eks_cluster.eks_cluster.certificate_authority.0.data}"
     eks_endpoint = "${aws_eks_cluster.eks_cluster.endpoint}"

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -22,3 +22,7 @@ variable "worker_drive_size" {
 variable "eks_version" {
   default = "1.10"
 }
+
+variable "deploy_jupyter_pool" {
+  default = "no"
+}


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Can now choose EKS with kubernetes version 1.11, or you can trigger the update in console and rerun terraform with the change and new workers would come ready for the new version

### Breaking Changes


### Bug Fixes
- The jupyter-deployment would sometimes be deployed on the default pool. It should now be 

### Improvements
- Documentation for EKS and EKS-nodepool modules.


### Dependency updates


### Deployment changes

