### PR TITLE
Chore/skip proxy worker nodes

### DIFF
--- a/doc/routing.md
+++ b/doc/routing.md
@@ -1,0 +1,22 @@
+# TL;DR
+
+Helper to manipulate the routing table for commons kubernetes workers
+
+## Use
+
+### skip-proxy
+
+Would add a CIDR to the routing table associated with the kubernetes workers to skip the proxy.
+
+Basically, the CIDR provided  will go through the NAT gateway associated with vpc. 
+Something equivalen to 
+`aws ec2 create-route --route-table-id <RT-ID> --destination-cidr-block <CIDR> --nat-gateway-id <NAT-ID>`
+is ran under the hood.
+
+
+```
+  gen3 routing skip-proxy 128.135.0.0/16
+```
+
+Note: be sure to provide a valid CIDR.
+

--- a/gen3/bin/routing.sh
+++ b/gen3/bin/routing.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Little route53 helper
+#
+
+source "${GEN3_HOME}/gen3/lib/utils.sh"
+gen3_load "gen3/gen3setup"
+
+
+
+# lib --------------------------
+
+#
+# Scan the active k8s environment for
+# public facing load balancers, and output a json
+# suitable for "aws route53 change-resource-record-sets"
+# to setup route53 A and AAAA records (via UPSERT)
+# that alias the LB
+#
+gen3_routing_skip_proxy() {
+  local routingTable
+  local natGateway
+  local cidrRegex
+
+  cidrRegex='(((25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|1?[0-9][0-9]?))(\/([8-9]|[1-2][0-9]|3[0-2]))([^0-9.]|$)'
+
+  if [[ $1 =~ $cidrRegex ]]
+  then
+      echo "$1 OK!"
+  else
+      echo "$1 Not OK!"
+      exit 1
+  fi
+  #local resultCode
+
+  routingTable="$(aws ec2 describe-route-tables --query 'RouteTables[].RouteTableId' --filters "Name=tag:Environment,Values=${vpc_name}" "Name=tag:Name,Values=eks_private" --output text)"
+  natGateway="$(aws ec2 describe-nat-gateways --query 'NatGateways[].NatGatewayId' --filter "Name=tag:Environment,Values=${vpc_name}" --output text)"
+
+  # Add the route to go over the nat GW instead of through the proxy 
+  aws ec2 create-route --route-table-id ${routingTable} --destination-cidr-block ${1} --nat-gateway-id ${natGateway}
+
+  #return $resultCode
+}
+
+
+# main -------------------------
+
+if [[ -z "$GEN3_SOURCE_ONLY" ]]; then
+  # Support sourcing this file for test suite
+  command="$1"
+  shift
+  case "$command" in
+    "skip-proxy")
+      gen3_routing_skip_proxy "$@"
+      ;;
+    *)
+      gen3 help route53
+      ;;
+  esac
+fi

--- a/gen3/bin/routing.sh
+++ b/gen3/bin/routing.sh
@@ -11,11 +11,10 @@ gen3_load "gen3/gen3setup"
 # lib --------------------------
 
 #
