### PR TITLE
Feat/authz endpoint

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -31,7 +31,7 @@ location = /gen3-authz {
 # authorization endpoint
 # https://hostname/authz?resource=programs/blah&method=acb&service=xyz
 #
-location = /authz {
+location ~ /authz/? {
     error_page 400 =403 @errorworkspace;
     error_page 500 =403 @errorworkspace;
 

--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -32,27 +32,23 @@ location = /gen3-authz {
 # https://hostname/authz?resource=programs/blah&method=acb&service=xyz
 #
 location ~ /authz/? {
-    error_page 400 =403 @errorworkspace;
-    error_page 500 =403 @errorworkspace;
+    if ($csrf_check !~ ^ok-\S.+$) {
+        return 403 "failed csrf check";
+    }
 
-    # avoid setting $upstream in authz subrequests ...
-    set $upstream_authz http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+    set $upstream http://${arborist_release_name}-service.$namespace.svc.cluster.local;
 
-    proxy_pass $upstream_authz/auth/proxy?resource=$arg_resource&method=$arg_method&service=$arg_service;
+    proxy_pass $upstream/auth/proxy?resource=$arg_resource&method=$arg_method&service=$arg_service;
+}
 
-    proxy_pass_request_body off;
-    proxy_set_header Authorization "$access_token";
-    proxy_set_header Content-Length "";
-    proxy_set_header X-Forwarded-For "$realip";
-    proxy_set_header X-UserId "$userid";
-    proxy_set_header X-ReqId "$request_id";
-    proxy_set_header X-SessionId "$session_id";
-    proxy_set_header X-VisitorId "$visitor_id";
-    proxy_set_header X-Original-URI $request_uri;
-    proxy_intercept_errors on;
+location = /authz/resources {
+    if ($csrf_check !~ ^ok-\S.+$) {
+        return 403 "failed csrf check";
+    }
 
-    # nginx bug that it checks even if request_body off
-    client_max_body_size 0;
+    set $upstream http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+
+    proxy_pass $upstream/auth/resources;
 }
 
 #

--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -28,6 +28,39 @@ location = /gen3-authz {
 }
 
 #
+# authorization endpoint
+# https://hostname/authz?resource=programs/blah&method=acb&service=xyz
+#
+location = /authz {
+    internal;
+    error_page 400 =403 @errorworkspace;
+    error_page 500 =403 @errorworkspace;
+
+    add_header X-resource "$arg_resource";
+    add_header X-method "$arg_method";
+    add_header X-service "$arg_service";
+
+    # avoid setting $upstream in authz subrequests ...
+    set $upstream_authz http://${arborist_release_name}-service.$namespace.svc.cluster.local;
+
+    proxy_pass $upstream_authz/auth/proxy?resource=$arg_resource&method=$arg_method&service=$arg_service;
+
+    proxy_pass_request_body off;
+    proxy_set_header Authorization "$access_token";
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Forwarded-For "$realip";
+    proxy_set_header X-UserId "$userid";
+    proxy_set_header X-ReqId "$request_id";
+    proxy_set_header X-SessionId "$session_id";
+    proxy_set_header X-VisitorId "$visitor_id";
+    proxy_set_header X-Original-URI $request_uri;
+    proxy_intercept_errors on;
+
+    # nginx bug that it checks even if request_body off
+    client_max_body_size 0;
+}
+
+#
 # Little endpoint for testing that authz is being enforced
 #
 location = /gen3-authz-test {

--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -32,13 +32,8 @@ location = /gen3-authz {
 # https://hostname/authz?resource=programs/blah&method=acb&service=xyz
 #
 location = /authz {
-    internal;
     error_page 400 =403 @errorworkspace;
     error_page 500 =403 @errorworkspace;
-
-    add_header X-resource "$arg_resource";
-    add_header X-method "$arg_method";
-    add_header X-service "$arg_service";
 
     # avoid setting $upstream in authz subrequests ...
     set $upstream_authz http://${arborist_release_name}-service.$namespace.svc.cluster.local;


### PR DESCRIPTION
`https://xxx/authz?resource=RESOURCE_PATH&method=METHOD_NAME&service=SERVICE_NAME`
or
`https://xxx/authz/?resource=RESOURCE_PATH&method=METHOD_NAME&service=SERVICE_NAME`

### New Features
- Expose arborist's `auth/proxy` and `auth/resources` endpoints
