### PR TITLE
chore(jupyterhub): disk size from manifest

### DIFF
--- a/kube/services/jupyterhub/jupyterhub-deploy.yaml
+++ b/kube/services/jupyterhub/jupyterhub-deploy.yaml
@@ -52,6 +52,12 @@ spec:
                   name: manifest-jupyterhub
                   key: containers
                   optional: true
+            - name: NOTEBOOK_STORAGE_CAPACITY
+              valueFrom:
+                configMapKeyRef:
+                  name: manifest-jupyterhub
+                  key: nb_storage_size
+                  optional: true
           imagePullPolicy: Always
           resources:
             limits:

--- a/kube/services/jupyterhub/jupyterhub_config.py
+++ b/kube/services/jupyterhub/jupyterhub_config.py
@@ -30,7 +30,12 @@ c.KubeSpawner.notebook_dir = "/home/jovyan/pd"
 c.KubeSpawner.uid = 1000
 c.KubeSpawner.fs_gid = 100
 c.KubeSpawner.storage_pvc_ensure = True
-c.KubeSpawner.storage_capacity = "10Gi"
+
+if os.environ.get("NOTEBOOK_STORAGE_CAPACITY"):
+  c.KubeSpawner.storage_capacity = os.environ.get("NOTEBOOK_STORAGE_CAPACITY")
+else:
+  c.KubeSpawner.storage_capacity = "10Gi"
+
 c.KubeSpawner.pvc_name_template = "claim-{username}{servername}"
 c.KubeSpawner.storage_class = "jupyter-storage"
 c.KubeSpawner.volumes = [
@@ -60,7 +65,7 @@ if raw_profiles:
                 x["name"], x["cpu"], x["memory"]
             ),
             "kubespawner_override": {
-                "singleuser_image_spec": x["image"],
+                "image_spec": x["image"],
                 "cpu_limit": x["cpu"],
                 "mem_limit": x["memory"],
             },
@@ -73,7 +78,7 @@ else:
         {
             "display_name": "Bioinfo - Python/R - 0.5 CPU 256M Mem",
             "kubespawner_override": {
-                "singleuser_image_spec": "quay.io/occ_data/jupyternotebook:1.7.2",
+                "image_spec": "quay.io/occ_data/jupyternotebook:1.7.2",
                 "cpu_limit": 0.5,
                 "mem_limit": "256M",
             },


### PR DESCRIPTION
* jupyter notebook disk size configurable in manifest
* small tweak in `jupyter_config.py` to get rid of `KubeSpawner.singleuser_image_spec deprecated ...` warning

ex:
```
  "jupyterhub": {
    "enabled": "yes",
    "nb_storage_size": "20Gi"
  },
```
### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

