### PR TITLE
Remove mariner revproxy conf.

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/mariner-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/mariner-service.conf
@@ -1,8 +1,0 @@
-
-	location  /mariner/ {
-		set $proxy_service "${mariner_release_name}";
-		set $upstream http://${mariner_release_name}-service.$namespace.svc.cluster.local;
-		proxy_pass $upstream;
-		proxy_redirect http://$host/ https://$host/;
-		}
-


### PR DESCRIPTION
Remove mariner conf. Mariner API not supposed to be publicly exposed.

### New Features

### Breaking Changes

### Bug Fixes
- remove mariner from revproxy

### Improvements

### Dependency updates

### Deployment changes
