### PR TITLE
feat(email-flag)

### DIFF
--- a/apis_configs/fence_credentials.json
+++ b/apis_configs/fence_credentials.json
@@ -31,6 +31,7 @@
     "WHITE_LISTED_GOOGLE_PARENT_ORGS": [],
     "GOOGLE_MANAGED_SERVICE_ACCOUNT_DOMAINS": [],
     "REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION": {
+        "enable": false,
         "domain": "planx-pla.net",
         "subject": "User service account removal notification",
         "from": "do-not-reply@planx-pla.net",


### PR DESCRIPTION
Add a flag to the `REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION` config to disable it (fence PR https://github.com/uc-cdis/fence/pull/580)

### Deployment changes
- the var `REMOVE_SERVICE_ACCOUNT_EMAIL_NOTIFICATION.enable` must be added to the fence config
