### PR TITLE
fix(shib-attributes): add attribute-policy.xml

### DIFF
--- a/gen3/bin/kube-setup-fenceshib.sh
+++ b/gen3/bin/kube-setup-fenceshib.sh
@@ -8,6 +8,8 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/lib/kube-setup-init"
 
+scriptDir="${GEN3_HOME}/kube/services/fenceshib"
+
 gen3 kube-setup-secrets
 
 if [[ -d "$(gen3_secrets_folder)/creds.json" ]]; then # create database
@@ -24,6 +26,8 @@ if [[ -d "$(gen3_secrets_folder)/creds.json" ]]; then # create database
   # avoid doing the previous block more than once or when not necessary ...
   touch "$(gen3_secrets_folder)/.rendered_fence_db"
 fi
+
+gen3 update_config fenceshib-attribute-policy "${scriptDir}/attribute-policy.xml"
 
 # deploy fenceshib
 gen3 roll fenceshib

--- a/kube/services/fenceshib/attribute-policy.xml
+++ b/kube/services/fenceshib/attribute-policy.xml
@@ -28,9 +28,9 @@
         <Rule xsi:type="saml:AttributeScopeMatchesShibMDScope"/>
     </afp:PermitValueRule>
 
-    <afp:PermitValueRule id="EppnScopingRules" xsi:type="AND">
-        <Rule xsi:type="saml:AttributeScopeMatchesShibMDScope"/>
-    </afp:PermitValueRule>
+    <afp:AttributeRule attributeID="eppn">
+        <afp:PermitValueRule xsi:type="saml:AttributeScopeMatchesShibMDScope"/>
+    </afp:AttributeRule>
 
     <afp:AttributeFilterPolicy>
         <!-- This policy is in effect in all cases. -->
@@ -48,10 +48,6 @@
         </afp:AttributeRule>
         <afp:AttributeRule attributeID="primary-affiliation">
             <afp:PermitValueRuleReference ref="eduPersonAffiliationValues"/>
-        </afp:AttributeRule>
-
-        <afp:AttributeRule attributeID="eppn">
-            <afp:PermitValueRuleReference ref="EppnScopingRules"/>
         </afp:AttributeRule>
 
         <afp:AttributeRule attributeID="targeted-id">

--- a/kube/services/fenceshib/attribute-policy.xml
+++ b/kube/services/fenceshib/attribute-policy.xml
@@ -22,6 +22,13 @@
     an AttributeRule for each attribute you want to check.
     -->
     <afp:PermitValueRule id="ScopingRules" xsi:type="AND">
+        <Rule xsi:type="NOT">
+            <Rule xsi:type="AttributeValueRegex" regex="@"/>
+        </Rule>
+        <Rule xsi:type="saml:AttributeScopeMatchesShibMDScope"/>
+    </afp:PermitValueRule>
+
+    <afp:PermitValueRule id="EppnScopingRules" xsi:type="AND">
         <Rule xsi:type="saml:AttributeScopeMatchesShibMDScope"/>
     </afp:PermitValueRule>
 
@@ -44,7 +51,7 @@
         </afp:AttributeRule>
 
         <afp:AttributeRule attributeID="eppn">
-            <afp:PermitValueRuleReference ref="ScopingRules"/>
+            <afp:PermitValueRuleReference ref="EppnScopingRules"/>
         </afp:AttributeRule>
 
         <afp:AttributeRule attributeID="targeted-id">

