### PR TITLE
chore(gist): allow gist in Squid

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -101,6 +101,7 @@ ppa.launchpad.net
 pubmirrors.dal.corespace.com
 quay.io
 raw.githubusercontent.com
+gist.githubusercontent.com
 reflector.westga.edu
 registry.npmjs.org
 registry.terraform.io


### PR DESCRIPTION
### Improvements
* Allow gist.githubusercontent.com in Squid whitelist