### PR TITLE
chore(arborist-param): peregrine and sheepdog apis_configs

### DIFF
--- a/apis_configs/peregrine_settings.py
+++ b/apis_configs/peregrine_settings.py
@@ -13,6 +13,8 @@ config["AUTH"] = 'https://auth.service.consul:5000/v3/'
 config["AUTH_ADMIN_CREDS"] = None
 config["INTERNAL_AUTH"] = None
 
+config["ARBORIST"] = "http://arborist-service/"
+
 # Signpost: deprecated, replaced by index client.
 config['SIGNPOST'] = {
     'host': environ.get('SIGNPOST_HOST') or 'http://indexd-service',

--- a/apis_configs/sheepdog_settings.py
+++ b/apis_configs/sheepdog_settings.py
@@ -13,6 +13,8 @@ config["AUTH"] = 'https://auth.service.consul:5000/v3/'
 config["AUTH_ADMIN_CREDS"] = None
 config["INTERNAL_AUTH"] = None
 
+config["ARBORIST"] = "http://arborist-service/"
+
 # Signpost: deprecated, replaced by index client.
 config['SIGNPOST'] = {
     'host': environ.get('SIGNPOST_HOST') or 'http://indexd-service',


### PR DESCRIPTION
Add "ARBORIST" parameter to Peregrine and Sheepdog configs to specify arborist URL
[Default is "http://arborist-service/"](https://github.com/uc-cdis/gen3authz/blob/0.2.2/python/gen3authz/client/arborist/client.py#L124)