### PR TITLE
fix(jupyterhub): run on default node pool

### DIFF
--- a/kube/services/jupyterhub/jupyterhub-deploy.yaml
+++ b/kube/services/jupyterhub/jupyterhub-deploy.yaml
@@ -20,11 +20,6 @@ spec:
     spec:
       nodeSelector:
         role: jupyter
-      tolerations:
-      - key: "role"
-        operator: "Equal"
-        value: "jupyter"
-        effect: "NoSchedule"
       serviceAccountName: jupyter-service
       volumes:
         - name: config-volume


### PR DESCRIPTION
jupyter hub does not have to run on the same node pool as the jupyter notebooks -
will avoid deployment issues in qa/jenkins if we allow it to run on the main worker pool

### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

