### PR TITLE
Chore/automated tfplan run

### DIFF
--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -65,7 +65,7 @@ gen3_run_tfplan_vpc() {
   local plan
   local slack_hook
   slack_hook="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic"
-  if [[ $(_check_cloud-automation_changes) == "true" ]];
+  if [[ $(_check_cloud-automation_changes) == "false" ]];
   then
     gen3 workon $(grep profile ~/.aws/config  |awk '{print $2}'| cut -d] -f1) ${vpc_name} > /dev/null 2>&1
     plan=$(gen3 tfplan | grep "Plan")
@@ -101,7 +101,7 @@ gen3_run_tfplan_eks() {
   local plan
   local slack_hook
   slack_hook="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic"
-  if [[ $(_check_cloud-automation_changes) == "true" ]];
+  if [[ $(_check_cloud-automation_changes) == "false" ]];
   then
     gen3 workon $(grep profile ~/.aws/config  |awk '{print $2}'| cut -d] -f1) ${vpc_name}_eks > /dev/null 2>&1
     plan=$(gen3 tfplan | grep "Plan")

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -73,10 +73,11 @@ gen3_run_tfplan() {
   module=$1
   changes=$(_check_cloud-automation_changes)
 
-  #echo ${changes}
+  echo ${changes}
 
   if [[ ${changes} == "true" ]];
   then
+    echo 1
     #local files_changes
     #changes="$(git diff-index --name-only HEAD --)"
     message=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
@@ -84,6 +85,7 @@ gen3_run_tfplan() {
     git diff-index --name-only HEAD -- >> ${message} 2>&1
   elif [[ ${changes} == "false" ]];
   then
+    echo 2
     # checking for the result of _check_cloud-automation_changes just in case it came out empty
     # for whatever reson 
     case "$module" in

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -69,15 +69,24 @@ gen3_run_tfplan() {
   local module
   local changes
   
-  slack_hook="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic"
+
   module=$1
+  if [ -z $2 ];
+  then
+    slack_hook="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic"
+  elif [ $2 == "local_hook" ];
+  then
+    slack_hook=$(g3kubectl get configmap global -o jsonpath='{ .data.slack_webhook }')
+  else
+    slack_hook="$2"
+  fi
+
   changes=$(_check_cloud-automation_changes)
 
-  echo ${changes}
+  #echo ${changes}
 
   if [[ ${changes} == "true" ]];
   then
-    echo 1
     #local files_changes
     #changes="$(git diff-index --name-only HEAD --)"
     message=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
@@ -85,7 +94,6 @@ gen3_run_tfplan() {
     git diff-index --name-only HEAD -- >> ${message} 2>&1
   elif [[ ${changes} == "false" ]];
   then
-    echo 2
     # checking for the result of _check_cloud-automation_changes just in case it came out empty
     # for whatever reson 
     case "$module" in

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -73,7 +73,7 @@ gen3_run_tfplan() {
   module=$1
   changes=$(_check_cloud-automation_changes)
 
-  echo ${changes}
+  #echo ${changes}
 
   if [[ ${changes} == "true" ]];
   then
@@ -81,7 +81,7 @@ gen3_run_tfplan() {
     #changes="$(git diff-index --name-only HEAD --)"
     message=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
     echo "${vpc_name} has uncommited changes for cloud-automation" > ${message}
-    git diff-index --name-only HEAD -- >> ${message}
+    git diff-index --name-only HEAD -- >> ${message} 2>&1
   elif [[ ${changes} == "false" ]];
   then
     # checking for the result of _check_cloud-automation_changes just in case it came out empty
@@ -98,7 +98,7 @@ gen3_run_tfplan() {
 
   if [ -n "${message}" ];
   then
-    aws sns publish --target-arn ${slack_hook} --message file://${message} > /dev/null #2>&1
+    aws sns publish --target-arn ${slack_hook} --message file://${message} > /dev/null 2>&1
     rm ${message}
   fi
 

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -50,7 +50,7 @@ _check_cloud-automation_changes() {
   cd ~/cloud-automation
   if git diff-index --quiet HEAD --; then
     # Should the repo has no changes, let's just pull, because why not
-    git pull
+    git pull > /dev/null 2>&1
     echo "false"
   else
     echo "true"

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -65,21 +65,13 @@ _check_cloud-automation_changes() {
 gen3_run_tfplan() {
 
   local message
-  local slack_hook
+  local sns_topic
   local module
   local changes
   
 
   module=$1
-  if [ -z $2 ];
-  then
-    slack_hook="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic"
-  elif [ $2 == "local_hook" ];
-  then
-    slack_hook=$(g3kubectl get configmap global -o jsonpath='{ .data.slack_webhook }')
-  else
-    slack_hook="$2"
-  fi
+  sns_topic="arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic"
 
   changes=$(_check_cloud-automation_changes)
 
@@ -108,7 +100,7 @@ gen3_run_tfplan() {
 
   if [ -n "${message}" ];
   then
-    aws sns publish --target-arn ${slack_hook} --message file://${message} > /dev/null 2>&1
+    aws sns publish --target-arn ${sns_topic} --message file://${message} > /dev/null 2>&1
     rm ${message}
   fi
 

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -688,6 +688,9 @@ if [[ -z "$GEN3_SOURCE_ONLY" ]]; then
     "dotag")
       gen3_gitops_repo_dotag "$@"
       ;;
+    "tfplan")
+      gen3_run_tfplan_vpc "$@"
+      ;;
     *)
       help
       ;;

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -42,6 +42,43 @@ _check_manifest_global_diff() {
 }
 
 #
+# Internal uptil for checking for differences in cloud-automation 
+# basicallt checking if through git 
+
+_check_cloud-automation_changes() {
+
+  cd ~/cloud-automation
+  if git diff-index --quiet HEAD --; then
+    echo "false"
+  else
+    echo "true"
+  fi
+}
+
+
+#
+# Function that checks 
+#
+#
+gen3_run_tfplan_vpc() {
+
+  local plan
+  if [ _check_cloud-automation_Changes == "false" ];
+  then
+    gen3 workon $(grep profile ~/.aws/config  |awk '{print $2}'| cut -d] -f1) ${vpc_name}
+    plan=$(gen3 tfplan | grep "^Plan")
+
+    if ! [ -z ${plan} ];
+    then
+      echo ${plan}
+      aws sns publish --target-arn arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic --message "${vpc_name} has unapplied plan \n${plan}"
+    fi
+
+  fi
+
+}
+
+#
 # command to update dictionary URL and image versions
 #
 gen3_gitops_sync() {

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -63,7 +63,7 @@ _check_cloud-automation_changes() {
 gen3_run_tfplan_vpc() {
 
   local plan
-  if [ _check_cloud-automation_Changes == "false" ];
+  if [[ $(_check_cloud-automation_Changes) == "false" ]];
   then
     gen3 workon $(grep profile ~/.aws/config  |awk '{print $2}'| cut -d] -f1) ${vpc_name}
     plan=$(gen3 tfplan | grep "^Plan")
@@ -73,7 +73,8 @@ gen3_run_tfplan_vpc() {
       echo ${plan}
       aws sns publish --target-arn arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic --message "${vpc_name} has unapplied plan \n${plan}"
     fi
-
+  else
+    aws sns publish --target-arn arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic --message "${vpc_name} uncommited changes for cloud-automation"
   fi
 
 }

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -110,7 +110,7 @@ gen3_run_tfplan_eks() {
     then
       #echo ${plan}
       tempFile=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
-      echo "${vpc_name} has unapplied plan:" > ${tempFile}
+      echo "${vpc_name}_eks has unapplied plan:" > ${tempFile}
       echo -e "${plan}"| sed -r "s/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[mGK]//g" >> ${tempFile}
       aws sns publish --target-arn ${slack_hook} --message file://${tempFile} > /dev/null 2>&1
       #  "${vpc_name} has unapplied plan \n${plan}"
@@ -120,7 +120,7 @@ gen3_run_tfplan_eks() {
     local changes
     changes="$(git diff-index --name-only HEAD --)"
     tempFile=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
-    echo "${vpc_name} has uncommited changes for cloud-automation" > ${tempFile}
+    echo "${vpc_name}_eks has uncommited changes for cloud-automation" > ${tempFile}
     git diff-index --name-only HEAD -- >> ${tempFile}
     aws sns publish --target-arn ${slack_hook} --message file://${tempFile} > /dev/null 2>&1
     # "${vpc_name} has uncommited changes for cloud-automation \n${changes}"

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -73,10 +73,12 @@ gen3_run_tfplan() {
   module=$1
   changes=$(_check_cloud-automation_changes)
 
+  echo ${changes}
+
   if [[ ${changes} == "true" ]];
   then
-    local changes
-    changes="$(git diff-index --name-only HEAD --)"
+    #local files_changes
+    #changes="$(git diff-index --name-only HEAD --)"
     message=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
     echo "${vpc_name} has uncommited changes for cloud-automation" > ${message}
     git diff-index --name-only HEAD -- >> ${message}

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -120,7 +120,7 @@ gen3_run_tfplan_eks() {
     local changes
     changes="$(git diff-index --name-only HEAD --)"
     tempFile=$(mktemp -p "$XDG_RUNTIME_DIR" "tmp_plan.XXXXXX")
-    echo "${vpc_name}_eks has uncommited changes for cloud-automation" > ${tempFile}
+    echo "${vpc_name} has uncommited changes for cloud-automation" > ${tempFile}
     git diff-index --name-only HEAD -- >> ${tempFile}
     aws sns publish --target-arn ${slack_hook} --message file://${tempFile} > /dev/null 2>&1
     # "${vpc_name} has uncommited changes for cloud-automation \n${changes}"

--- a/gen3/lib/_zsh-completions.sh
+++ b/gen3/lib/_zsh-completions.sh
@@ -34,7 +34,7 @@ _gen3_zsh_completions() {
     args)
       case $line[1] in
         gitops)
-          _values "gitops commands" configmaps rsync sshlist sync repolist taglist dotag && ret=0
+          _values "gitops commands" configmaps rsync sshlist sync repolist taglist dotag tfplan-vpc tfplan-eks && ret=0
           ;;
         job)
           if [[ "$line[2]" == "run" ]]; then

--- a/gen3/lib/_zsh-completions.sh
+++ b/gen3/lib/_zsh-completions.sh
@@ -34,7 +34,7 @@ _gen3_zsh_completions() {
     args)
       case $line[1] in
         gitops)
-          _values "gitops commands" configmaps rsync sshlist sync repolist taglist dotag tfplan-vpc tfplan-eks && ret=0
+          _values "gitops commands" configmaps rsync sshlist sync repolist taglist dotag tfplan && ret=0
           ;;
         job)
           if [[ "$line[2]" == "run" ]]; then

--- a/gen3/lib/bash-completions.sh
+++ b/gen3/lib/bash-completions.sh
@@ -8,7 +8,7 @@ gen3_completions() {
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "es" ]]; then
     COMPREPLY=($(compgen -W "filter configmaps alias indices delete dump export import mapping port-forward" "${COMP_WORDS[2]}"))
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "gitops" ]]; then
-    COMPREPLY=($(compgen -W "filter configmaps rsync sshlist sync repolist taglist dotag tfplan-vpc tfplan-eks" "${COMP_WORDS[2]}"))
+    COMPREPLY=($(compgen -W "filter configmaps rsync sshlist sync repolist taglist dotag tfplan" "${COMP_WORDS[2]}"))
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "job" ]]; then
     COMPREPLY=($(compgen -W "run logs" "${COMP_WORDS[2]}"))
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "klock" ]]; then

--- a/gen3/lib/bash-completions.sh
+++ b/gen3/lib/bash-completions.sh
@@ -8,7 +8,7 @@ gen3_completions() {
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "es" ]]; then
     COMPREPLY=($(compgen -W "filter configmaps alias indices delete dump export import mapping port-forward" "${COMP_WORDS[2]}"))
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "gitops" ]]; then
-    COMPREPLY=($(compgen -W "filter configmaps rsync sshlist sync repolist taglist dotag" "${COMP_WORDS[2]}"))
+    COMPREPLY=($(compgen -W "filter configmaps rsync sshlist sync repolist taglist dotag tfplan-vpc tfplan-eks" "${COMP_WORDS[2]}"))
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "job" ]]; then
     COMPREPLY=($(compgen -W "run logs" "${COMP_WORDS[2]}"))
   elif [[ ${COMP_CWORD} -eq 2 && "${COMP_WORDS[1]}" == "klock" ]]; then

