### PR TITLE
feat(consent-codes): add auth namespace var to sheepdog

### DIFF
--- a/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
@@ -91,6 +91,12 @@ spec:
                 name: manifest-global
                 key: fence_url
                 optional: true
+          - name: AUTH_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: auth_namespace
+                optional: true
           - name: REQUESTS_CA_BUNDLE
             #
             # override python 'requests' SSL certificate bundle
@@ -112,7 +118,7 @@ spec:
             - name: "config-helper"
               readOnly: true
               mountPath: "/var/www/sheepdog/config_helper.py"
-              subPath: config_helper.py  
+              subPath: config_helper.py
             - name: "cert-volume"
               readOnly: true
               mountPath: "/mnt/ssl/service.crt"

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -91,6 +91,12 @@ spec:
                 name: manifest-global
                 key: fence_url
                 optional: true
+          - name: AUTH_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: auth_namespace
+                optional: true
           - name: REQUESTS_CA_BUNDLE
             #
             # override python 'requests' SSL certificate bundle
@@ -112,7 +118,7 @@ spec:
             - name: "config-helper"
               readOnly: true
               mountPath: "/var/www/sheepdog/config_helper.py"
-              subPath: config_helper.py  
+              subPath: config_helper.py
             - name: "cert-volume"
               readOnly: true
               mountPath: "/mnt/ssl/service.crt"


### PR DESCRIPTION
- Add `AUTH_NAMESPACE` env to sheepdog from `auth_namespace` in the manifest. Supports [this PR](https://github.com/uc-cdis/sheepdog/pull/288) so we can actually add resource paths to metadata entries on submission.