### PR TITLE
chore(volumes): naming after deploying from snapshot

### DIFF
--- a/files/scripts/jupyter_migration.sh
+++ b/files/scripts/jupyter_migration.sh
@@ -83,7 +83,7 @@ function createVolumesCopy()
                 VAL=$(echo $tags |awk '{print $2}')
                 if [ ${KEY} == "Name" ];
                 then
-                        VAL="copy-${VAL}"
+                        VAL="${NEW_VOLUME_PREFIX}${VAL}"
                 elif [ ${KEY} == "kubernetes.io/created-for/pv/name" ];
                 then
                         PVNAME="${VAL}"


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

### Breaking Changes


### Bug Fixes
- When volumes were created off snapshots taken from existing jupyter volumes, naming prefix were hardcoded instead of using the variable assigned for that purpose 

### Improvements


### Dependency updates


### Deployment changes

