### PR TITLE
PXD-2561: fix noise of /_status

### DIFF
--- a/kube/services/peregrine/peregrine-canary-deploy.yaml
+++ b/kube/services/peregrine/peregrine-canary-deploy.yaml
@@ -94,15 +94,15 @@ spec:
               memory: 2048Mi
           livenessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=20
               port: 80
             # peregrine can take forever to initialize
-            initialDelaySeconds: 300
+            initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 30
           readinessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=2
               port: 80
         #
         # Containers interact via /var/run/gen3/uwsgi.sock ...

--- a/kube/services/peregrine/peregrine-deploy.yaml
+++ b/kube/services/peregrine/peregrine-deploy.yaml
@@ -97,13 +97,13 @@ spec:
               memory: 2048Mi
           livenessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=20
               port: 80
             # peregrine can take forever to initialize
-            initialDelaySeconds: 600
+            initialDelaySeconds: 60
             periodSeconds: 60
             timeoutSeconds: 30
           readinessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=2
               port: 80

--- a/kube/services/sheepdog/sheepdog-canary-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-canary-deploy.yaml
@@ -58,14 +58,14 @@ spec:
           GEN3_SHEEPDOG-CANARY_IMAGE|-GEN3_SHEEPDOG_IMAGE-|
           livenessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=20
               port: 80
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 30
           readinessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=2
               port: 80
           ports:
           - containerPort: 80

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -58,14 +58,14 @@ spec:
           GEN3_SHEEPDOG_IMAGE
           livenessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=20
               port: 80
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 30
           readinessProbe:
             httpGet:
-              path: /_status
+              path: /_status?timeout=2
               port: 80
           ports:
           - containerPort: 80


### PR DESCRIPTION
### Improvements
* fix noise of `/_status`

### Deployment changes
* Reduced peregrine startup waiting time (`livenessProbe.initialDelaySeconds`) refs uc-cdis/peregrine#104
