### PR TITLE
fix(typo): guppy readme has a typo, camelCase should be underscore style

### DIFF
--- a/kube/services/guppy/README.md
+++ b/kube/services/guppy/README.md
@@ -22,7 +22,7 @@ Please add following block into your `manifest.json`:
     },
     ...
   ],
-  "configIndex": "${ES_ARRAY_CONFIG}", // optional, if there's array field, Guppy read the configs from this index.
+  "config_index": "${ES_ARRAY_CONFIG}", // optional, if there's array field, Guppy read the configs from this index.
   "auth_filter_field": "${AUTH_FILTER_FIELD}",
 },
 ```


### PR DESCRIPTION
In guppy readme there's a typo, camelCase should be underscore style

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

