### PR TITLE
chore(authz-migration): add job to set authz fields

### DIFF
--- a/kube/services/jobs/indexd-authz-job.yaml
+++ b/kube/services/jobs/indexd-authz-job.yaml
@@ -1,0 +1,62 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: indexd-authz
+spec:
+  template:
+    metadata:
+      labels:
+        app: gen3job
+    spec:
+      automountServiceAccountToken: false
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: "indexd-secret"
+        - name: "sheepdog-creds-volume"
+          secret:
+            secretName: "sheepdog-creds"
+        - name: "indexd-creds-volume"
+          secret:
+            secretName: "indexd-creds"
+        - name: config-helper
+          configMap:
+            name: config-helper
+      containers:
+        - name: indexd
+          GEN3_INDEXD_IMAGE
+          volumeMounts:
+            - name: "config-volume"
+              readOnly: true
+              mountPath: "/var/www/indexd/local_settings.py"
+              subPath: "local_settings.py"
+            - name: "sheepdog-creds-volume"
+              readOnly: true
+              mountPath: "/var/www/indexd/sheepdog_creds.json"
+              subPath: creds.json
+            - name: "indexd-creds-volume"
+              readOnly: true
+              mountPath: "/var/www/indexd/creds.json"
+              subPath: creds.json
+            - name: "config-helper"
+              readOnly: true
+              mountPath: "/var/www/indexd/config_helper.py"
+              subPath: config_helper.py  
+          imagePullPolicy: Always
+          command: ["/bin/bash"]
+          args:
+            - "-c"
+            - |
+              db_uri=$(python - <<- EOF
+              from base64 import b64decode
+              import json
+
+              with open("/var/www/indexd/sheepdog_creds.json") as f:
+                  creds = json.loads(f.read())
+
+              print("postgres://{}:{}@{}:5432/{}".format(creds["db_username"], creds["db_password"], creds["db_host"], creds["db_database"]))
+              EOF
+              )
+              python /indexd/bin/migrate_acl_authz.py --path "/var/www/indexd/" --sheepdog-db "$db_uri" --arborist-url "http://arborist-service"
+              echo "Exit code: $?"
+      restartPolicy: Never

--- a/kube/services/jobs/indexd-authz-job.yaml
+++ b/kube/services/jobs/indexd-authz-job.yaml
@@ -32,6 +32,10 @@ spec:
                   name: manifest-global
                   key: auth_namespace
                   optional: true
+            - name: START_DID
+              GEN3_START_DID|-value: ""-|
+            - name: USE_SHEEPDOG
+              GEN3_USE_SHEEPDOG|-value: ""-|
           volumeMounts:
             - name: "config-volume"
               readOnly: true
@@ -54,7 +58,9 @@ spec:
           args:
             - "-c"
             - |
-              db_uri=$(python - <<- EOF
+              flags="--path /var/www/indexd/ --arborist-url http://arborist-service"
+              if [[ "$USE_SHEEPDOG" == "true" ]]; then
+                db_uri=$(python - <<- EOF
               from base64 import b64decode
               import json
 
@@ -63,7 +69,12 @@ spec:
 
               print("postgres://{}:{}@{}:5432/{}".format(creds["db_username"], creds["db_password"], creds["db_host"], creds["db_database"]))
               EOF
-              )
-              python /indexd/bin/migrate_acl_authz.py --path "/var/www/indexd/" --sheepdog-db "$db_uri" --arborist-url "http://arborist-service"
+                )
+                flags="$flags --sheepdog-db $db_uri"
+              fi
+              if [[ -n "$START_DID" ]]; then
+                flags="$flags --start-did $START_DID"
+              fi
+              python /indexd/bin/migrate_acl_authz.py $flags
               echo "Exit code: $?"
       restartPolicy: Never

--- a/kube/services/jobs/indexd-authz-job.yaml
+++ b/kube/services/jobs/indexd-authz-job.yaml
@@ -35,7 +35,7 @@ spec:
             - name: START_DID
               GEN3_START_DID|-value: ""-|
             - name: USE_SHEEPDOG
-              GEN3_USE_SHEEPDOG|-value: ""-|
+              GEN3_USE_SHEEPDOG|-value: "true"-|
           volumeMounts:
             - name: "config-volume"
               readOnly: true

--- a/kube/services/jobs/indexd-authz-job.yaml
+++ b/kube/services/jobs/indexd-authz-job.yaml
@@ -25,6 +25,12 @@ spec:
       containers:
         - name: indexd
           GEN3_INDEXD_IMAGE
+          env:
+            - name: AUTH_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: manifest-global
+                  key: auth_namespace
           volumeMounts:
             - name: "config-volume"
               readOnly: true
@@ -41,7 +47,7 @@ spec:
             - name: "config-helper"
               readOnly: true
               mountPath: "/var/www/indexd/config_helper.py"
-              subPath: config_helper.py  
+              subPath: config_helper.py
           imagePullPolicy: Always
           command: ["/bin/bash"]
           args:

--- a/kube/services/jobs/indexd-authz-job.yaml
+++ b/kube/services/jobs/indexd-authz-job.yaml
@@ -31,6 +31,7 @@ spec:
                 configMapKeyRef:
                   name: manifest-global
                   key: auth_namespace
+                  optional: true
           volumeMounts:
             - name: "config-volume"
               readOnly: true


### PR DESCRIPTION
### New Features

- Add `indexd-authz` job to set the `authz` fields in index records according to their existing ACLs.