### PR TITLE
chore(permission): to allow ES write on the loggroup PXP-2554

### DIFF
--- a/tf_files/aws/modules/commons-vpc-es/cloud.tf
+++ b/tf_files/aws/modules/commons-vpc-es/cloud.tf
@@ -75,7 +75,7 @@ resource "aws_cloudwatch_log_resource_policy" "es_logs" {
         "logs:PutLogEventsBatch",
         "logs:CreateLogStream"
       ],
-      "Resource": "arn:aws:logs:*"
+      "Resource": "${data.aws_cloudwatch_log_group.logs_group.arn}"
     }
   ]
 }
@@ -144,4 +144,5 @@ CONFIG
   lifecycle {
     ignore_changes = ["elasticsearch_version"]
   }
+  depends_on = ["aws_cloudwatch_log_resource_policy.es_logs"]
 }

--- a/tf_files/aws/modules/commons-vpc-es/cloud.tf
+++ b/tf_files/aws/modules/commons-vpc-es/cloud.tf
@@ -59,6 +59,30 @@ resource "aws_security_group" "private_es" {
 #}
 
 
+resource "aws_cloudwatch_log_resource_policy" "es_logs" {
+  policy_name = "es_logs_for_${var.vpc_name}"
+  policy_document = <<CONFIG
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "es.amazonaws.com"
+      },
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:PutLogEventsBatch",
+        "logs:CreateLogStream"
+      ],
+      "Resource": "arn:aws:logs:*"
+    }
+  ]
+}
+CONFIG
+}
+
+
 resource "aws_elasticsearch_domain" "gen3_metadata" {
   domain_name           = "${var.vpc_name}-gen3-metadata"
   elasticsearch_version = "6.3"


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

### Breaking Changes


### Bug Fixes
- Elastic search not able to write to cloudwatchlogs 

### Improvements


### Dependency updates


### Deployment changes

