### PR TITLE
add(arborist): in manifest template

### DIFF
--- a/doc/csoc-free-commons-steps.md
+++ b/doc/csoc-free-commons-steps.md
@@ -270,7 +270,10 @@ mkdir -p ${HOME}/cdis-manifest/commons-test.planx-pla.net
       "subject"
     ]
   },
-"jupyterhub": {
+  "arborist": {
+    "deployment_version": "2"
+  },
+  "jupyterhub": {
     "enabled": "no"
   },
   "global": {


### PR DESCRIPTION
Without it, deployments of arborist will fail to come up due to not having secrets.

kube-setup-arborist expect a version in the manifest to come up properly

Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- csoc free documentation

### Dependency updates


### Deployment changes

