### PR TITLE
fix(canaries): support dev-canaries cookie

### DIFF
--- a/doc/canary.md
+++ b/doc/canary.md
@@ -1,10 +1,12 @@
 # TL;DR
 
-Deploy and manage canary services. The reverse proxy [readme](../kube/services/revproxy/README.md) has the more technical details.
-When the `service_releases` cookie is included in a request, the revproxy will use the release versions it finds in the cookie.
+We can deploy and manage canary versions of the fence, indexd, sheepdog, and peregrine services. The reverse proxy [readme](../kube/services/revproxy/README.md) has the more technical details.
+When the `service_releases` (or `dev_canaries` - see below) cookie is included in a request, the revproxy will use the release versions it finds in the cookie.
 When the cookie is not included, or for services that aren't in the cookie, revproxy uses the service weights from the manifest to determine which release version to use and sets the client's cookie with that configuration.
 
 ## Use
+
+### manifest.json setup
 
 To change the branch a canary service is pointing to, just edit the `<service>-canary` in the manifest. Then `gen3 roll <service>-canary`
 
@@ -13,3 +15,26 @@ To change the probability that a client is directed to the canary service:
 * deploy the reverse proxy, run `gen3 kube-setup-revproxy`
 
 If the weight is set to `0` for a service, the `service_releases` cookie is ignored and the production release is used.
+
+```
+...
+  "versions": {
+    "fence-canary": "quay.io...",
+    ...
+  },
+  "canary": {
+    "fence": 5,
+    "default": 0
+  }
+}
+```
+
+### dev override
+
+A developer may deploy a canary build of a service, and access it directly
+without making the canary available for general visitors by setting the
+"dev_canaries" cookie - ex:
+
+```
+fence.canary&peregrine.canary
+```

--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -124,19 +124,25 @@ function releasesObjToString(releases) {
 }
 
 /**
- * Checks cookie for service release versions and assigns
- *   release versions for services not in the cookie based
- *   on hash value and the percent weight of the canary.
- *   If the weight for a service is 0, it ignores the cookie
- *   and sets the release to production.
- * Returns a string of service assignments. E.g:
- *   "fence.canary&sheepdog.production&"
- *
+ * Checks cookie (dev_canaries or service_releases) 
+ * for service release versions and assigns
+ * release versions for services not in the cookie based
+ * on hash value and the percent weight of the canary.
+ * If the weight for a service is 0, it ignores the cookie
+ * and sets the release to production.
+ * 
  * @param req - nginx request object
+ * @return a string of service assignments. E.g:
+ *   "fence.canary&sheepdog.production&"
  */
 function getServiceReleases(req) {
+  //
   // client cookie containing releases
-  var release_cookie = req.variables['cookie_service_releases'] || '';
+  // developer override can force canary even when canary has
+  // been deployed for general users by setting the canary weights to zero
+  //
+  var devOverride= !!req.variables['cookie_dev_canaries'];
+  var release_cookie = req.variables['cookie_dev_canaries'] || req.variables['cookie_service_releases'] || '';
   // services to assign to a service (edit this if adding a new canary service)
   var services = ['fence', 'sheepdog', 'indexd', 'peregrine'];
   // weights for services - if given a default weight, use it; else use the default weight from this file
@@ -158,7 +164,7 @@ function getServiceReleases(req) {
   for (var i=0; i < services.length; i++) {
     var service = services[i];
     var parsed_release = release_cookie.match(service+'\.(production|canary)');
-    if (getWeight(service, canary_weights) === 0) {
+    if ((!devOverride) && getWeight(service, canary_weights) === 0) {
       updated_releases[service] = 'production';
     } else if (!parsed_release) {
       // if we haven't yet generated a hash value, do that now

--- a/kube/services/revproxy/helpersTest.js
+++ b/kube/services/revproxy/helpersTest.js
@@ -111,6 +111,23 @@ describe("Nginx helper function", function() {
     expect(serviceReleases).toMatch('fence.production');
   });
 
+  it("getServiceReleases returns dev override release versions if in cookie", function() {
+    const cookie = 'fence.production';
+    const devCookie = 'fence.canary';
+    let nginxRequest = {
+      variables: {
+        cookie_service_releases: cookie,
+        cookie_dev_canaries: devCookie,
+        canary_percent_json: '{ "fence": 0 }',
+        ...propertiesForHash,
+      },
+      log: log,
+    };
+
+    const serviceReleases = getServiceReleases(nginxRequest);
+    expect(serviceReleases).toMatch('fence.canary');
+  });
+
   it("getServiceReleases returns correct release version when no cookie val is set (test 1)", function() {
     // don't define the service release cookie, forcing it to hash and select a release
     let nginxRequest = {


### PR DESCRIPTION
Adds support for `dev_canaries` override cookie.

### New Features

### Breaking Changes


### Bug Fixes


### Improvements
* Adds support for `dev_canaries` override cookie.


### Dependency updates


### Deployment changes

