### PR TITLE
fix(move-ssh-copy): Moved the ssh key copy to the top of the bootsrap…

### DIFF
--- a/flavors/eks/bootstrap-2.0.0.sh
+++ b/flavors/eks/bootstrap-2.0.0.sh
@@ -3,6 +3,8 @@
 # User data for our EKS worker nodes basic arguments to call the bootstrap script for EKS images 
 # More info https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
  
+sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/authorized_keys
+
 sudo sysctl fs.inotify.max_user_watches=12000
 
 KUBELET_EXTRA_ARGUMENTS="--node-labels=role=${nodepool}"
@@ -16,5 +18,3 @@ fi
 cat > /home/ec2-user/.ssh/authorized_keys <<EFO
 ${ssh_keys}
 EFO
-
-sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/authorized_keys

--- a/flavors/eks/bootstrap-2.1.0.sh
+++ b/flavors/eks/bootstrap-2.1.0.sh
@@ -2,6 +2,8 @@
 
 # User data for our EKS worker nodes basic arguments to call the bootstrap script for EKS images 
 # More info https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
+
+sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/authorized_keys
  
 sudo sysctl fs.inotify.max_user_watches=12000
 
@@ -43,8 +45,6 @@ fi
 cat > /home/ec2-user/.ssh/authorized_keys <<EFO
 ${ssh_keys}
 EFO
-
-sudo cp /home/ec2-user/.ssh/authorized_keys /root/.ssh/authorized_keys
 
 # forcing a restart of docker at the very end, it seems like the changes are not picked up for some reason
 systemctl daemon-reload


### PR DESCRIPTION
… script so that users can login and troubleshoot if script fails

Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

### Breaking Changes


### Bug Fixes
Moved the ssh key copy to the top of the bootsrap script so that users can login and troubleshoot if script fails

### Improvements


### Dependency updates


### Deployment changes

