### PR TITLE
chore(jenkins): new GOOGLE_APP_CREDS_JSON secret

### DIFF
--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.166
+FROM jenkins/jenkins:2.169
 
 USER root
 

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -80,8 +80,8 @@ spec:
           - name: GOOGLE_APP_CREDS_JSON
             valueFrom:
               secretKeyRef:
-                name: fence-google-app-creds-secret
-                key: fence_google_app_creds_secret.json
+                name: gen3-qa-g3auto
+                key: gen3-qa-g3auto
         readinessProbe:
           httpGet:
             path: /login

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -80,8 +80,8 @@ spec:
           - name: GOOGLE_APP_CREDS_JSON
             valueFrom:
               secretKeyRef:
-                name: gen3-qa-g3auto
-                key: gen3-qa-g3auto
+                name: jenkins-g3auto
+                key: jenkins-g3auto
         readinessProbe:
           httpGet:
             path: /login


### PR DESCRIPTION
The new DCF tests need to use a different service account

### Deployment changes
- Use a new secret (manually set up in `qaplanetv1` with `gen3 secrets`)
- Bump docker jenkins version