### PR TITLE
chore/jenkins

### DIFF
--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.187
+FROM jenkins/jenkins:2.192
 
 USER root
 


### PR DESCRIPTION
### Dependency updates
* Security update of Jenkins to latest available version (2.192). Per [news](https://jenkins.io/security/advisory/2019-08-28/).