### PR TITLE
Active-Standby setup for squid in commons

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -116,4 +116,4 @@ www.mathworks.com
 www.oracle.com
 www.rabbitmq.com
 www.uniprot.org
-
+yahoo.com

--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -116,4 +116,4 @@ www.mathworks.com
 www.oracle.com
 www.rabbitmq.com
 www.uniprot.org
-yahoo.com
+

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -1,6 +1,6 @@
 for i in {1..12}
 do
-timestamp=$(date +%T)
+timestamp=$(date)
 
 count_stat1=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Healthy | awk '{print NF}')
 

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+# We run this script in a loop with a sleep interval of  5 seconds so that the squid VMs can do a health check 
+# on the autoscaling group every 5 secs. Please note the VM in autoscaling group only goes Unhealthy/ or not available
+# only for a sort duration like 20-25 secs
+
 for i in {1..12}
 do
 timestamp=$(date)

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -1,9 +1,13 @@
-count_stat=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep Unhealthy | awk '{print NF}')
+count_stat1=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Healthy | awk '{print NF}')
 
-echo "The count stat is $count_stat"
+count_stat2=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Unhealthy | awk '{print NF}')
 
-if [ ! -z "$count_stat" ] ; then
-#if [ "$count_stat" -ge 1 ] ; then
+
+echo "The count stat is $count_stat1"
+echo "The count stat is $count_stat2"
+
+
+if [[ "$count_stat1" -lt '2'  ||   "$count_stat2" -ge '1' ]] ; then
 echo "Running the private subnets route table script"
 bash /home/ubuntu/default_ip_route_and_instance_check_config.sh
 echo "Running the route53 DNS update script"

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -16,7 +16,7 @@ count_stat2=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-
 
 
 
-if [[ "$count_stat1" -lt '2'  ||   "$count_stat2" -ge '1' ]] ; then
+if [[ "$count_stat1" -lt '2'  ||   ! -z "$count_stat2" ]] ; then
 echo "The number of Healthy hosts  at $timestamp  is $count_stat1" >> /var/log/squid_health.log
 echo "The number of Unhealthy hosts  at $timestamp is $count_stat2" >> /var/log/squid_health.log
 echo "Running the private subnets route table script at $timestamp" >> /var/log/squid_health.log

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -7,11 +7,12 @@ count_stat1=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-
 count_stat2=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Unhealthy | awk '{print NF}')
 
 
-echo "The number of Healthy hosts  at $timestamp  is $count_stat1" >> /var/log/squid_health.log
-echo "The number of Unhealthy hosts  at $timestamp is $count_stat2" >> /var/log/squid_health.log
+
 
 
 if [[ "$count_stat1" -lt '2'  ||   "$count_stat2" -ge '1' ]] ; then
+echo "The number of Healthy hosts  at $timestamp  is $count_stat1" >> /var/log/squid_health.log
+echo "The number of Unhealthy hosts  at $timestamp is $count_stat2" >> /var/log/squid_health.log
 echo "Running the private subnets route table script at $timestamp" >> /var/log/squid_health.log
 sudo bash /home/ubuntu/default_ip_route_and_instance_check_config.sh
 echo "Running the route53 DNS update script at $timestamp" >> /var/log/squid_health.log

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -1,15 +1,22 @@
+for i in {1..12}
+do
+timestamp=$(date +%T)
+
 count_stat1=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Healthy | awk '{print NF}')
 
 count_stat2=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Unhealthy | awk '{print NF}')
 
 
-echo "The count stat is $count_stat1"
-echo "The count stat is $count_stat2"
+echo "The number of Healthy hosts  at $timestamp  is $count_stat1" >> /var/log/squid_health.log
+echo "The number of Unhealthy hosts  at $timestamp is $count_stat2" >> /var/log/squid_health.log
 
 
 if [[ "$count_stat1" -lt '2'  ||   "$count_stat2" -ge '1' ]] ; then
-echo "Running the private subnets route table script"
-bash /home/ubuntu/default_ip_route_and_instance_check_config.sh
-echo "Running the route53 DNS update script"
-bash /home/ubuntu/proxy_route53_config.sh
+echo "Running the private subnets route table script at $timestamp" >> /var/log/squid_health.log
+sudo bash /home/ubuntu/default_ip_route_and_instance_check_config.sh
+echo "Running the route53 DNS update script at $timestamp" >> /var/log/squid_health.log
+sudo bash /home/ubuntu/proxy_route53_config.sh
 fi
+
+sleep 5
+done

