### PR TITLE
Fix/squidnlbloggingfixv1

### DIFF
--- a/flavors/squid_nlb_central/squidvm.sh
+++ b/flavors/squid_nlb_central/squidvm.sh
@@ -104,7 +104,8 @@ sudo chmod 644 /etc/init.d/awslogs
 # Configure the AWS logs
 
 HOSTNAME=$(which hostname)
-instance_ip=$(ip -f inet -o addr show eth0|cut -d\  -f 7 | cut -d/ -f 1)
+server_int=$(route | grep '^default' | grep -o '[^ ]*$')
+instance_ip=$(ip -f inet -o addr show $server_int|cut -d\  -f 7 | cut -d/ -f 1)
 IFS=. read ip1 ip2 ip3 ip4 <<< "$instance_ip"
 
 sed -i 's/SERVER/http_proxy-auth-'$($HOSTNAME)'/g' /var/awslogs/etc/awslogs.conf

--- a/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
@@ -265,8 +265,8 @@ sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 cd /home/ubuntu/cloud-automation
 git pull
 # this is just temporary to test stuff from my branch; not needed once it is merged
-#git checkout feat/squidnlb_files
-#git pull
+git checkout fix/squidnlbloggingfixv1
+git pull
 #####
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
@@ -265,8 +265,8 @@ sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 cd /home/ubuntu/cloud-automation
 git pull
 # this is just temporary to test stuff from my branch; not needed once it is merged
-git checkout fix/squidnlbloggingfixv1
-git pull
+#git checkout fix/squidnlbloggingfixv1
+#git pull
 #####
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 


### PR DESCRIPTION
Description about what this pull request does.
This fix the logging for the squidVMs in csoc squidnlb, which were hardcoded to use ip on eth0 for creating log_streams. 

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

