### PR TITLE
feat(retry): Retry S3 downloads for usersync cronjob

### DIFF
--- a/kube/services/jobs/usersync-cronjob.yaml
+++ b/kube/services/jobs/usersync-cronjob.yaml
@@ -213,7 +213,14 @@ spec:
                   cp /var/www/fence/user.yaml /mnt/shared/user.yaml
                 else
                   echo "awshelper downloading ${userYamlS3Path} to /mnt/shared/useryaml";
-                  aws s3 cp "${userYamlS3Path}" /mnt/shared/user.yaml;
+                  n=0
+                  until [ $n -ge 5 ]
+                  do
+                    echo "Download attempt $n"
+                    aws s3 cp "${userYamlS3Path}" /mnt/shared/user.yaml && break
+                    n=$[$n+1]
+                    sleep 2
+                  done
                   if [[ -f /mnt/shared/user.yaml ]]; then
                     echo "awshelper container user.yaml diff ..."
                     diff /var/www/fence/user.yaml /mnt/shared/user.yaml


### PR DESCRIPTION
Sometimes the credentials need to be refreshed on the nodes leading to initial awscli command failures. This retries the usersync user.yaml download up to 5 times.

Example of this working:

```
awshelper downloading s3://cdis-gen3-users/dcfstaging/user.yaml to /mnt/shared/useryaml
Download attempt 0
download failed: s3://cdis-gen3-users/dcfstaging/user.yaml to ../../mnt/shared/user.yaml Unable to locate credentials
Download attempt 1
download: s3://cdis-gen3-users/dcfstaging/user.yaml to ../../mnt/shared/user.yaml
awshelper container user.yaml diff ...
no difference found
```

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Retry user.yaml download in usersync cronjob

### Dependency updates


### Deployment changes

