### PR TITLE
Chore/snapshot

### DIFF
--- a/doc/logs.md
+++ b/doc/logs.md
@@ -149,3 +149,7 @@ Retrieve aggregations from the `gen3-aggs-daily` index.
 ```
 $ gen3 logs history daily "start=-7 days" "vpc=all"
 ```
+
+### `gen3 logs snapshot`
+
+Snapshot the logs of currently running pods excluding jupyterhub to `.gz` files.

--- a/gen3/bin/jupyter.sh
+++ b/gen3/bin/jupyter.sh
@@ -96,7 +96,12 @@ gen3_jupyter_upgrade() {
   fi
   gen3 roll jupyterhub
 
-  gen3_jupyter_prepuller | g3kubectl apply -f -
+  local namespace
+  namespace="$(gen3 db namespace)"
+  if [[ "$namespace" == "default" ]]; then
+    # avoid deploying prepuller in dev/qa namespaces ...
+    gen3_jupyter_prepuller | g3kubectl apply -f -
+  fi
 }
 
 # main ----------------------

--- a/gen3/bin/logs.sh
+++ b/gen3/bin/logs.sh
@@ -9,6 +9,7 @@ gen3_load "gen3/lib/logs/utils"
 gen3_load "gen3/lib/logs/raw"
 gen3_load "gen3/lib/logs/daily"
 gen3_load "gen3/lib/logs/ubh"
+gen3_load "gen3/lib/logs/snapshot"
 
 if [[ -z "$vpc_name" ]]; then
   vpc_name="$(g3kubectl get configmap global -o json | jq -r .data.environment)"
@@ -84,6 +85,9 @@ if [[ -z "$GEN3_SOURCE_ONLY" ]]; then
           exit 1
           ;;
       esac
+      ;;
+    "snapshot")
+      gen3_logs_snapshot_all "$@"
       ;;
     "user")
       gen3_logs_user_list "$@"

--- a/gen3/lib/logs/snapshot.sh
+++ b/gen3/lib/logs/snapshot.sh
@@ -1,0 +1,45 @@
+
+#
+# Snapshot logs from a particular container of a particular pod
+# to a .log.gz file
+#
+# @param pod
+# @param container
+# @param folder
+# @return echo the path to the generated .log.gz file
+#
+gen3_logs_snapshot_container() {
+  local podName
+  local containerName
+
+  if [[ $# -lt 1 ]]; then
+    gen3_log_err "must pass podName argument, containerName is optional"
+    return 1
+  fi
+  podName="$1"
+  shift
+  containerName=""
+  if [[ $# -gt 0 ]]; then
+    containerName="$1"
+    shift
+  fi
+  local fileName
+  fileName="${podName}.${containerName}.log"
+  if g3kubectl logs "$podName" -c "$containerName" --limit-bytes 250000 > "$fileName" && gzip "$fileName"; then
+    echo "${fileName}.gz"
+    return 0
+  fi
+  return 1
+}
+
+#
+# Snapshot all the pods
+#
+gen3_logs_snapshot_all() {
+  g3kubectl get pods -o json | \
+    jq -r '.items | map( {pod: .metadata.name, containers: .spec.containers | map(.name) } ) | map( .pod as $pod | .containers | map( { pod: $pod, cont: .})[]) | map(select(.cont != "pause" and .cont != "jupyterhub"))[] | .pod + "  " + .cont' | \
+    while read -r line; do
+      gen3_logs_snapshot_container $line
+    done
+}
+

--- a/gen3/lib/logs/snapshot.sh
+++ b/gen3/lib/logs/snapshot.sh
@@ -25,7 +25,7 @@ gen3_logs_snapshot_container() {
   fi
   local fileName
   fileName="${podName}.${containerName}.log"
-  if g3kubectl logs "$podName" -c "$containerName" --limit-bytes 250000 > "$fileName" && gzip "$fileName"; then
+  if g3kubectl logs "$podName" -c "$containerName" --limit-bytes 250000 > "$fileName" && gzip -f "$fileName"; then
     echo "${fileName}.gz"
     return 0
   fi

--- a/gen3/test/logsTest.sh
+++ b/gen3/test/logsTest.sh
@@ -16,9 +16,12 @@ test_logs_curl() {
 }
 
 
-#
-# Little helper for test_logs_awk
-#
+test_logs_snapshot() {
+  # just make sure the snapshot thing works
+  (cd "$XDG_RUNTIME_DIR" && gen3 logs snapshot); because $? "gen3 logs snapshot should run ok"
+  ls "$XDG_RUNTIME_DIR/" | grep -E '\.log\.gz$'; because $? "gen3 logs snapshot should generate some service.container.log.gz files"
+}
+
 test_logs_awk() {
   local tempFile
   tempFile="$(mktemp $XDG_RUNTIME_DIR/awktest.txt_XXXXXX)"
@@ -66,3 +69,4 @@ fi
 
 shunit_runtest "test_logs_curl" "logs,local"
 shunit_runtest "test_logs_awk" "logs,local"
+shunit_runtest "test_logs_snapshot" "logs"

--- a/kube/services/jupyterhub/jupyterhub-deploy.yaml
+++ b/kube/services/jupyterhub/jupyterhub-deploy.yaml
@@ -18,13 +18,6 @@ spec:
         userhelper: "yes"
         GEN3_DATE_LABEL
     spec:
-      nodeSelector:
-        role: jupyter
-      tolerations:
-      - key: "role"
-        operator: "Equal"
-        value: "jupyter"
-        effect: "NoSchedule"
       serviceAccountName: jupyter-service
       volumes:
         - name: config-volume


### PR DESCRIPTION
* add `gen3 logs snapshot` to generate `.log.gz` snapshots of current pods logs - for use in Jenkins
* allow `jupyterhub` to deploy to the default node pool - notebooks and prepullers deploy to jupyter pool
* do not deploy jupyter prepuller daemonset in dev/qa namespaces

### New Features

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

