### PR TITLE
PXP-2441: make sheepdog termination shorter

### DIFF
--- a/gen3/lib/testData/default/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/default/expectedSheepdogResult.yaml
@@ -50,7 +50,7 @@ spec:
             secretName: "service-ca"
       # sheepdog transactions take forever -
       # try to let the complete before termination
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 50
       containers:
         - name: sheepdog
           image: quay.io/cdis/sheepdog:1.0.1

--- a/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
@@ -52,7 +52,7 @@ spec:
             secretName: "service-ca"
       # sheepdog transactions take forever -
       # try to let the complete before termination
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 50
       containers:
         - name: sheepdog
           image: quay.io/cdis/sheepdog:master

--- a/kube/services/sheepdog/sheepdog-canary-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-canary-deploy.yaml
@@ -52,7 +52,7 @@ spec:
             secretName: "service-ca"
       # sheepdog transactions take forever -
       # try to let the complete before termination
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 50
       containers:
         - name: sheepdog
           GEN3_SHEEPDOG-CANARY_IMAGE|-GEN3_SHEEPDOG_IMAGE-|

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -52,7 +52,7 @@ spec:
             secretName: "service-ca"
       # sheepdog transactions take forever -
       # try to let the complete before termination
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 50
       containers:
         - name: sheepdog
           GEN3_SHEEPDOG_IMAGE


### PR DESCRIPTION
chore(sheepdog): Now that both reverse proxy and uWSGI worker of sheepdog will timeout in 45 seconds, it shall be safe to terminate the Docker container after 50 seconds.

### Deployment changes
* Sheepdog shutdown wait time is now 50 seconds