### PR TITLE
fix(s3): fetch aws account id and warn when unable to find policy

### DIFF
--- a/gen3/bin/s3.sh
+++ b/gen3/bin/s3.sh
@@ -89,6 +89,10 @@ gen3_s3_info() {
   local writerName="bucket_writer_$1"
   local readerName="bucket_reader_$1"
   local AWS_ACCOUNT_ID=$(gen3_aws_run aws sts get-caller-identity | jq -r .Account)
+  if [[ -z "$AWS_ACCOUNT_ID" ]]; then
+    gen3_log_err "Unable to fetch AWS account ID."
+    exit 1
+  fi
   local rootPolicyArn="arn:aws:iam::${AWS_ACCOUNT_ID}:policy"
   if gen3_aws_run aws iam get-policy --policy-arn ${rootPolicyArn}/${writerName} >/dev/null 2>&1; then
     writerPolicy="{ \"name\": \"$writerName\", \"policy_arn\": \"${rootPolicyArn}/${writerName}\" } "

--- a/tf_files/aws/modules/s3-bucket/cloud.tf
+++ b/tf_files/aws/modules/s3-bucket/cloud.tf
@@ -62,6 +62,7 @@ data "aws_iam_policy_document" "mybucket_reader" {
 }
 
 resource "aws_iam_policy" "mybucket_reader" {
+  # This name is used in the `gen3 s3 info` function
   name        = "bucket_reader_${local.clean_bucket_name}"
   description = "Read ${local.clean_bucket_name}"
   policy      = "${data.aws_iam_policy_document.mybucket_reader.json}"
@@ -131,6 +132,7 @@ data "aws_iam_policy_document" "mybucket_writer" {
 }
 
 resource "aws_iam_policy" "mybucket_writer" {
+  # This name is used in the `gen3 s3 info` function
   name        = "bucket_writer_${local.clean_bucket_name}"
   description = "Read or write ${local.clean_bucket_name}"
   policy      = "${data.aws_iam_policy_document.mybucket_writer.json}"


### PR DESCRIPTION
### Bug Fixes
`gen3 s3 info`: fetch aws account id before checking for the policy