--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -1,0 +1,11 @@
+count_stat=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep Unhealthy | awk '{print NF}')
+
+echo "The count stat is $count_stat"
+
+if [ ! -z "$count_stat" ] ; then
+#if [ "$count_stat" -ge 1 ] ; then
+echo "Running the private subnets route table script"
+bash /home/ubuntu/default_ip_route_and_instance_check_config.sh
+echo "Running the route53 DNS update script"
+bash /home/ubuntu/proxy_route53_config.sh
+fi

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -149,9 +149,11 @@ sudo chmod +x /home/ubuntu/healthcheck_status.sh
 
 
 crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null 2>&1' >> file
-crontab -l > file1; echo '* * * * * for i in {1..12}; do /home/ubuntu/health_check.sh ; sleep 5; done >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
+
+crontab -l > file1; echo '* * * * * for i in {1..60}; do /home/ubuntu/health_check.sh ; sleep 1; done >/dev/null 2>&1' >> file1
+sudo chown -R ubuntu. /home/ubuntu/
 crontab file1
 
 cd /home/ubuntu

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -160,7 +160,7 @@ crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
 
-crontab -l > file1; echo '* * * * * /home/ubuntu/healthcheck_status.sh >/dev/null 2>&1' >> file1
+crontab -l > file1; echo '* * * * * sudo bash /home/ubuntu/healthcheck_status.sh >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file1
 

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -160,7 +160,7 @@ crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
 
-crontab -l > file1; echo '* * * * * sudo bash /home/ubuntu/healthcheck_status.sh ;done >/dev/null 2>&1' >> file1
+crontab -l > file1; echo '* * * * * sudo bash /home/ubuntu/healthcheck_status.sh >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file1
 

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -44,9 +44,11 @@ sudo iptables-restore < /etc/iptables.conf
 
 sudo cp /etc/rc.local /etc/rc.local.bak
 sudo sed -i 's/^exit/#exit/' /etc/rc.local
-sudo echo "iptables-restore < /etc/iptables.conf" >> /etc/rc.local
-sudo echo exit 0 >> /etc/rc.local
 
+#sudo echo "iptables-restore < /etc/iptables.conf" >> /etc/rc.local
+#sudo echo exit 0 >> /etc/rc.local
+echo "iptables-restore < /etc/iptables.conf" | sudo tee -a /etc/rc.local
+echo exit 0 | sudo tee -a /etc/rc.local
 
 
 sudo mkdir /etc/squid/ssl

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -160,7 +160,7 @@ crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
 
-crontab -l > file1; echo '* * * * * sudo bash /home/ubuntu/healthcheck_status.sh >/dev/null 2>&1' >> file1
+crontab -l > file1; echo '* * * * * /home/ubuntu/healthcheck_status.sh >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file1
 

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -149,7 +149,7 @@ sudo chmod +x /home/ubuntu/healthcheck_status.sh
 
 
 crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null 2>&1' >> file
-crontab -l > file1; echo '* * * * * for i in {1..60}; do sudo bash /home/ubuntu/health_check.sh ; sleep 5; done >/dev/null 2>&1' >> file1
+crontab -l > file1; echo '* * * * * for i in {1..12}; do /home/ubuntu/health_check.sh ; sleep 5; done >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
 crontab file1

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -41,6 +41,14 @@ sudo chmod 0755 /etc/network/if-up.d/iptables-rules
 ## Enable iptables for NAT. We need this so that the proxy can be used transparently
 sudo iptables-restore < /etc/iptables.conf
 
+
+sudo cp /etc/rc.local /etc/rc.local.bak
+sudo sed -i 's/^exit/#exit/' /etc/rc.local
+sudo echo "iptables-restore < /etc/iptables.conf" >> /etc/rc.local
+sudo echo exit 0 >> /etc/rc.local
+
+
+
 sudo mkdir /etc/squid/ssl
 sudo openssl genrsa -out /etc/squid/ssl/squid.key 2048
 sudo openssl req -new -key /etc/squid/ssl/squid.key -out /etc/squid/ssl/squid.csr -subj '/C=XX/ST=XX/L=squid/O=squid/CN=squid'

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -136,7 +136,7 @@ sudo chown -R sftpuser. /home/sftpuser
 
 sudo cp  ${SUB_FOLDER}flavors/squid_auto/updatewhitelist.sh /home/ubuntu
 
-
+sudo cp  ${SUB_FOLDER}flavors/squid_auto/healthcheck_status.sh /home/ubuntu
 
 
 sudo chmod +x /home/ubuntu/updatewhitelist.sh
@@ -144,13 +144,15 @@ sudo chmod +x /home/ubuntu/updatewhitelist.sh
 ##Updating the route table and the cloud-proxy dns entry
 sudo chmod +x /home/ubuntu/proxy_route53_config.sh
 sudo chmod +x /home/ubuntu/default_ip_route_and_instance_check_config.sh
