### PR TITLE
feat(indices): recreate all indices

### DIFF
--- a/files/scripts/es-cronjob.sh
+++ b/files/scripts/es-cronjob.sh
@@ -28,3 +28,19 @@ gen3 logs save ubh '-12 hours'
 
 # Delete indices older than 3 weeks
 gen3_retry gen3 logs curl200 "*-w$(date -d '3 week ago' +%U)" -X DELETE
+
+# re-create indices
+URL_ROOT="https://kibana.planx-pla.net"
+curl "${URL_ROOT}/_cat/indices?v" | awk -F' ' '{print $3}' | awk -F'-' '{print $1}' | sort -u | while read -r prefix ; do
+  res=$(curl "${URL_ROOT}/.kibana/index-pattern/${prefix}-*")
+  found=$(echo $res | jq '.found')
+  if [ $found == "true" ]; then
+    timeFieldName=$(echo $res | jq '._source.timeFieldName')
+    curl -XDELETE "${URL_ROOT}/.kibana/index-pattern/${prefix}-*"
+    curl "${URL_ROOT}/.kibana/index-pattern/${prefix}-*/_create"\
+    -H "Content-Type: application/json"\
+    -H "Accept: application/json, text/plain, */*"\
+    -H "kbn-xsrf: $prefix-*"\
+    --data-binary "{\"title\":\"${prefix}-*\",\"timeFieldName\":$timeFieldName}" -w "\n"
+  fi
+done


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

Run cronjob to re-create ES indices for Kibana

### New Features
- Add bash script to automate es indices creation