### PR TITLE
feat/privacy policy: support for fence & windmill serving privacy policy

### DIFF
--- a/gen3/bin/kube-setup-secrets.sh
+++ b/gen3/bin/kube-setup-secrets.sh
@@ -324,6 +324,11 @@ if [[ -f "$ETL_MAPPING_PATH" ]]; then
   gen3 update_config etl-mapping "$ETL_MAPPING_PATH"
 fi
 
+PRIVACY_POLICY="$(dirname $(g3k_manifest_path))/privacy_policy.md"
+if [[ -f "$PRIVACY_POLICY" ]]; then
+  gen3 update_config privacy-policy "$PRIVACY_POLICY"
+fi
+
 (
   version="$(g3kubectl get secrets/sheepdog-secret -ojson 2> /dev/null | jq -r .metadata.labels.g3version)"
   if [[ -z "$version" || "$version" == null || "$version" -lt 2 ]]; then

--- a/gen3/bin/kube-setup-secrets.sh
+++ b/gen3/bin/kube-setup-secrets.sh
@@ -325,9 +325,11 @@ if [[ -f "$ETL_MAPPING_PATH" ]]; then
 fi
 
 PRIVACY_POLICY="$(dirname $(g3k_manifest_path))/privacy_policy.md"
-if [[ -f "$PRIVACY_POLICY" ]]; then
-  gen3 update_config privacy-policy "$PRIVACY_POLICY"
+if [[ ! -f "$PRIVACY_POLICY" ]]; then
+  # the file has to at least exist, otherwise fence will error out trying to mount it
+  touch $PRIVACY_POLICY
 fi
+gen3 update_config privacy-policy "$PRIVACY_POLICY"
 
 (
   version="$(g3kubectl get secrets/sheepdog-secret -ojson 2> /dev/null | jq -r .metadata.labels.g3version)"

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -93,12 +93,6 @@ spec:
             value: /var/www/fence
           - name: GEN3_DEBUG
             value: "False"
-          - name: PRIVACY_POLICY_URL
-            valueFrom:
-              configMapKeyRef:
-                name: manifest-global
-                key: privacy_policy_url
-                optional: true
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -82,6 +82,9 @@ spec:
         - name: ca-volume
           secret:
             secretName: "service-ca"
+        - name: privacy-policy
+          configMap:
+            name: "privacy-policy"
       containers:
       - name: fence
         image: quay.io/cdis/fence:master
@@ -90,6 +93,12 @@ spec:
             value: /var/www/fence
           - name: GEN3_DEBUG
             value: "False"
+          - name: PRIVACY_POLICY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: privacy_policy_url
+                optional: true
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -131,6 +140,10 @@ spec:
             readOnly: true
             mountPath: "/fence/fence/static/img/logo.svg"
             subPath: "logo.svg"
+          - name: "privacy-policy"
+            readOnly: true
+            mountPath: "/fence/fence/static/privacy_policy.md"
+            subPath: "privacy_policy.md"
           - name: "config-volume"
             readOnly: true
             mountPath: "/var/www/fence/fence-config.yaml"

--- a/kube/services/fence/fence-canary-deploy.yaml
+++ b/kube/services/fence/fence-canary-deploy.yaml
@@ -81,6 +81,9 @@ spec:
         - name: ca-volume
           secret:
             secretName: "service-ca"
+        - name: privacy-policy
+          configMap:
+            name: "privacy-policy"
       containers:
       - name: fence
         GEN3_FENCE-CANARY_IMAGE|-GEN3_FENCE_IMAGE-|
@@ -130,6 +133,10 @@ spec:
             readOnly: true
             mountPath: "/fence/fence/static/img/logo.svg"
             subPath: "logo.svg"
+          - name: "privacy-policy"
+            readOnly: true
+            mountPath: "/fence/fence/static/privacy_policy.md"
+            subPath: "privacy_policy.md"
           - name: "config-volume"
             readOnly: true
             mountPath: "/var/www/fence/fence-config.yaml"

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -82,6 +82,9 @@ spec:
         - name: ca-volume
           secret:
             secretName: "service-ca"
+        - name: privacy-policy
+          configMap:
+            name: "privacy-policy"
       containers:
       - name: fence
         GEN3_FENCE_IMAGE
@@ -131,6 +134,9 @@ spec:
             readOnly: true
             mountPath: "/fence/fence/static/img/logo.svg"
             subPath: "logo.svg"
+          - name: "privacy-policy"
+            readOnly: true
+            mountPath: "/fence/fence/static/privacy_policy.md"
           - name: "config-volume"
             readOnly: true
             mountPath: "/var/www/fence/fence-config.yaml"

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -93,12 +93,6 @@ spec:
           value: /var/www/fence
         - name: GEN3_DEBUG
           GEN3_DEBUG_FLAG|-value: "False"-|
-        - name: PRIVACY_POLICY_URL
-          valueFrom:
-            configMapKeyRef:
-              name: manifest-global
-              key: privacy_policy_url
-              optional: true
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -93,6 +93,12 @@ spec:
           value: /var/www/fence
         - name: GEN3_DEBUG
           GEN3_DEBUG_FLAG|-value: "False"-|
+        - name: PRIVACY_POLICY_URL
+          valueFrom:
+            configMapKeyRef:
+              name: global
+              key: privacy_policy_url
+              optional: true
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -96,7 +96,7 @@ spec:
         - name: PRIVACY_POLICY_URL
           valueFrom:
             configMapKeyRef:
-              name: global
+              name: manifest-global
               key: privacy_policy_url
               optional: true
         imagePullPolicy: Always
@@ -143,6 +143,7 @@ spec:
           - name: "privacy-policy"
             readOnly: true
             mountPath: "/fence/fence/static/privacy_policy.md"
+            subPath: "privacy_policy.md"
           - name: "config-volume"
             readOnly: true
             mountPath: "/var/www/fence/fence-config.yaml"

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -46,6 +46,9 @@ spec:
       - name: sponsor-img-volume
         secret:
           secretName: "portal-sponsor-config"
+      - name: privacy-policy
+        configMap:
+          name: "privacy-policy"
       containers:
       - name: portal
         GEN3_PORTAL_IMAGE
@@ -118,6 +121,12 @@ spec:
                 name: manifest-global
                 key: indexd_url
                 optional: true
+          - name: PRIVACY_POLICY_URL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: privacy_policy_url
+                optional: true
         volumeMounts:
           - name: "cert-volume"
             readOnly: true
@@ -148,6 +157,10 @@ spec:
             subPath: "gitops.css"
           - name: "sponsor-img-volume"
             mountPath: "/data-portal/custom/sponsors/gitops-sponsors"
+          - name: "privacy-policy"
+            readOnly: true
+            mountPath: "/data-portal/custom/privacy_policy.md"
+            subPath: "privacy_policy.md"
         readinessProbe:
           httpGet:
             path: /


### PR DESCRIPTION
TODO:
- [x] fence changes
- [x] windmill changes

### New Features

- add support for fence serving privacy policy
    - add `PRIVACY_POLICY_URL` env for fence which defines redirect
    - add volume mount for static `.md` file to put the policy in

In terms of deployment changes, be sure to run `kube-setup-secrets` before using these changes, otherwise the fence and data-portal pods will fail to come up because of the missing volume.