-
+sudo chmod +x /home/ubuntu/healthcheck_status.sh
 
 
 
 crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null 2>&1' >> file
+crontab -l > file1; echo '* * * * * for i in {1..60}; do sudo bash /home/ubuntu/health_check.sh ; sleep 5; done >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
+crontab file1
 
 cd /home/ubuntu
 

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -152,7 +152,7 @@ crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
 
-crontab -l > file1; echo '* * * * * for i in {1..60}; do /home/ubuntu/healthcheck_status.sh ; sleep 1; done >/dev/null 2>&1' >> file1
+crontab -l > file1; echo '* * * * * sudo bash /home/ubuntu/healthcheck_status.sh ;done >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file1
 

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -152,7 +152,7 @@ crontab -l > file; echo '*/15 * * * * /home/ubuntu/updatewhitelist.sh >/dev/null
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file
 
-crontab -l > file1; echo '* * * * * for i in {1..60}; do /home/ubuntu/health_check.sh ; sleep 1; done >/dev/null 2>&1' >> file1
+crontab -l > file1; echo '* * * * * for i in {1..60}; do /home/ubuntu/healthcheck_status.sh ; sleep 1; done >/dev/null 2>&1' >> file1
 sudo chown -R ubuntu. /home/ubuntu/
 crontab file1
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -291,8 +291,8 @@ resource "aws_autoscaling_group" "squid_auto" {
 #If you define a list of subnet IDs split across the desired availability zones set them using vpc_zone_identifier 
 # and there is no need to set availability_zones.
 # (https://www.terraform.io/docs/providers/aws/r/autoscaling_group.html#availability_zones).
-  desired_capacity = 1
-  max_size = 1
+  desired_capacity = 2
+  max_size = 2
   min_size = 1
   vpc_zone_identifier = ["${aws_subnet.squid_pub0.id}", "${aws_subnet.squid_pub1.id}", "${aws_subnet.squid_pub2.id}","${aws_subnet.squid_pub3.id}","${aws_subnet.squid_pub4.id}","${aws_subnet.squid_pub5.id}"]
   launch_configuration = "${aws_launch_configuration.squid_auto.name}"

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -40,6 +40,7 @@ data "aws_iam_policy_document" "squid_policy_document" {
   statement {
     actions = ["ec2:*",
                "route53:*",
+               "autoscaling:*",
                "sts:AssumeRole",
                "logs:CreateLogGroup",
                "logs:CreateLogStream",

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -157,21 +157,21 @@ resource "aws_subnet" "squid_pub2" {
 resource "aws_subnet" "squid_pub3" {
   vpc_id                  = "${data.aws_vpc.the_vpc.id}"
   cidr_block              =  "${cidrsubnet("${var.squid_proxy_subnet}",3,3)}"
-  availability_zone = "${data.aws_availability_zones.available.names[0]}"
+  availability_zone = "${data.aws_availability_zones.available.names[3]}"
   tags                    = "${map("Name", "${var.env_squid_name}_pub0", "Organization", "Basic Service", "Environment", var.env_squid_name)}"
 }
 
 resource "aws_subnet" "squid_pub4" {
   vpc_id                  = "${data.aws_vpc.the_vpc.id}"
   cidr_block              =   "${cidrsubnet("${var.squid_proxy_subnet}",3,4)}"
-  availability_zone = "${data.aws_availability_zones.available.names[1]}"
+  availability_zone = "${data.aws_availability_zones.available.names[4]}"
   tags                    = "${map("Name", "${var.env_squid_name}_pub1", "Organization", "Basic Service", "Environment", var.env_squid_name)}"
 }
 
 resource "aws_subnet" "squid_pub5" {
   vpc_id                  = "${data.aws_vpc.the_vpc.id}"
   cidr_block              =   "${cidrsubnet("${var.squid_proxy_subnet}",3,5)}"
-  availability_zone = "${data.aws_availability_zones.available.names[2]}"
+  availability_zone = "${data.aws_availability_zones.available.names[5]}"
   tags                    = "${map("Name", "${var.env_squid_name}_pub2", "Organization", "Basic Service", "Environment", var.env_squid_name)}"
 }
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,8 +243,8 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-git checkout fix/squid_auto_activestandby
-git pull
+#git checkout fix/squid_auto_activestandby
+#git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,7 +243,7 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-#git checkout feat/autosquidVM
+git checkout fix/squid_auto_activestandby
 git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation


### PR DESCRIPTION
Description about what this pull request does.
Introduced an active-standby squid set-up for commons; where if the active VM goes down the standby VM takes the active role. Reducing the downtime greatly.
 
Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

