### PR TITLE
chore(sower): sower 0.3.0 doesn't need any additional secrets

### DIFF
--- a/kube/services/sower/sower-deploy.yaml
+++ b/kube/services/sower/sower-deploy.yaml
@@ -43,12 +43,6 @@ spec:
             items:
               - key: json
                 path: sower_config.json
-        - name: pelican-creds-volume
-          secret:
-            secretName: "pelicanservice-g3auto"
-        - name: peregrine-creds-volume
-          secret:
-            secretName: "peregrine-creds"
       containers:
       - name: sower
         GEN3_SOWER_IMAGE
@@ -86,11 +80,3 @@ spec:
             readOnly: true
             mountPath: /sower_config.json
             subPath: sower_config.json
-          - name: pelican-creds-volume
-            readOnly: true
-            mountPath: /pelican-creds.json
-            subPath: config.json
-          - name: "peregrine-creds-volume"
-            readOnly: true
-            mountPath: "/peregrine-creds.json"
-            subPath: creds.json


### PR DESCRIPTION
Sower 0.3.0 and up doesn't use additional Pelican or Peregrine secrets therefore they are not needed.

### Breaking Changes
- No

### Deployment changes
- No, just use 0.3.0 and above. No changes for VPODC, it has pinned sower version which doesn't use secrets at all.