### PR TITLE
Fix/500s

### DIFF
--- a/gen3/bin/kube-dev-namespace.sh
+++ b/gen3/bin/kube-dev-namespace.sh
@@ -77,7 +77,7 @@ if [[ ! -d ./cdis-manifest ]]; then
 fi
 
 # setup ~/vpc_name
-for name in 00configmap.yaml apis_configs kubeconfig; do
+for name in 00configmap.yaml apis_configs kubeconfig ssh-keys; do
   cp -r ~/${vpc_name}/$name /home/$namespace/${vpc_name}/$name
 done
 

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -240,6 +240,7 @@ server {
   proxy_set_header   X-ReqId "$request_id";
   proxy_set_header   X-SessionId "$session_id";
   proxy_set_header   X-VisitorId "$visitor_id";
+  proxy_intercept_errors on;
 
   #
   # Accomodate large jwt token headers
@@ -300,6 +301,13 @@ server {
     set $manifestservice_release_name "${manifestservice_release_name}-canary";
   }
   set $arborist_release_name "arborist";
+
+  error_page 500 501 502 503 504 @5xx;
+
+  location @5xx {
+      internal;
+      return 500 "{ \"error\": \"service failure - try again later\"}";
+  }
 
   include /etc/nginx/gen3.conf/*.conf;
 


### PR DESCRIPTION
* include fence `ssh-keys/` in `kube-dev-namespace` setup
* add 500 error page to reverse proxy to avoid leaking information in service explosions
https://ctds-planx.atlassian.net/browse/PXP-3128

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

