### PR TITLE
squid whitelist += login.bionimbus.org

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -66,6 +66,7 @@ k8s.gcr.io
 keyservice.opensciencedatacloud.org
 ks.osdc.io
 lib.stat.cmu.edu
+login.bionimbus.org/Shibboleth.sso/DiscoFeed
 login.mathworks.com
 login.microsoftonline.com
 maven.restlet.org

--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -66,7 +66,7 @@ k8s.gcr.io
 keyservice.opensciencedatacloud.org
 ks.osdc.io
 lib.stat.cmu.edu
-login.bionimbus.org/Shibboleth.sso/DiscoFeed
+login.bionimbus.org
 login.mathworks.com
 login.microsoftonline.com
 maven.restlet.org


### PR DESCRIPTION
Add login.bionimbus.org/Shibboleth.sso/DiscoFeed to squid whitelist to fetch list of available shibboleth IDPs from data-portal for incommon
