### PR TITLE
fix/pelicanjob

### DIFF
--- a/gen3/bin/kube-setup-pelicanjob.sh
+++ b/gen3/bin/kube-setup-pelicanjob.sh
@@ -7,29 +7,24 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/gen3setup"
 
-hostname="$(g3kubectl get configmap global -o json | jq -r .data.hostname)"
-short_hostname=$(echo "$hostname" | cut -f1 -d".")
-short_awsuser="${short_hostname}-pelican"
-
-if ! g3kubectl describe secret $short_awsuser-g3auto | grep awsusercreds.json > /dev/null 2>&1; then
+if ! g3kubectl describe secret pelicanservice-g3auto | grep config.json > /dev/null 2>&1; then
+  hostname="$(g3kubectl get configmap global -o json | jq -r .data.hostname)"
   ref_hostname=$(echo "$hostname" | sed 's/\./-/g')
   bucketname="${ref_hostname}-pfb-export"
   awsuser="${ref_hostname}-pelican"
+  mkdir -p $(gen3_secrets_folder)/g3auto/pelicanservice
+  credsFile="$(gen3_secrets_folder)/g3auto/pelicanservice/config.json"
 
-  if ! g3kubectl describe secret $awsuser-g3auto | grep awsusercreds.json > /dev/null 2>&1; then
-    mkdir -p $(gen3_secrets_folder)/g3auto/pelicanservice
-    credsFile="$(gen3_secrets_folder)/g3auto/pelicanservice/config.json"
+  if [[ (! -f "$credsFile") && -z "$JENKINS_HOME" ]]; then
+    gen3 s3 create "$bucketname"
+    gen3 awsuser create "${ref_hostname}-pelican"
+    gen3 s3 attach-bucket-policy "$bucketname" --read-write --user-name "${ref_hostname}-pelican"
 
-    if [[ (! -f "$credsFile") && -z "$JENKINS_HOME" ]]; then
-      gen3 s3 create "$bucketname"
-      gen3 awsuser create "${ref_hostname}-pelican"
-      gen3 s3 attach-bucket-policy "$bucketname" --read-write --user-name "${ref_hostname}-pelican"
-
-      gen3_log_info "initializing pelicanservice config.json"
-      user=$(gen3 secrets decode $awsuser-g3auto awsusercreds.json)
-      key_id=$(jq -r .id <<< $user)
-      access_key=$(jq -r .secret <<< $user)
-      cat - > "$credsFile" <<EOM
+    gen3_log_info "initializing pelicanservice config.json"
+    user=$(gen3 secrets decode $awsuser-g3auto awsusercreds.json)
+    key_id=$(jq -r .id <<< $user)
+    access_key=$(jq -r .secret <<< $user)
+    cat - > "$credsFile" <<EOM
 {
   "manifest_bucket_name": "$bucketname",
   "hostname": "$hostname",
@@ -37,6 +32,5 @@ if ! g3kubectl describe secret $short_awsuser-g3auto | grep awsusercreds.json > 
   "aws_secret_access_key": "$access_key"
 }
 EOM
-    gen3 secrets sync "initialize pelicanservice/config.json"
-  fi
+  gen3 secrets sync "initialize pelicanservice/config.json"
 fi

--- a/gen3/bin/kube-setup-pelicanjob.sh
+++ b/gen3/bin/kube-setup-pelicanjob.sh
@@ -8,12 +8,12 @@ source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/gen3setup"
 
 hostname="$(g3kubectl get configmap global -o json | jq -r .data.hostname)"
-short_hostname=$(echo "$hostname" | cut -f1 -d".")
-bucketname="${short_hostname}-pfb-export"
+ref_hostname=$(echo "$hostname" | sed 's/\./-/g')
+bucketname="${ref_hostname}-pfb-export"
 gen3 s3 create "$bucketname"
-awsuser="${short_hostname}-pelican"
-gen3 awsuser create "${short_hostname}-pelican"
-gen3 s3 attach-bucket-policy "$bucketname" --read-write --user-name "${short_hostname}-pelican"
+awsuser="${ref_hostname}-pelican"
+gen3 awsuser create "${ref_hostname}-pelican"
+gen3 s3 attach-bucket-policy "$bucketname" --read-write --user-name "${ref_hostname}-pelican"
 
 mkdir -p $(gen3_secrets_folder)/g3auto/pelicanservice
 credsFile="$(gen3_secrets_folder)/g3auto/pelicanservice/config.json"


### PR DESCRIPTION
### Bug Fixes
- Previously `pelicanjob` used only the first part of domain, this cased an issue if multiple environments have the same subdomain (staging.theanvil.io vs staging.datastage.io), this PR fixes it by using the the full hostname as a part of bucket and username

### Deployment changes
- Old environments will keep working, but it is better to rerun `kube-setup-pelicanjob` and remove the old IAM user and bucket