### PR TITLE
chore(gen3 db): 'server info' and 'g3FarmServer'

### DIFF
--- a/doc/db.md
+++ b/doc/db.md
@@ -18,6 +18,15 @@ gen3 db creds fence
 
 ### gen3 db server list
 
+Get the credentials associated with a farm server.
+
+```
+ex: 
+gen3 db server info server1
+```
+
+### gen3 db server list
+
 List the servers in the database farm.  Note that the server for the 
 sheepdog and peregrine services is dedicated to those servers, and not
 included in the list.

--- a/gen3/test/dbTest.sh
+++ b/gen3/test/dbTest.sh
@@ -70,7 +70,17 @@ test_db_create() {
   (yes | gen3 db reset "$serviceName"); because $? "db reset should re-create the database"
   gen3 db psql "$serviceName" -c 'SELECT 1'; because $? "should be able to connect to the new service db after reset"
   
+  local serverName
+  serverName="$(gen3 db creds "$serviceName" | jq -r '.g3FarmServer')"
+  [[ "$serverName" == "server1" ]]; because $? "db creds includes new service the farm server: $serverName"
+  
   gen3 klock unlock dbctest dbctest
+}
+
+test_db_creds() {
+  local serverName
+  serverName="$(gen3 db creds fence | jq -r '.g3FarmServer')"
+  [[ "$serverName" =~ ^server[0-9]+$ ]]; because $? "db creds includes the farm server: $serverName"
 }
 
 shunit_runtest "test_db_init" "db"
@@ -79,3 +89,4 @@ shunit_runtest "test_db_random_server" "db"
 shunit_runtest "test_db_list" "db"
 shunit_runtest "test_db_namespace" "db"
 shunit_runtest "test_db_create" "db"
+shunit_runtest "test_db_creds" "db"


### PR DESCRIPTION
Can do this kind of thing:
```
serverName="$(gen3 db creds "$serviceName" | jq -r .g3FarmServer)"
dbName="$(gen3 db creds "$serviceName" | jq -r .db_database)"
gen3 db psql "$serverName" -d "$dbName" -c 'CREATE EXTENSION ltree;'
```

### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

