### PR TITLE
chore: add gopkg and golang to whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -49,6 +49,8 @@ ftp.usf.edu
 ftp.ussg.iu.edu
 git.bionimbus.org
 git.io
+golang.org
+gopkg.in
 http.us.debian.org
 hooks.slack.com
 internet2.edu


### PR DESCRIPTION
To facilitate the go-getting of packages. For example:

    go get -u golang.org/x/crypto/ssh/terminal
    go get -u golang.org/x/sys/unix
    go get -u golang.org/x/net/context
    go get -u gopkg.in/yaml.v2