### PR TITLE
Feat/nodepool size control

### DIFF
--- a/tf_files/aws/eks/root.tf
+++ b/tf_files/aws/eks/root.tf
@@ -17,7 +17,7 @@ module "eks" {
   users_policy              = "${var.users_policy}"
   worker_drive_size         = "${var.worker_drive_size}"
   eks_version               = "${var.eks_version}"
-  deploy_jupyter_pool       = "${var.deploy_jupyter_pool}"
+#  deploy_jupyter_pool       = "${var.deploy_jupyter_pool}"
   jupyter_instance_type     = "${var.jupyter_instance_type}"
   workers_subnet_size       = "${var.workers_subnet_size}"
   bootstrap_script          = "${var.bootstrap_script}"

--- a/tf_files/aws/eks/root.tf
+++ b/tf_files/aws/eks/root.tf
@@ -28,5 +28,8 @@ module "eks" {
   organization_name         = "${var.organization_name}"
   peering_vpc_id            = "${var.peering_vpc_id}"
   proxy_name                = "${var.proxy_name}"
+  jupyter_asg_desired_capacity = "${var.jupyter_asg_desired_capacity}"
+  jupyter_asg_max_size         = "${var.jupyter_asg_max_size}" 
+  jupyter_asg_min_size         = "${var.jupyter_asg_min_size}" 
 
 }

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -68,3 +68,16 @@ variable "organization_name" {
 variable "proxy_name" {
   default = " HTTP Proxy"
 }
+
+
+variable "jupyter_asg_desired_capasity" {
+  default = 0
+}
+
+variable "jupyter_asg_max_size" {
+  default = 10
+}
+
+variable "jupyter_asg_min_size" {
+  default = 0
+}

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -33,9 +33,9 @@ variable "eks_version" {
   default = "1.11"
 }
 
-variable "deploy_jupyter_pool" {
-  default = "no"
-}
+#variable "deploy_jupyter_pool" {
+#  default = "no"
+#}
 
 variable "workers_subnet_size" {
   default = 24
@@ -70,7 +70,7 @@ variable "proxy_name" {
 }
 
 
-variable "jupyter_asg_desired_capasity" {
+variable "jupyter_asg_desired_capacity" {
   default = 0
 }
 

--- a/tf_files/aws/modules/eks-nodepool/README.md
+++ b/tf_files/aws/modules/eks-nodepool/README.md
@@ -40,10 +40,12 @@ All variables in this module are mandatory, however, since it is not intended to
 * `eks_private_subnets` list of cidr for private subneting.
 * `control_plane_sg` security group for the control plane to talk to the workers.
 * `default_nodepool_sg` Security group of the default pool. This hasn't been tested for additional pools other than jupyter, but theoretically you could create as many pools as you want.
-* `deploy_jupyter_pool` If expolicit "yes" provided, then the autoscaling group for the pool will be set for 3 as minimum and desired capasity. Default is no.
 * `bootstrap_script` Script to use to initialize the worker. Default value `bootstrap-2.0.0.sh`
 * `kernel` If your bootstrap script requires another kernel, you could point to it with this variable. Available kernels will be in `gen3-kernels` bucket. Default value `N/A`
 * `jupyter_worker_drive_size` size of the worker driver size. Default 30.
+* `jupyter_asg_desired_capacity` How many workers you want in your jupyter autoscaling group. Default 0
+* `jupyter_asg_max_size` The max number of workers you would allow your jupyter autoscaling group to grow. Default 10.
+* `jupyter_asg_min_size` The min number of workers you would allow your jupyter autoscaling group to shrink. Default 0.
 
 
 ## 5. Considerations

--- a/tf_files/aws/modules/eks-nodepool/cloud.tf
+++ b/tf_files/aws/modules/eks-nodepool/cloud.tf
@@ -285,10 +285,10 @@ resource "aws_launch_configuration" "eks_launch_configuration" {
 
 
 resource "aws_autoscaling_group" "eks_autoscaling_group" {
-  desired_capacity     = "${var.deploy_jupyter_pool == "yes" ? 3 : 0}"
+  desired_capacity     = "${var.asg_desired_capasity}"
   launch_configuration = "${aws_launch_configuration.eks_launch_configuration.id}"
-  max_size             = 10
-  min_size             = "${var.deploy_jupyter_pool == "yes" ? 3 : 0}"
+  max_size             = "${var.asg_max_size}"
+  min_size             = "${var.asg_min_size}" 
   name                 = "eks-${var.nodepool}worker-node-${var.vpc_name}"
   #vpc_zone_identifier  = ["${data.aws_subnet.eks_private.*.id}"]
   #vpc_zone_identifier  = ["${data.aws_subnet_ids.private.ids}"]

--- a/tf_files/aws/modules/eks-nodepool/cloud.tf
+++ b/tf_files/aws/modules/eks-nodepool/cloud.tf
@@ -285,10 +285,10 @@ resource "aws_launch_configuration" "eks_launch_configuration" {
 
 
 resource "aws_autoscaling_group" "eks_autoscaling_group" {
-  desired_capacity     = "${var.asg_desired_capasity}"
+  desired_capacity     = "${var.jupyter_asg_desired_capasity}"
   launch_configuration = "${aws_launch_configuration.eks_launch_configuration.id}"
-  max_size             = "${var.asg_max_size}"
-  min_size             = "${var.asg_min_size}" 
+  max_size             = "${var.jupyter_asg_max_size}"
+  min_size             = "${var.jupyter_asg_min_size}" 
   name                 = "eks-${var.nodepool}worker-node-${var.vpc_name}"
   #vpc_zone_identifier  = ["${data.aws_subnet.eks_private.*.id}"]
   #vpc_zone_identifier  = ["${data.aws_subnet_ids.private.ids}"]

--- a/tf_files/aws/modules/eks-nodepool/cloud.tf
+++ b/tf_files/aws/modules/eks-nodepool/cloud.tf
@@ -285,7 +285,7 @@ resource "aws_launch_configuration" "eks_launch_configuration" {
 
 
 resource "aws_autoscaling_group" "eks_autoscaling_group" {
-  desired_capacity     = "${var.jupyter_asg_desired_capasity}"
+  desired_capacity     = "${var.jupyter_asg_desired_capacity}"
   launch_configuration = "${aws_launch_configuration.eks_launch_configuration.id}"
   max_size             = "${var.jupyter_asg_max_size}"
   min_size             = "${var.jupyter_asg_min_size}" 

--- a/tf_files/aws/modules/eks-nodepool/variables.tf
+++ b/tf_files/aws/modules/eks-nodepool/variables.tf
@@ -60,3 +60,15 @@ variable "jupyter_worker_drive_size" {
 variable "organization_name" {
   default = "Basic Service"
 }
+
+variable "asg_desired_capasity" {
+  default = 0
+}
+
+variable "asg_max_size" {
+  default = 10
+}
+
+variable "asg_min_size" {
+  default = 0
+}

--- a/tf_files/aws/modules/eks-nodepool/variables.tf
+++ b/tf_files/aws/modules/eks-nodepool/variables.tf
@@ -61,14 +61,14 @@ variable "organization_name" {
   default = "Basic Service"
 }
 
-variable "asg_desired_capasity" {
+variable "jupyter_asg_desired_capasity" {
   default = 0
 }
 
-variable "asg_max_size" {
+variable "jupyter_asg_max_size" {
   default = 10
 }
 
-variable "asg_min_size" {
+variable "jupyter_asg_min_size" {
   default = 0
 }

--- a/tf_files/aws/modules/eks-nodepool/variables.tf
+++ b/tf_files/aws/modules/eks-nodepool/variables.tf
@@ -61,7 +61,7 @@ variable "organization_name" {
   default = "Basic Service"
 }
 
-variable "jupyter_asg_desired_capasity" {
+variable "jupyter_asg_desired_capacity" {
   default = 0
 }
 

--- a/tf_files/aws/modules/eks/README.md
+++ b/tf_files/aws/modules/eks/README.md
@@ -55,7 +55,6 @@ users_policy = "fauziv1"
 * `csoc_cidr` By default set to 10.128.0.0/20.
 * `eks_version` Version of kubernetes to deploy for EKS, default is set to 1.10.
 * `worker_drive_size` Size of the root volume for the workers. Default is set to 30 GB.
-* `deploy_jupyter_pool` If you want the jupyter pool. If explicit "yes" is passed, then the autoscaling group would be set to a minimum of three instances, and same value for desired capasity. Default is no.
 * `jupyter_instance_type` Instance_type for nodepool by default this is set to t3.medium, but it can be changed if needed.
 * `bootstrap_script` Script to use to initialize the worker nodes. Default value `bootstrap-2.0.0.sh`.
 * `jupyter_bootstrap_script` Script to intialize jupyter worekers. Default value `bootstrap-2.0.0.sh`.
@@ -64,6 +63,9 @@ users_policy = "fauziv1"
 * `cidrs_to_route_to_gw` CIDRs you would like to get out skiping the proxy. This var should be a list type, Ex: `cidrs_to_route_to_gw = ["192.170.230.192/26", "192.170.230.160/27"]`. Default, empty list.
 * `csoc_manged` If you want your commons attached to a CSOC accunt, just set the value of this one as "Yes", exactly like that. Any other value would be taken as no. Default is "Yes".
 * `peering_cidr` Basically the CIDR of the vpc your adminVM belongs to. Since the above variable default is "Yes" this variable default is PlanX CSOC account.
+* `jupyter_asg_desired_capacity` How many workers you want in your jupyter autoscaling group. Default 0
+* `jupyter_asg_max_size` The max number of workers you would allow your jupyter autoscaling group to grow. Default 10.
+* `jupyter_asg_min_size` The min number of workers you would allow your jupyter autoscaling group to shrink. Default 0.
 
 ## 5. Considerations
 

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -21,7 +21,7 @@ module "jupyter_pool" {
   eks_private_subnets       = "${aws_subnet.eks_private.*.id}"
   control_plane_sg          = "${aws_security_group.eks_control_plane_sg.id}"
   default_nodepool_sg       = "${aws_security_group.eks_nodes_sg.id}"
-  deploy_jupyter_pool       = "${var.deploy_jupyter_pool}"
+  #deploy_jupyter_pool       = "${var.deploy_jupyter_pool}"
   eks_version               = "${var.eks_version}"
   jupyter_instance_type     = "${var.jupyter_instance_type}"
   kernel                    = "${var.kernel}"

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -28,6 +28,9 @@ module "jupyter_pool" {
   bootstrap_script          = "${var.jupyter_bootstrap_script}"
   jupyter_worker_drive_size = "${var.jupyter_worker_drive_size}"
   organization_name         = "${var.organization_name}"
+  jupyter_asg_desired_capacity = "${var.jupyter_asg_desired_capacity}"
+  jupyter_asg_max_size         = "${var.jupyter_asg_max_size}" 
+  jupyter_asg_min_size         = "${var.jupyter_asg_min_size}" 
 }
 
 

--- a/tf_files/aws/modules/eks/init_cluster.sh
+++ b/tf_files/aws/modules/eks/init_cluster.sh
@@ -15,7 +15,7 @@ fi
 
 #KUBECTL=$(bash which kubectl)
 if ! $(bash which kubectl) --kubeconfig "${kubeconfig_path}" get daemonsets -n kube-system calico-node > /dev/null 2>&1; then
-  $(bash which kubectl) --kubeconfig "${kubeconfig_path}" apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.3/calico.yaml
+  $(bash which kubectl) --kubeconfig "${kubeconfig_path}" apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.4/calico.yaml
                                                                   # https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.1/config/v1.1/calico.yaml
 fi
 

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -32,9 +32,9 @@ variable "eks_version" {
   default = "1.11"
 }
 
-variable "deploy_jupyter_pool" {
-  default = "no"
-}
+#variable "deploy_jupyter_pool" {
+#  default = "no"
+#}
 
 variable "workers_subnet_size" {
   default = 24
@@ -70,7 +70,7 @@ variable "proxy_name" {
 }
 
 
-variable "jupyter_asg_desired_capasity" {
+variable "jupyter_asg_desired_capacity" {
   default = 0
 }
 

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -68,3 +68,16 @@ variable "organization_name" {
 variable "proxy_name" {
   default = " HTTP Proxy"
 }
+
+
+variable "jupyter_asg_desired_capasity" {
+  default = 0
+}
+
+variable "jupyter_asg_max_size" {
+  default = 10
+}
+
+variable "jupyter_asg_min_size" {
+  default = 0
+}


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

### Breaking Changes


### Bug Fixes


### Improvements
- jupyter autoscaling group size and desired capacity are now variables that must be set in config.tfvars. Defaults are to not deploy nodes in the cluster, should you not set them up is like you don't want the nodepool to be deployed.

### Dependency updates


### Deployment changes

