### PR TITLE
fix(jupyter): namespace role binding

### DIFF
--- a/gen3/bin/kube-setup-jupyterhub.sh
+++ b/gen3/bin/kube-setup-jupyterhub.sh
@@ -25,7 +25,8 @@ gen3 update_config jupyterhub-config "${GEN3_HOME}/kube/services/jupyterhub/jupy
 
 g3kubectl apply -f "${GEN3_HOME}/kube/services/jupyterhub/serviceaccount.yaml"
 g3kubectl apply -f "${GEN3_HOME}/kube/services/jupyterhub/role-jupyter.yaml"
-g3kubectl apply -f "${GEN3_HOME}/kube/services/jupyterhub/rolebinding-jupyter.yaml"
+namespace="$(gen3 db namespace)"
+g3k_kv_filter ${GEN3_HOME}/kube/services/jupyterhub/rolebinding-jupyter.yaml JUPYTER_BINDING "name: jupyter-binding-$namespace" CURRENT_NAMESPACE "namespace: $namespace" | g3kubectl apply -f -
 
 g3kubectl apply -f "${GEN3_HOME}/kube/services/jupyterhub/jupyterhub-prepuller.yaml"
 g3kubectl apply -f "${GEN3_HOME}/kube/services/jupyterhub/jupyterhub-service.yaml"

--- a/kube/services/jupyterhub/rolebinding-jupyter.yaml
+++ b/kube/services/jupyterhub/rolebinding-jupyter.yaml
@@ -1,12 +1,12 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: jupyter-binding
+  JUPYTER_BINDING
   namespace: jupyter-pods
 subjects:
 - kind: ServiceAccount
   name: jupyter-service
-  namespace: default
+  CURRENT_NAMESPACE
 roleRef:
   kind: ClusterRole
   name: jupyter


### PR DESCRIPTION
This allows doing parallel QA in jupyterhub in our QA environments sharing the same jupyter namespace.
It doesn't allow a test user in both QA envs to use jupyter at the same time

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- namespace the rolebinding name for service account used by jupyterhub in gen3 services' namespace

### Dependency updates


### Deployment changes

