### PR TITLE
chore(deprecate-signpost): add indexclient env vars/config

### DIFF
--- a/apis_configs/peregrine_settings.py
+++ b/apis_configs/peregrine_settings.py
@@ -13,9 +13,14 @@ config["AUTH"] = 'https://auth.service.consul:5000/v3/'
 config["AUTH_ADMIN_CREDS"] = None
 config["INTERNAL_AUTH"] = None
 
-# Signpost
+# Signpost: deprecated, replaced by index client.
 config['SIGNPOST'] = {
     'host': environ.get('SIGNPOST_HOST') or 'http://indexd-service',
+    'version': 'v0',
+    'auth': ('gdcapi', conf_data.get( 'indexd_password', '{{indexd_password}}')),
+}
+config['INDEX_CLIENT'] = {
+    'host': environ.get('INDEX_CLIENT_HOST') or 'http://indexd-service',
     'version': 'v0',
     'auth': ('gdcapi', conf_data.get( 'indexd_password', '{{indexd_password}}')),
 }

--- a/apis_configs/sheepdog_settings.py
+++ b/apis_configs/sheepdog_settings.py
@@ -13,9 +13,14 @@ config["AUTH"] = 'https://auth.service.consul:5000/v3/'
 config["AUTH_ADMIN_CREDS"] = None
 config["INTERNAL_AUTH"] = None
 
-# Signpost
+# Signpost: deprecated, replaced by index client.
 config['SIGNPOST'] = {
     'host': environ.get('SIGNPOST_HOST') or 'http://indexd-service',
+    'version': 'v0',
+    'auth': ('gdcapi', conf_data.get('indexd_password', '{{indexd_password}}')),
+}
+config['INDEX_CLIENT'] = {
+    'host': environ.get('INDEX_CLIENT_HOST') or 'http://indexd-service',
     'version': 'v0',
     'auth': ('gdcapi', conf_data.get('indexd_password', '{{indexd_password}}')),
 }

--- a/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
@@ -79,7 +79,14 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: dictionary_url
+          # Signpost is deprecated; replace this w INDEX_CLIENT_HOST block
           - name: SIGNPOST_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: indexd_url
+                optional: true
+          - name: INDEX_CLIENT_HOST
             valueFrom:
               configMapKeyRef:
                 name: manifest-global

--- a/kube/services/peregrine/peregrine-canary-deploy.yaml
+++ b/kube/services/peregrine/peregrine-canary-deploy.yaml
@@ -62,7 +62,14 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: dictionary_url
+          # Signpost is deprecated; replace this w INDEX_CLIENT_HOST block
           - name: SIGNPOST_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: indexd_url
+                optional: true
+          - name: INDEX_CLIENT_HOST
             valueFrom:
               configMapKeyRef:
                 name: manifest-global

--- a/kube/services/peregrine/peregrine-deploy.yaml
+++ b/kube/services/peregrine/peregrine-deploy.yaml
@@ -75,7 +75,14 @@ spec:
                 name: manifest-global
                 key: public_datasets
                 optional: true
+          # Signpost is deprecated; replace this w INDEX_CLIENT_HOST block
           - name: SIGNPOST_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: indexd_url
+                optional: true
+          - name: INDEX_CLIENT_HOST
             valueFrom:
               configMapKeyRef:
                 name: manifest-global

--- a/kube/services/sheepdog/sheepdog-canary-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-canary-deploy.yaml
@@ -77,7 +77,14 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: dictionary_url
+          # Signpost is deprecated; replace this w INDEX_CLIENT_HOST block
           - name: SIGNPOST_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: indexd_url
+                optional: true
+          - name: INDEX_CLIENT_HOST
             valueFrom:
               configMapKeyRef:
                 name: manifest-global

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -79,7 +79,14 @@ spec:
               configMapKeyRef:
                 name: manifest-global
                 key: dictionary_url
+          # Signpost is deprecated; replace this w INDEX_CLIENT_HOST block
           - name: SIGNPOST_HOST
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: indexd_url
+                optional: true
+          - name: INDEX_CLIENT_HOST
             valueFrom:
               configMapKeyRef:
                 name: manifest-global


### PR DESCRIPTION
We are removing signpost from sheepdog and peregrine. Sheepdog > 1.1.11 and Peregrine >1.2.1 will look for `INDEX_CLIENT` in config dict and `INDEX_CLIENT_HOST` env var. So add those here but retain the signpost settings for backwards compatibility. 

