### PR TITLE
Squid_auto commons role change for the squidVMs as per the commons name

### DIFF
--- a/flavors/squid_auto/healthcheck_status.sh
+++ b/flavors/squid_auto/healthcheck_status.sh
@@ -8,9 +8,11 @@ for i in {1..12}
 do
 timestamp=$(date)
 
-count_stat1=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Healthy | awk '{print NF}')
+COMMONS_SQUID_AUTO_ROLE=$(sed -n -e '/VAR4/ s/.*\= *//p' /home/ubuntu/squid_auto_user_variable)
 
-count_stat2=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names commons_squid_auto_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Unhealthy | awk '{print NF}')
+count_stat1=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names ${COMMONS_SQUID_AUTO_ROLE}_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Healthy | awk '{print NF}')
+
+count_stat2=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names ${COMMONS_SQUID_AUTO_ROLE}_autoscaling_grp --region us-east-1  --query AutoScalingGroups[].Instances[].HealthStatus --output text | grep -w Unhealthy | awk '{print NF}')
 
 
 

--- a/flavors/squid_auto/squid_auto_user_variable
+++ b/flavors/squid_auto/squid_auto_user_variable
@@ -1,5 +1,6 @@
 VAR1dnszoneid = DNS_ZONE_ID
 VAR2eksroutetableid = EKS_ROUTETABLE_ID
 VAR3privatekuberoutetableid = PRIVATE_KUBE_ROUTETABLE_ID
+VAR4commons_squid_role = COMMONS_SQUID_ROLE
 
 

--- a/flavors/squid_auto/squidvm.sh
+++ b/flavors/squid_auto/squidvm.sh
@@ -75,7 +75,7 @@ sudo apt install -y curl jq python-pip apt-transport-https ca-certificates softw
 sudo pip install --upgrade pip
 ACCOUNT_ID=$(curl -s ${MAGIC_URL}iam/info | jq '.InstanceProfileArn' |sed -e 's/.*:://' -e 's/:.*//')
 #ROLE_NAME=$(curl -s ${MAGIC_URL}iam/info | jq '.InstanceProfileArn'|sed -e 's/.*instance-profile\///' -e 's/_squid.*//')
-
+COMMONS_SQUID_AUTO_ROLE=$(sed -n -e '/VAR4/ s/.*\= *//p' /home/ubuntu/squid_auto_user_variable)
 # Let's install awscli and configure it
 # Adding AWS profile to the admin VM
 sudo pip install awscli
@@ -85,7 +85,7 @@ sudo cat <<EOT  >> /home/ubuntu/.aws/config
 output = json
 region = us-east-1
 role_session_name = gen3-squidautovm
-role_arn = arn:aws:iam::${ACCOUNT_ID}:role/commons_squid_auto_role
+role_arn = arn:aws:iam::${ACCOUNT_ID}:role/${COMMONS_SQUID_AUTO_ROLE}_role
 credential_source = Ec2InstanceMetadata
 EOT
 sudo chown ubuntu:ubuntu -R /home/ubuntu

--- a/gen3/lib/aws.sh
+++ b/gen3/lib/aws.sh
@@ -276,7 +276,8 @@ EOM
     cat - <<EOM
   env_vpc_name         = "VPC-NAME"
   vpc_cidr             = "VPC_CIDR"
-  squid_proxy_subnet = "ASSIGNED SUBNET FOR SQUID SET-UP a /24"
+  squid_proxy_subnet = "ASSIGN SUBNET FOR SQUID SET-UP a /24"
+  env_squid_name     = "ASSING A SQUID NAME AS '<commons_name>_squid_auto_setup' "
 EOM
     return 0
   fi

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -273,6 +273,8 @@ sudo cp /home/ubuntu/cloud-automation/flavors/squid_auto/squid_auto_user_variabl
 sudo sed -i "s/DNS_ZONE_ID/${data.aws_route53_zone.vpczone.zone_id}/" /home/ubuntu/squid_auto_user_variable
 sudo sed -i "s/EKS_ROUTETABLE_ID/${data.aws_route_table.eks_private_route_table.id}/" /home/ubuntu/squid_auto_user_variable
 sudo sed -i "s/PRIVATE_KUBE_ROUTETABLE_ID/${data.aws_route_table.private_kube_route_table.id}/" /home/ubuntu/squid_auto_user_variable
+sudo sed -i "s/COMMONS_SQUID_ROLE/${var.env_squid_name}/" /home/ubuntu/squid_auto_user_variable
+
 
 
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,8 +243,8 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-git checkout fix/squidauto_rolechange
-git pull
+#git checkout fix/squidauto_rolechange
+#git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -243,8 +243,8 @@ cd /home/ubuntu/cloud-automation
 git pull
 
 # This is needed temporarily for testing purposes ; before merging the code to master
-#git checkout fix/squidautoroutetable
-#git pull
+git checkout fix/squidauto_rolechange
+git pull
 
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 

--- a/tf_files/aws/modules/squid_auto/variables.tf
+++ b/tf_files/aws/modules/squid_auto/variables.tf
@@ -15,7 +15,7 @@ variable "env_vpc_name" {
 }
 
 variable "env_squid_name" {
-  default = "commons_squid_auto"
+  #default = "commons_squid_auto"
 }
 
 

--- a/tf_files/aws/squid_auto/variables.tf
+++ b/tf_files/aws/squid_auto/variables.tf
@@ -14,7 +14,7 @@ variable "env_vpc_name" {
 }
 
 variable "env_squid_name" {
-  default = "commons_squid_auto"
+ # default = "commons_squid_auto"
 }
 
 


### PR DESCRIPTION
Description about what this pull request does.
The roles on the VMs were sharing the same role name; which have created issues for accounts which have more than 1 commons. Moved a static variable as user variable to take care of it.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

