### PR TITLE
fix(revproxy): track $upstream in logs

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -6,7 +6,8 @@ location = /gen3-authz {
     internal;
     error_page 400 =403 @errorworkspace;
     error_page 500 =403 @errorworkspace;
-              
+    
+    # avoid setting $upstream in authz subrequests ...
     set $upstream_authz http://${arborist_release_name}-service.$namespace.svc.cluster.local;
 
     proxy_pass $upstream_authz/auth/proxy?resource=$authz_resource&method=$authz_method&service=$authz_service;

--- a/kube/services/revproxy/gen3.nginx.conf/arranger-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arranger-service.conf
@@ -6,8 +6,9 @@
               #  return 403 "failed csrf check";
               #}
               set $proxy_service  "arranger";
-              set $upstream_arranger http://arranger-service.$namespace.svc.cluster.local;
+              # this goes into the logs ...
+              set $upstream http://arranger-service.$namespace.svc.cluster.local;
               rewrite ^/api/v0/flat-search/(.*) /$1 break;
-              proxy_pass $upstream_arranger;
+              proxy_pass $upstream;
               client_max_body_size 0;
           }

--- a/kube/services/revproxy/gen3.nginx.conf/google-sa-validation-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/google-sa-validation-service.conf
@@ -1,6 +1,7 @@
           location /google-sa-validation-status/ {
               set $proxy_service  "google-sa-validation";
-              set $upstream_sa http://google-sa-validation-service.$namespace.svc.cluster.local;
+              # $upstream is written to logs ...
+              set $upstream http://google-sa-validation-service.$namespace.svc.cluster.local;
               rewrite ^/google-sa-validation-status/(.*) /$1 break;
-              proxy_pass $upstream_sa;
+              proxy_pass $upstream;
           }

--- a/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
@@ -1,7 +1,8 @@
           location /guppy/ {
               set $proxy_service  "guppy";
-              set $upstream_guppy http://guppy-service.$namespace.svc.cluster.local;
+              # upstream is written to logs
+              set $upstream http://guppy-service.$namespace.svc.cluster.local;
               rewrite ^/guppy/(.*) /$1 break;
-              proxy_pass $upstream_guppy;
+              proxy_pass $upstream;
               client_max_body_size 0;
           }

--- a/kube/services/revproxy/gen3.nginx.conf/jupyterhub-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/jupyterhub-service.conf
@@ -22,8 +22,9 @@
               # if not using the jupyterhub service
               # this isn't dev namespace friendly, must be manually updated
               set $proxy_service  "jupyterhub";
-              set $upstream_jh http://jupyterhub-service.$namespace.svc.cluster.local:8000;
-              proxy_pass $upstream_jh;
+              # $upstream is written to logs
+              set $upstream http://jupyterhub-service.$namespace.svc.cluster.local:8000;
+              proxy_pass $upstream;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/kube/services/revproxy/gen3.nginx.conf/pidgin-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/pidgin-service.conf
@@ -9,7 +9,8 @@
               }
 
               set $proxy_service  "pidgin";
-              set $upstream_pidgin http://pidgin-service.$namespace.svc.cluster.local;
+              # $upstream is written to the logs
+              set $upstream http://pidgin-service.$namespace.svc.cluster.local;
               rewrite ^/coremetadata/(.*) /$1 break;
-              proxy_pass $upstream_pidgin;
+              proxy_pass $upstream;
           }

--- a/kube/services/revproxy/gen3.nginx.conf/portal-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/portal-service.conf
@@ -4,6 +4,7 @@
               }
 
               set $proxy_service  "portal";
-              set $upstream_portal http://portal-service.$namespace.svc.cluster.local;
-              proxy_pass $upstream_portal;
+              # $upstream is written to the logs
+              set $upstream http://portal-service.$namespace.svc.cluster.local;
+              proxy_pass $upstream;
           }

--- a/kube/services/revproxy/gen3.nginx.conf/shiny-nb2-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/shiny-nb2-service.conf
@@ -3,8 +3,9 @@
 
               # Use this variable so nginx won't error out on start
               set $proxy_service  "shiny";
-              set $upstream_shiny http://shiny-nb2-service.$namespace.svc.cluster.local:3838;
-              proxy_pass $upstream_shiny;
+              # $upstream is written to the logs
+              set $upstream http://shiny-nb2-service.$namespace.svc.cluster.local:3838;
+              proxy_pass $upstream;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/kube/services/revproxy/gen3.nginx.conf/shiny-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/shiny-service.conf
@@ -7,8 +7,9 @@
 
               # Use this variable so nginx won't error out on start
               set $proxy_service  "shiny";
-              set $upstream_shiny http://shiny-service.$namespace.svc.cluster.local:3838;
-              proxy_pass $upstream_shiny;
+              # $upstream is written to the logs
+              set $upstream http://shiny-service.$namespace.svc.cluster.local:3838;
+              proxy_pass $upstream;
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;
               proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/kube/services/revproxy/gen3.nginx.conf/sower-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/sower-service.conf
@@ -6,9 +6,10 @@
 
               # Use this variable so nginx won't error out on start
               set $proxy_service  "sower";
-              set $upstream_shiny http://sower-service.$namespace.svc.cluster.local;
+              # $upstream is written to the logs
+              set $upstream http://sower-service.$namespace.svc.cluster.local;
               rewrite ^/job/(.*) /$1 break;
-              proxy_pass $upstream_shiny;
+              proxy_pass $upstream;
               proxy_set_header Authorization "$access_token";
               proxy_set_header Host $host;
               proxy_set_header X-Real-IP $remote_addr;

--- a/kube/services/revproxy/gen3.nginx.conf/workspace-token-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/workspace-token-service.conf
@@ -14,7 +14,8 @@
               proxy_set_header   X-VisitorId "$visitor_id";
 
               set $proxy_service  "wts";
-              set $upstream_wts http://workspace-token-service.$namespace.svc.cluster.local;
+              # $upstream is written to the logs
+              set $upstream http://workspace-token-service.$namespace.svc.cluster.local;
               rewrite ^/wts/(.*) /$1 break;
-              proxy_pass $upstream_wts;
+              proxy_pass $upstream;
           }


### PR DESCRIPTION
The $upstream variable was not being set correctly in many cases, so revproxy logs were missing that useful data

### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

