### PR TITLE
chore(grafana): update the Grafana to latest (6.3.5) version

### DIFF
--- a/kube/services/monitoring/grafana-values.yaml
+++ b/kube/services/monitoring/grafana-values.yaml
@@ -26,7 +26,7 @@ livenessProbe:
 
 image:
   repository: grafana/grafana
-  tag: 6.0.0
+  tag: 6.3.5
   pullPolicy: IfNotPresent
 
   ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
* Updates the Grafana to latest (6.3.5) version: improved filtering for Prometheus, better provisioning setup, Loki improvements. 