### PR TITLE
fix(guppy): remove unused env var, and allow large size queries

### DIFF
--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -51,16 +51,16 @@ spec:
           livenessProbe:
             httpGet:
               path: /_status
-              port: 3000
+              port: 80
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 30
           readinessProbe:
             httpGet:
               path: /_status
-              port: 3000
+              port: 80
           ports:
-          - containerPort: 3000
+          - containerPort: 80
           env:
           - name: GUPPY_CONFIG_FILEPATH
             value: /guppy/guppy_config.json

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -68,10 +68,6 @@ spec:
             value: esproxy-service:9200
           - name: GEN3_ARBORIST_ENDPOINT
             value: http://arborist-service
-          - name: GEN3_ES_INDEX
-            value: GEN3_GUPPY_ES_INDEX|-gen3-subject-dev-|
-          - name: GEN3_ES_TYPE
-            value: GEN3_GUPPY_ES_TYPE|-subject-|
           volumeMounts:
             - name: guppy-config
               readOnly: true

--- a/kube/services/guppy/guppy-service.yaml
+++ b/kube/services/guppy/guppy-service.yaml
@@ -8,6 +8,6 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 3000 
+      targetPort: 80 
       name: http
   type: NodePort

--- a/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
@@ -3,4 +3,5 @@
               set $upstream_guppy http://guppy-service.$namespace.svc.cluster.local;
               rewrite ^/guppy/(.*) /$1 break;
               proxy_pass $upstream_guppy;
+              client_max_body_size 0;
           }


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
 - Remove unused env var from guppy config, and allow large size queries
