### PR TITLE
chore(limit): add tier_access_limit for minimum visible aggs count

### DIFF
--- a/kube/services/guppy/README.md
+++ b/kube/services/guppy/README.md
@@ -4,3 +4,5 @@ This folder holds kubernetes deployment and service resources for [Guppy](https:
 Configure and launch Guppy with `gen3 kube-setup-guppy`.
 
 Guppy also imports configuration for the commons' manifest. The optional `tier_access_level` property in the `global` object of `manifest.json` determines the access level of a common and thus affects the behavior of Guppy. Valid options for `tier_access_level` are `libre`, `regular` and `private`. Common will be treated as `private` by default.
+
+For `regular` level data commons, there's another configuration environment variable `tier_access_limit`, which is the minimum visible count for aggregation results. By default set to 1000. 

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -76,6 +76,12 @@ spec:
                 key: tier_access_level
                 # for now making it optional so won't break anything
                 optional: true
+          - name: TIER_ACCESS_LIMIT
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: tier_access_limit
+                optional: true
           volumeMounts:
             - name: guppy-config
               readOnly: true

--- a/kube/services/portal/README.md
+++ b/kube/services/portal/README.md
@@ -14,6 +14,7 @@ includes customizations necessary for the common's dictionary, so the `bhc` port
 customizes the portal to work with the brain commons' dictionary.
 
 Second, the optional `tier_access_level` property in the `global` object of `manifest.json` determines the access level of a common. Valid options for `tier_access_level` are `libre`, `regular` and `private`. Common will be treated as `private` by default.
+For `regular` level data commons, there's another configuration environment variable `tier_access_limit`, which is the minimum visible count for aggregation results. By default set to 1000. 
 
 The portal includes support for several customization profiles in its code base in various files under the [data/config](https://github.com/uc-cdis/data-portal/tree/master/data/config)
 and [custom/](https://github.com/uc-cdis/data-portal/tree/master/custom) folders.

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -87,6 +87,12 @@ spec:
                 key: tier_access_level
                 # for now making it optional so won't break anything
                 optional: true
+          - name: TIER_ACCESS_LIMIT
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: tier_access_limit
+                optional: true
         volumeMounts:
           - name: "cert-volume"
             readOnly: true


### PR DESCRIPTION
For `regular` tier-access-level data commons, add `tier_access_limit` to portal and guppy, for minimum visible count for aggregation results.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
 - For `regular` tier-access-level data commons, add `tier_access_limit` to portal and guppy, for minimum visible count for aggregation results.

### Dependency updates


### Deployment changes