--- a/tf_files/aws/commons/outputs.tf
+++ b/tf_files/aws/commons/outputs.tf
@@ -90,9 +90,9 @@ data "template_file" "cluster" {
 # instead just publish output variables
 #
 resource "null_resource" "config_setup" {
-  triggers {
-    cluster_change = "${data.template_file.cluster.rendered}"
-  }
+#  triggers {
+#    cluster_change = "${data.template_file.cluster.rendered}"
+#  }
 
 #  provisioner "local-exec" {
 #    command = "mkdir ${var.vpc_name}_output; echo '${data.template_file.cluster.rendered}' > ${var.vpc_name}_output/kube-aws.cluster.yaml"

--- a/tf_files/aws/modules/alarms-lambda/lambda.tf
+++ b/tf_files/aws/modules/alarms-lambda/lambda.tf
@@ -7,14 +7,15 @@ resource "aws_iam_role" "lambda_role" {
 
   assume_role_policy = <<EOF
 {
+  "Version": "2008-10-17",
   "Statement": [
     {
-      "Action": "sts:AssumeRole",
+      "Sid": "",
+      "Effect": "Allow",
       "Principal": {
         "Service": "lambda.amazonaws.com"
       },
-      "Effect": "Allow",
-      "Sid": ""
+      "Action": "sts:AssumeRole"
     }
   ]
 }


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- `gitops tfplan-vpc` `gitops tfplan-eks` should allow us to run tfplan periodically on al environments and get the status of the current status along with the content of cloud-automation 

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