--- a/kube/services/fenceshib/attribute-policy.xml
+++ b/kube/services/fenceshib/attribute-policy.xml
@@ -1,0 +1,66 @@
+<afp:AttributeFilterPolicyGroup
+    xmlns="urn:mace:shibboleth:2.0:afp:mf:basic"
+    xmlns:saml="urn:mace:shibboleth:2.0:afp:mf:saml"
+    xmlns:basic="urn:mace:shibboleth:2.0:afp:mf:basic"
+    xmlns:afp="urn:mace:shibboleth:2.0:afp"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <!-- Shared rule for affiliation values. -->
+    <afp:PermitValueRule id="eduPersonAffiliationValues" xsi:type="OR">
+        <Rule xsi:type="AttributeValueString" value="faculty"/>
+        <Rule xsi:type="AttributeValueString" value="student"/>
+        <Rule xsi:type="AttributeValueString" value="staff"/>
+        <Rule xsi:type="AttributeValueString" value="alum"/>
+        <Rule xsi:type="AttributeValueString" value="member"/>
+        <Rule xsi:type="AttributeValueString" value="affiliate"/>
+        <Rule xsi:type="AttributeValueString" value="employee"/>
+        <Rule xsi:type="AttributeValueString" value="library-walk-in"/>
+    </afp:PermitValueRule>
+
+    <!--
+    Shared rule for all "scoped" attributes, but you'll have to manually apply it inside
+    an AttributeRule for each attribute you want to check.
+    -->
+    <afp:PermitValueRule id="ScopingRules" xsi:type="AND">
+        <Rule xsi:type="saml:AttributeScopeMatchesShibMDScope"/>
+    </afp:PermitValueRule>
+
+    <afp:AttributeFilterPolicy>
+        <!-- This policy is in effect in all cases. -->
+        <afp:PolicyRequirementRule xsi:type="ANY"/>
+
+        <!-- Filter out undefined affiliations and ensure only one primary. -->
+        <afp:AttributeRule attributeID="affiliation">
+            <afp:PermitValueRule xsi:type="AND">
+                <RuleReference ref="eduPersonAffiliationValues"/>
+                <RuleReference ref="ScopingRules"/>
+            </afp:PermitValueRule>
+        </afp:AttributeRule>
+        <afp:AttributeRule attributeID="unscoped-affiliation">
+            <afp:PermitValueRuleReference ref="eduPersonAffiliationValues"/>
+        </afp:AttributeRule>
+        <afp:AttributeRule attributeID="primary-affiliation">
+            <afp:PermitValueRuleReference ref="eduPersonAffiliationValues"/>
+        </afp:AttributeRule>
+
+        <afp:AttributeRule attributeID="eppn">
+            <afp:PermitValueRuleReference ref="ScopingRules"/>
+        </afp:AttributeRule>
+
+        <afp:AttributeRule attributeID="targeted-id">
+            <afp:PermitValueRuleReference ref="ScopingRules"/>
+        </afp:AttributeRule>
+
+        <!-- Require NameQualifier/SPNameQualifier match IdP and SP entityID respectively. -->
+        <afp:AttributeRule attributeID="persistent-id">
+            <afp:PermitValueRule xsi:type="saml:NameIDQualifierString"/>
+        </afp:AttributeRule>
+
+        <!-- Catch-all that passes everything else through unmolested. -->
+        <afp:AttributeRule attributeID="*">
+            <afp:PermitValueRule xsi:type="ANY"/>
+        </afp:AttributeRule>
+
+    </afp:AttributeFilterPolicy>
+
+</afp:AttributeFilterPolicyGroup>

--- a/kube/services/fenceshib/fenceshib-deploy.yaml
+++ b/kube/services/fenceshib/fenceshib-deploy.yaml
@@ -85,6 +85,9 @@ spec:
         - name: fenceshib-secret
           secret:
             secretName: "fenceshib-g3auto"
+        - name: attribute-policy
+          configMap:
+            name: "fenceshib-attribute-policy"
       containers:
       - name: fenceshib
         GEN3_FENCESHIB_IMAGE
@@ -190,6 +193,10 @@ spec:
             readOnly: true
             mountPath: "/etc/shibboleth/inc-md-cert.pem"
             subPath: "inc-md-cert.pem"
+          - name: "attribute-policy"
+            readOnly: true
+            mountPath: "/etc/shibboleth/attribute-policy.xml"
+            subPath: "attribute-policy.xml"
         resources:
             limits:
               cpu: 2


### PR DESCRIPTION
- Shibboleth deployment default `attribute-policy.xml` file includes a regex disallowing `@` in a rule affecting the `eppn` (`eduPersonPrincipalName`, see `attribute-map.xml`), which seems to be causing empty `eppn` for providers using email in this field. This adds & mounts a modified `attribute-policy.xml` file for the shibboleth deployment to fix this.