### PR TITLE
Allow credentials origin white list

### DIFF
--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -13,6 +13,7 @@ load_module modules/ngx_http_perl_module.so;
 ##
 env POD_NAMESPACE;
 env CANARY_PERCENT_JSON;
+env ORIGINS_ALLOW_CREDENTIALS;
 
 events {
 worker_connections 768;
@@ -121,6 +122,12 @@ gzip_types
 perl_set $namespace 'sub { return $ENV{"POD_NAMESPACE"}; }';
 
 ##
+# CORS Credential White List
+##
+perl_set $origins_allow_credentials 'sub { return $ENV{"ORIGINS_ALLOW_CREDENTIALS"}; }';
+js_set $credentials_allowed isCredentialsAllowed;
+
+##
 # Proxy Settings
 ##
 # Serve internet facing http requests via this, and redirect to https
@@ -159,13 +166,7 @@ server {
 
   more_set_headers "Access-Control-Allow-Origin: $allow_origin";
   more_set_headers "Access-Control-Allow-Methods: GET, POST, OPTIONS";
-  #
-  # DO NOT DO THIS!!!
-  # Opens us up to CSRF requests from sites in other tabs ...
-  # TODO - add CORS whitelist to gitops
-  # https://stackoverflow.com/questions/24687313/what-exactly-does-the-access-control-allow-credentials-header-do
-  #
-  #more_set_headers "Access-Control-Allow-Credentials: true";
+  more_set_headers "Access-Control-Allow-Credentials: $credentials_allowed";
   more_set_headers "Access-Control-Allow-Headers: DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,Cookie,X-CSRF-Token";
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -81,6 +81,12 @@ spec:
               configMapKeyRef:
                 name: manifest-canary
                 key: json
+          - name: ORIGINS_ALLOW_CREDENTIALS
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: origins_allow_credentials
+                optional: true
         volumeMounts:
           - name: "revproxy-conf"
             readOnly: true


### PR DESCRIPTION
Fixed TODO about setting `Access-Control-Allow-Credentials: true` which is required for NIAID `tb` and `charlie` sub-commons.

### New Features
- Added `origins_allow_credentials` in `global-manifest` to support sending cookies to trusted origins
