### PR TITLE
feat(usersync): add arguments to modify dbgap syncing logic without m…

### DIFF
--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -1,14 +1,26 @@
 #
 # run with:
-# gen3 job run usersync FORCE true
-# NOTE: FORCE is an optional argument. Will default to "false"
+# gen3 job run usersync
 #
-# FORCE
-#    Force running full userync without doing diff of user.yaml
+# Optional Arguments:
+#     FORCE Force running full userync without doing diff of user.yaml
+#           default: false
+#           ex: gen3 job run usersync FORCE true
+#
+#     ADD_DBGAP Force attempting a dbgap sync if "true", falls back to manifest configuration
+#               by defualt. i.e. this isn't required for a dbGaP sync to happen
+#               default: "false" - fall back to manifest configuration
+#               ex: gen3 job run usersync ADD_DBGAP true
+#
+#     ONLY_DBGAP Forces ONLY a dbgap sync if "true", IGNORING user.yaml
+#                default: "false"
+#                ex: gen3 job run usersync ONLY_DBGAP true
 #
 # Examples
 # gen3 job run usersync
 # gen3 job run usersync FORCE true
+# gen3 job run usersync ADD_DBGAP true
+# gen3 job run usersync ONLY_DBGAP true
 #
 apiVersion: batch/v1
 kind: Job
@@ -78,6 +90,10 @@ spec:
                 key: sync_from_dbgap
           - name: FORCE
             GEN3_FORCE|-value: "false"-|
+          - name: ADD_DBGAP
+            GEN3_ADD_DBGAP|-value: "false"-|
+          - name: ONLY_DBGAP
+            GEN3_ONLY_DBGAP|-value: "false"-|
         volumeMounts:
           - name: shared-data
             mountPath: /mnt/shared
@@ -140,10 +156,19 @@ spec:
               sleep 2
               let count=$count+1
             done
-            if [ ! "$SYNC_FROM_DBGAP" = True ]; then
+
+            if [[ "$ONLY_DBGAP" == "true" ]]; then
+              echo "ONLY_DBGAP arg provided... forcing a sync from dbGaP and IGNORING user.yaml"
+              fence-create sync --arborist http://arborist-service --sync_from_dbgap True --projects /var/www/fence/projects.yaml
+            elif [ ! "$SYNC_FROM_DBGAP" = True ]; then
               if [[ -f /mnt/shared/user.yaml ]]; then
-                if [[ "$FORCE" == "true" ]]; then
-                  echo "running fence-create"
+                # if manifest said not to sync from dbgap, there's a user.yaml, and
+                # ADD_DBGAP arg was provided, we should force a sync using dbgap AND the user.yaml
+                if [[ "$ADD_DBGAP" == "true" ]]; then
+                  echo "ADD_DBGAP arg provided... forcing a sync from both dbGaP AND user.yaml"
+                  fence-create sync --arborist http://arborist-service --sync_from_dbgap True --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml
+                elif [[ "$FORCE" == "true" ]]; then
+                  echo "FORCE arg provided... ignoring user.yaml diff and forcing a usersync anyway"
                   fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml
                 else
                   echo "fence container user.yaml diff ..."
@@ -156,9 +181,16 @@ spec:
                   fi
                 fi
               else
+                # if manifest said not to sync from dbgap, there's NOT a user.yaml, and
+                # ADD_DBGAP arg was provided, we should at least force a sync using dbgap
+                if [[ "$ADD_DBGAP" == "true" ]]; then
+                  echo "ADD_DBGAP arg provided... forcing a sync from dbGaP"
+                  fence-create sync --arborist http://arborist-service --sync_from_dbgap True --projects /var/www/fence/projects.yaml
+                fi
                 echo "/mnt/shared/user.yaml did not appear within timeout :-("
               fi
             else
+              # manifest says to sync from dbgap, so check if there's also a user.yaml to sync
               if [[ -f /mnt/shared/user.yaml ]]; then
                 fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml
               else


### PR DESCRIPTION
This is primarily to support integration tests running dbGaP syncing without mucking up the env's manifest and secrets. Mostly just to prevent the situation where it doesn't correctly revert the manifest back to do a normal usersync (so future test runs in the env will fail).

The new arguments allow integration tests to run dbGaP syncing without messing with the environments manifest. Previous functionality is also maintained.

### New Features
- added new arguments to usersync job to force dbGaP syncing without modifying the env's manifest

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

