### PR TITLE
Feat/squidnlbdiskspace

### DIFF
--- a/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
@@ -244,11 +244,15 @@ resource "aws_vpc_endpoint_service" "squid_nlb" {
 resource "aws_launch_configuration" "squid_nlb" {
   name_prefix = "${var.env_nlb_name}_autoscaling_launch_config"
   image_id = "${data.aws_ami.public_squid_ami.id}"
-  instance_type = "t2.medium"
+  #instance_type = "t2.medium"
+  instance_type = "t3.xlarge"
   security_groups = ["${aws_security_group.squidnlb_in.id}", "${aws_security_group.squidnlb_out.id}"]
   key_name = "${var.ssh_key_name}"
   iam_instance_profile   = "${aws_iam_instance_profile.squid-nlb_role_profile.id}"
   associate_public_ip_address = true
+  root_block_device {
+    volume_size = 30
+  }
 
   depends_on = ["aws_iam_instance_profile.squid-nlb_role_profile"]
 

--- a/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
@@ -188,6 +188,7 @@ resource "aws_lb" "squid_nlb" {
   tags {
     Environment = "production"
   }
+  lifecycle{ignore_changes=["subnet_mapping"]}
 }
 # For http/https traffic
 resource "aws_lb_target_group" "squid_nlb-http" {


### PR DESCRIPTION
Description about what this pull request does.
It increased the disk space to 30G, change the instance type to t3.xlarge and add the following 👍
lifecycle{ignore_changes=["subnet_mapping"]} to the network LB creation.


Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

