### PR TITLE
chore(cert copy): admin certs are not needed after EKS

### DIFF
--- a/gen3/bin/kube-dev-namespace.sh
+++ b/gen3/bin/kube-dev-namespace.sh
@@ -84,7 +84,7 @@ done
 # setup ~/vpc_name/credentials and kubeconfig
 cd /home/$namespace/${vpc_name}
 mkdir -p credentials
-for name in ca.pem ca-key.pem admin.pem admin-key.pem; do
+for name in ca.pem ca-key.pem; do
   cp ~/${vpc_name}/credentials/$name credentials/
 done
 sed -i.bak "s/default/$namespace/" kubeconfig


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- kube-dev-namespaces should now work on every environment, not just dev

### Dependency updates


### Deployment changes

