### PR TITLE
fix(nginx-helper): do not expose auth token

### DIFF
--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -50,7 +50,7 @@ function userid(req, res) {
   var user = "uid:null,unknown@unknown";
 
   if (token) {
-    user = token;
+    // note - raw token is secret, so do not expose in userid
     var raw = atob((token.split('.')[1] || "").replace('-', '+').replace('_', '/'));
     if (raw) {
       try {


### PR DESCRIPTION
### New Features

### Breaking Changes


### Bug Fixes
- do not set user to raw access token

### Improvements


### Dependency updates


### Deployment changes

