### PR TITLE
feat(peregrine): add datasets config

### DIFF
--- a/kube/services/peregrine/peregrine-deploy.yaml
+++ b/kube/services/peregrine/peregrine-deploy.yaml
@@ -64,6 +64,12 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: dictionary_url
+          - name: PUBLIC_DATASETS
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: public_datasets
+                optional: true
           - name: GEN3_DEBUG
             GEN3_DEBUG_FLAG|-value: "False"-|
           - name: GEN3_SIDECAR

--- a/kube/services/revproxy/gen3.nginx.conf/peregrine-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/peregrine-service.conf
@@ -8,6 +8,31 @@
               set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local/_version;
               proxy_pass $upstream;
           }
+          location /api/search {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+
+              gzip off;
+              proxy_next_upstream off;
+              proxy_set_header   Host $host;
+              proxy_set_header   Authorization "$access_token";
+              proxy_set_header   X-Forwarded-For "$realip";
+              proxy_set_header   X-UserId "$userid";
+              proxy_set_header   X-ReqId "$request_id";
+              proxy_set_header   X-SessionId "$session_id";
+              proxy_set_header   X-VisitorId "$visitor_id";
+
+              proxy_connect_timeout 300;
+              proxy_send_timeout 300;
+              proxy_read_timeout 300;
+              send_timeout 300;
+
+              set $proxy_service  "${peregrine_release_name}";
+              set $upstream http://${peregrine_release_name}-service.$namespace.svc.cluster.local;
+              rewrite ^/api/search/(.*) /$1 break;
+              proxy_pass $upstream;
+          }
           location /api/v0/submission/graphql {
               if ($csrf_check !~ ^ok-\S.+$) {
                 return 403 "failed csrf check";
@@ -15,10 +40,7 @@
 
               gzip off;
               proxy_next_upstream off;
-              # Forward the host and set Subdir header so api
-              # knows the original request path for hmac signing
               proxy_set_header   Host $host;
-              proxy_set_header   Subdir /api;
               proxy_set_header   Authorization "$access_token";
               proxy_set_header   X-Forwarded-For "$realip";
               proxy_set_header   X-UserId "$userid";


### PR DESCRIPTION
Add a new optional variable to peregrine deployment for setting datasets endpoint to public.
If this variable is set to true in gitops, the datasets endpoint will allow anonymous access

### New Features
- add a new optional variable to peregrine deployment for setting datasets endpoint to public

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

