### PR TITLE
Removing the private_user route table for updates

### DIFF
--- a/flavors/squid_auto/default_ip_route_and_instance_check_config.sh
+++ b/flavors/squid_auto/default_ip_route_and_instance_check_config.sh
@@ -6,7 +6,7 @@ server_int=$(route | grep '^default' | grep -o '[^ ]*$')
 instance_ip=$(ip -f inet -o addr show $server_int|cut -d\  -f 7 | cut -d/ -f 1)
 route_table_id1=$(sed -n -e '/VAR2/ s/.*\= *//p' /home/ubuntu/squid_auto_user_variable)
 route_table_id2=$(sed -n -e '/VAR3/ s/.*\= *//p' /home/ubuntu/squid_auto_user_variable)
-route_table_id3=$(sed -n -e '/VAR4/ s/.*\= *//p' /home/ubuntu/squid_auto_user_variable)
+
 
 squid_auto_interface_id=$(aws ec2 describe-instances  --filters "Name=network-interface.addresses.private-ip-address,Values=$instance_ip" --query 'Reservations[*].Instances[*].{ID:NetworkInterfaces[0].NetworkInterfaceId}' --region us-east-1 --output text)
 
@@ -26,10 +26,7 @@ aws ec2 replace-route  --route-table-id $route_table_id2 --destination-cidr-bloc
 
 
 
-echo "Creating the default route for private user route table ....."
-aws ec2 create-route  --route-table-id $route_table_id3 --destination-cidr-block 0.0.0.0/0 --network-interface-id $squid_auto_interface_id --region us-east-1
-echo "Updating the default route for private user route table ...."
-aws ec2 replace-route  --route-table-id $route_table_id3 --destination-cidr-block 0.0.0.0/0 --network-interface-id $squid_auto_interface_id --region us-east-1
+
 
 
 ## disable the source destination check on the instance

--- a/flavors/squid_auto/squid_auto_user_variable
+++ b/flavors/squid_auto/squid_auto_user_variable
@@ -1,5 +1,5 @@
 VAR1dnszoneid = DNS_ZONE_ID
 VAR2eksroutetableid = EKS_ROUTETABLE_ID
 VAR3privatekuberoutetableid = PRIVATE_KUBE_ROUTETABLE_ID
-VAR4privateuserroutetableid = PRIVATE_USER_ROUTETABLE_ID
+
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -273,7 +273,7 @@ sudo cp /home/ubuntu/cloud-automation/flavors/squid_auto/squid_auto_user_variabl
 sudo sed -i "s/DNS_ZONE_ID/${data.aws_route53_zone.vpczone.zone_id}/" /home/ubuntu/squid_auto_user_variable
 sudo sed -i "s/EKS_ROUTETABLE_ID/${data.aws_route_table.eks_private_route_table.id}/" /home/ubuntu/squid_auto_user_variable
 sudo sed -i "s/PRIVATE_KUBE_ROUTETABLE_ID/${data.aws_route_table.private_kube_route_table.id}/" /home/ubuntu/squid_auto_user_variable
-#sudo sed -i "s/PRIVATE_USER_ROUTETABLE_ID/${data.aws_route_table.private_user_route_table.id}/" /home/ubuntu/squid_auto_user_variable
+
 
 
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,8 +243,8 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-git checkout fix/squidautoroutetable
-git pull
+#git checkout fix/squidautoroutetable
+#git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,8 +243,8 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-#git checkout fix/squid_auto_activestandby
-#git pull
+git checkout fix/squidautoroutetable
+git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,8 +243,8 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-#git checkout fix/squidautoroutetable
-#git pull
+git checkout fix/squidautoroutetable
+git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -110,12 +110,12 @@ data "aws_route_table" "private_kube_route_table" {
 }
 
 # get the private user table id 
-data "aws_route_table" "private_user_route_table" {
-  vpc_id      = "${data.aws_vpc.the_vpc.id}"
-  tags {
-    Name = "private_user"
-  }
-}
+#data "aws_route_table" "private_user_route_table" {
+#  vpc_id      = "${data.aws_vpc.the_vpc.id}"
+#  tags {
+#    Name = "private_user"
+#  }
+#}
 
 
 #get the internal zone id
@@ -273,7 +273,7 @@ sudo cp /home/ubuntu/cloud-automation/flavors/squid_auto/squid_auto_user_variabl
 sudo sed -i "s/DNS_ZONE_ID/${data.aws_route53_zone.vpczone.zone_id}/" /home/ubuntu/squid_auto_user_variable
 sudo sed -i "s/EKS_ROUTETABLE_ID/${data.aws_route_table.eks_private_route_table.id}/" /home/ubuntu/squid_auto_user_variable
 sudo sed -i "s/PRIVATE_KUBE_ROUTETABLE_ID/${data.aws_route_table.private_kube_route_table.id}/" /home/ubuntu/squid_auto_user_variable
-sudo sed -i "s/PRIVATE_USER_ROUTETABLE_ID/${data.aws_route_table.private_user_route_table.id}/" /home/ubuntu/squid_auto_user_variable
+#sudo sed -i "s/PRIVATE_USER_ROUTETABLE_ID/${data.aws_route_table.private_user_route_table.id}/" /home/ubuntu/squid_auto_user_variable
 
 
 


### PR DESCRIPTION
Description about what this pull request does:

Getting rid of the route updates for private_user route table; as this route table has been removed in commons now.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

