### PR TITLE
fix(g3k): don't return canary if not specified

### DIFF
--- a/gen3/lib/g3k.sh
+++ b/gen3/lib/g3k.sh
@@ -37,7 +37,7 @@ get_pod() {
   (
     set +e
     # prefer Running pods
-    pod=$(g3kubectl get pods --output=jsonpath='{range .items[*]}{.status.phase}{"   "}{.metadata.name}{"\n"}{end}' | grep Running | awk '{ print $2 }' | grep -m 1 $name)
+    pod=$(g3kubectl get pods --output=jsonpath='{range .items[*]}{.status.phase}{"   "}{.metadata.name}{"\n"}{end}' | grep Running | awk '{ print $2 }' | grep -m 1 -E "$name-[^\(canary\)]")
     if [[ -z "$pod" ]]; then # fall back to any pod if no Running pods available
       pod=$(g3kubectl get pods --output=jsonpath='{range .items[*]}{.metadata.name}  {"\n"}{end}' | grep -m 1 $name)
     fi


### PR DESCRIPTION
### Bug Fixes
Previously `gen3 pod <name>` was returning the canary deployment if it existed. Should fix that problem