-# Scan the active k8s environment for
-# public facing load balancers, and output a json
-# suitable for "aws route53 change-resource-record-sets"
-# to setup route53 A and AAAA records (via UPSERT)
-# that alias the LB
+# Scan routing tables looking for eks_private 
+# then it'll scan the nat gateways related to the commons
+# and add the provided CIDR to the routing table found using the NAT GW as GW
+# for the CIDR
 #
 gen3_routing_skip_proxy() {
   local routingTable

--- a/tf_files/aws/eks/root.tf
+++ b/tf_files/aws/eks/root.tf
@@ -23,4 +23,5 @@ module "eks" {
   jupyter_bootstrap_script  = "${var.jupyter_bootstrap_script}"
   kernel                    = "${var.kernel}"
   jupyter_worker_drive_size = "${var.jupyter_worker_drive_size}"
+  cidrs_to_route_to_gw      = "${var.cidrs_to_route_to_gw}"
 }

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -51,3 +51,7 @@ variable "kernel" {
 variable "jupyter_worker_drive_size" {
   default = 30
 }
+
+variable "cidrs_to_route_to_gw" {
+  default = []
+}

--- a/tf_files/aws/modules/eks/README.md
+++ b/tf_files/aws/modules/eks/README.md
@@ -61,6 +61,7 @@ users_policy = "fauziv1"
 * `jupyter_bootstrap_script` Script to intialize jupyter worekers. Default value `bootstrap-2.0.0.sh`
 * `kernel` If your bootstrap script requires a different kernel that what ships with the AMIs. Additionally, kernels will be uploaded onto `gen3-kernels` bucket in the CSOC account. Default value `"N/A"`
 * `jupyter_worker_drive_size` Size of the jupyter workers drive. Default 30.
+* `cidrs_to_route_to_gw` CIDRs you would like to get out skiping the proxy. This var should be a list type, Ex: `cidrs_to_route_to_gw = ["192.170.230.192/26", "192.170.230.160/27"]`. Default, empty list.
 
 ## 5. Considerations
 

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -197,20 +197,6 @@ resource "aws_route" "skip_proxy" {
   depends_on             = ["aws_route_table.eks_private"]
 }
 
-#resource "aws_route_table" "eks_private_skip_proxy" {
-#  count            = "${length(var.cidrs_to_route_to_gw)}"
-#  vpc_id           = "${data.aws_vpc.the_vpc.id}"
-#  route {
-#    cidr_block     = "${element(var.cidrs_to_route_to_gw,count.index)}"
-#    nat_gateway_id = "${data.aws_nat_gateway.the_gateway.id}"
-#  }
-#  tags {
-#    Name           = "eks_private_skip_proxy"
-#    Environment    = "${var.vpc_name}"
-#    Organization   = "Basic Service"
-#  }
-#}
-  
 
 # Apparently we cannot iterate over the resource, therefore I am querying them after creation
 data "aws_subnet_ids" "private" {
@@ -223,26 +209,16 @@ data "aws_subnet_ids" "private" {
   ]
 }
 
-#resource "aws_route_table_association" "private_kube_skip_proxy" {
-#  count          = "${random_shuffle.az.result_count}"
-#  subnet_id      = "${data.aws_subnet_ids.private.ids[count.index]}"
-#  route_table_id = "${aws_route_table.eks_private_skip_proxy[count.index].id}"
-#  lifecycle {
-#    ignore_changes = ["id", "subnet_id","tags"]
-#  }
-#}
 
 resource "aws_route_table_association" "private_kube" {
   #count          = 3
   count          = "${random_shuffle.az.result_count}"
-  #count          = "${length(data.aws_subnet_ids.private.ids)}"
   subnet_id      = "${data.aws_subnet_ids.private.ids[count.index]}"
   route_table_id = "${aws_route_table.eks_private.id}"
   lifecycle {
     # allow user to change tags interactively - ex - new kube-aws cluster
     ignore_changes = ["id", "subnet_id","tags"]
   }
-#  depends_on = ["aws_route.skip_proxy"]
 }
 
 

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -199,26 +199,28 @@ resource "aws_route" "skip_proxy" {
 
 
 # Apparently we cannot iterate over the resource, therefore I am querying them after creation
-data "aws_subnet_ids" "private" {
-  vpc_id = "${data.aws_vpc.the_vpc.id}"
-  tags {
-    Name = "eks_private_*"
-  }
-  depends_on = [
-    "aws_subnet.eks_private",
-  ]
-}
+#data "aws_subnet_ids" "private" {
+#  vpc_id = "${data.aws_vpc.the_vpc.id}"
+#  tags {
+#    Name = "eks_private_*"
+#  }
+#  depends_on = [
+#    "aws_subnet.eks_private",
+#  ]
+#}
 
 
 resource "aws_route_table_association" "private_kube" {
   #count          = 3
   count          = "${random_shuffle.az.result_count}"
-  subnet_id      = "${data.aws_subnet_ids.private.ids[count.index]}"
+  #subnet_id      = "${data.aws_subnet_ids.private.ids[count.index]}"
+  subnet_id      = "${aws_subnet.eks_private.*.id[count.index]}"
   route_table_id = "${aws_route_table.eks_private.id}"
   lifecycle {
     # allow user to change tags interactively - ex - new kube-aws cluster
-    ignore_changes = ["id", "subnet_id","tags"]
+    #ignore_changes = ["id", "subnet_id","tags"]
   }
+  depends_on = ["aws_subnet.eks_private"]
 }
 
 
@@ -240,10 +242,11 @@ resource "aws_vpc_endpoint" "k8s-logs" {
   ]
 
   private_dns_enabled = true
-  subnet_ids          = ["${data.aws_subnet_ids.private.ids}"]
+  #subnet_ids          = ["${data.aws_subnet_ids.private.ids}"]
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
   #route_table_ids    = ["${aws_route_table.eks_private.id}"]
   lifecycle {
-    ignore_changes = ["subnet_ids"]
+    #ignore_changes = ["subnet_ids"]
   }
 }
 
@@ -267,26 +270,27 @@ resource "aws_security_group" "eks_control_plane_sg" {
 
 
 # Apparently we cannot iterate over the resource, therefore I am querying them after creation
-data "aws_subnet_ids" "public_kube" {
-  vpc_id = "${data.aws_vpc.the_vpc.id}"
-  tags {
-    Name = "eks_public_*"
-  }
-  depends_on = [
-    "aws_subnet.eks_public",
-  ]
-}
+#data "aws_subnet_ids" "public_kube" {
+#  vpc_id = "${data.aws_vpc.the_vpc.id}"
+#  tags {
+#    Name = "eks_public_*"
+#  }
+#  depends_on = [
+#    "aws_subnet.eks_public",
+#  ]
+#}
 
 
 resource "aws_route_table_association" "public_kube" {
   #count          = 3
   count          = "${random_shuffle.az.result_count}"
-  subnet_id      = "${data.aws_subnet_ids.public_kube.ids[count.index]}"
+  #subnet_id      = "${data.aws_subnet_ids.public_kube.ids[count.index]}"
+  subnet_id      = "${aws_subnet.eks_public.*.id[count.index]}"
   route_table_id = "${data.aws_route_table.public_kube.id}"
 
   lifecycle {
     # allow user to change tags interactively - ex - new kube-aws cluster
-    ignore_changes = ["id", "subnet_id"]
+    #ignore_changes = ["id", "subnet_id"]
   }
 }
 

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -218,7 +218,7 @@ resource "aws_route_table_association" "private_kube" {
   route_table_id = "${aws_route_table.eks_private.id}"
   lifecycle {
     # allow user to change tags interactively - ex - new kube-aws cluster
-    #ignore_changes = ["id", "subnet_id","tags"]
+    ignore_changes = ["tags"]
   }
   depends_on = ["aws_subnet.eks_private"]
 }

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -251,6 +251,23 @@ resource "aws_vpc_endpoint" "k8s-logs" {
 }
 
 
+# Autoscaling logs endpoint
+resource "aws_vpc_endpoint" "k8s-autoscaling" {
+  vpc_id              = "${data.aws_vpc.the_vpc.id}"
+  service_name        = "${data.aws_vpc_endpoint_service.autoscaling.service_name}"
+  vpc_endpoint_type   = "Interface"
+
+  security_group_ids  = [
+    "${aws_security_group.eks_nodes_sg.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  lifecycle {
+    #ignore_changes = ["subnet_ids"]
+  }
+}
+
 
 resource "aws_security_group" "eks_control_plane_sg" {
   name        = "${var.vpc_name}-control-plane"

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -251,24 +251,6 @@ resource "aws_vpc_endpoint" "k8s-logs" {
 }
 
 
-# Autoscaling logs endpoint
-resource "aws_vpc_endpoint" "k8s-autoscaling" {
-  vpc_id              = "${data.aws_vpc.the_vpc.id}"
-  service_name        = "${data.aws_vpc_endpoint_service.autoscaling.service_name}"
-  vpc_endpoint_type   = "Interface"
-
-  security_group_ids  = [
-    "${aws_security_group.eks_nodes_sg.id}"
-  ]
-
-  private_dns_enabled = true
-  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
-  lifecycle {
-    #ignore_changes = ["subnet_ids"]
-  }
-}
-
-
 resource "aws_security_group" "eks_control_plane_sg" {
   name        = "${var.vpc_name}-control-plane"
   description = "Cluster communication with worker nodes [${var.vpc_name}]"

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -185,7 +185,7 @@ resource "aws_route_table" "eks_private" {
   }
 
   lifecycle {
-    ignore_changes = ["*"]
+    #ignore_changes = ["*"]
   }
 }
 

--- a/tf_files/aws/modules/eks/data.tf
+++ b/tf_files/aws/modules/eks/data.tf
@@ -58,6 +58,9 @@ data "aws_vpc_endpoint_service" "logs" {
   service = "logs"
 }
 
+data "aws_vpc_endpoint_service" "autoscaling" {
+  service = "autoscaling"
+}
 
 # get the route to public kube 
 data "aws_route_table" "public_kube" {

--- a/tf_files/aws/modules/eks/data.tf
+++ b/tf_files/aws/modules/eks/data.tf
@@ -54,6 +54,10 @@ data "aws_vpc_endpoint_service" "s3" {
   service = "s3"
 }
 
+data "aws_vpc_endpoint_service" "logs" {
+  service = "logs"
+}
+
 
 # get the route to public kube 
 data "aws_route_table" "public_kube" {

--- a/tf_files/aws/modules/eks/data.tf
+++ b/tf_files/aws/modules/eks/data.tf
@@ -58,10 +58,6 @@ data "aws_vpc_endpoint_service" "logs" {
   service = "logs"
 }
 
-data "aws_vpc_endpoint_service" "autoscaling" {
-  service = "autoscaling"
-}
-
 # get the route to public kube 
 data "aws_route_table" "public_kube" {
   vpc_id      = "${data.aws_vpc.the_vpc.id}"

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -50,3 +50,8 @@ variable "jupyter_bootstrap_script" {
 variable "jupyter_worker_drive_size" {
   default = 30
 }
+
+
+variable "cidrs_to_route_to_gw" {
+  default = []
+}


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Introduces a new variable to the EKS module in which you can add a list of CIDR you want to go out the internet bypassing the proxy. `cidrs_to_route_to_gw`
- A new gen3 command that would alter the routing table associated with kubernetes workers. Said command would add a CIDR to the routing table which gateway will be the NAT gateway of the commons. In other words, the provided CIDR would skip the proxy. Useful for making the workers not use the proxy for large file downloading. Command usage example: `gen3 routing skip-proxy 192.170.230.192/26`.
- Kubernetes worker would now talk to CloudWatch Logs over an endpoint instead of connecting over public IPs product of name resolution.
- Introducing EKS private communication.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

