### PR TITLE
fix(roll-all): disable netpolicy earlier

### DIFF
--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -36,11 +36,13 @@ if ! g3kubectl get storageclass standard > /dev/null 2>&1; then
   g3kubectl apply -f "${GEN3_HOME}/kube/services/storageclass/aws-storageclass.yaml"
 fi
 
-
+gen3 kube-setup-networkpolicy disable
+#
+# Hopefull core secrets/config in place - start bringing up services
+#
 gen3 kube-setup-indexd
 gen3 kube-setup-arborist || true
 gen3 kube-setup-fence
-
 
 if g3k_manifest_lookup .versions.ssjdispatcher 2>&1 /dev/null; then
   gen3 kube-setup-ssjdispatcher


### PR DESCRIPTION
need to apply the "disable" rule before we start bringing up services,
because rolling a service updates that service networkpolicy,
and networkpolicy does not work if only some of the rules are applied ...