### PR TITLE
feat/add 'secure-level' args for guppy and portal

### DIFF
--- a/kube/services/guppy/README.md
+++ b/kube/services/guppy/README.md
@@ -1,0 +1,6 @@
+# TL;DR
+
+This folder holds kubernetes deployment and service resources for [Guppy](https://github.com/uc-cdis/guppy).
+Configure and launch Guppy with `gen3 kube-setup-guppy`.
+
+Guppy also imports configuration for the commons' manifest. The optional `tier_access_level` property in the `global` object of `manifest.json` determines the access level of a common and thus affects the behavior of Guppy. Valid options for `tier_access_level` are `libre`, `regular` and `private`. Common will be treated as `private` by default.

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -74,7 +74,7 @@ spec:
                 name: manifest-global
                 key: secure_level
                 # for now making it optional so won't break anything
-                optinal: true
+                optional: true
           volumeMounts:
             - name: guppy-config
               readOnly: true

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -68,11 +68,11 @@ spec:
             value: esproxy-service:9200
           - name: GEN3_ARBORIST_ENDPOINT
             value: http://arborist-service
-          - name: SECURE_LEVEL
+          - name: TIER_ACCESS_LEVEL
             valueFrom:
               configMapKeyRef:
                 name: manifest-global
-                key: secure_level
+                key: tier_access_level
                 # for now making it optional so won't break anything
                 optional: true
           volumeMounts:

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -72,6 +72,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: manifest-global
+                # acceptable values for `tier_access_level` are: `libre`, `regular` and `private`. If omitted, by default common will be treated as `private`
                 key: tier_access_level
                 # for now making it optional so won't break anything
                 optional: true

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -68,6 +68,13 @@ spec:
             value: esproxy-service:9200
           - name: GEN3_ARBORIST_ENDPOINT
             value: http://arborist-service
+          - name: SECURE_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: secure_level
+                # for now making it optional so won't break anything
+                optinal: true
           volumeMounts:
             - name: guppy-config
               readOnly: true

--- a/kube/services/portal/README.md
+++ b/kube/services/portal/README.md
@@ -13,6 +13,8 @@ determines which "profile" the portal runs with.  The portal's profile
 includes customizations necessary for the common's dictionary, so the `bhc` portal_app
 customizes the portal to work with the brain commons' dictionary.
 
+Second, the optional `tier_access_level` property in the `global` object of `manifest.json` determines the access level of a common. Valid options for `tier_access_level` are `libre`, `regular` and `private`. Common will be treated as `private` by default.
+
 The portal includes support for several customization profiles in its code base in various files under the [data/config](https://github.com/uc-cdis/data-portal/tree/master/data/config)
 and [custom/](https://github.com/uc-cdis/data-portal/tree/master/custom) folders.
 An environment may also define its own `gitops` profile by installing files

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -85,7 +85,7 @@ spec:
                 name: manifest-global
                 key: secure_level
                 # for now making it optional so won't break anything
-                optinal: true
+                optional: true
         volumeMounts:
           - name: "cert-volume"
             readOnly: true

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -79,11 +79,11 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: portal_app
-          - name: SECURE_LEVEL
+          - name: TIER_ACCESS_LEVEL
             valueFrom:
               configMapKeyRef:
                 name: manifest-global
-                key: secure_level
+                key: tier_access_level
                 # for now making it optional so won't break anything
                 optional: true
         volumeMounts:

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -79,6 +79,13 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: portal_app
+          - name: SECURE_LEVEL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: secure_level
+                # for now making it optional so won't break anything
+                optinal: true
         volumeMounts:
           - name: "cert-volume"
             readOnly: true

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -83,6 +83,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: manifest-global
+                # acceptable values for `tier_access_level` are: `libre`, `regular` and `private`. If omitted, by default common will be treated as `private`
                 key: tier_access_level
                 # for now making it optional so won't break anything
                 optional: true


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- A new global arg `tier_access_level` will be added to `manifest.json` to be used by both portal and guppy for tiered access
- `tier_access_level` includs `libre`, `regular` and `private`, for default commons will be using `private`

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

