### PR TITLE
Chore/fence dbmigrate

### DIFF
--- a/gen3/bin/job.sh
+++ b/gen3/bin/job.sh
@@ -20,7 +20,7 @@ g3k_wait4job(){
       echo "job fail"
       exit 1
     fi
-    gen3_log_err "waiting for $jobName to finish"
+    gen3_log_info "waiting for $jobName to finish"
     sleep 10
   done
 }

--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -56,6 +56,8 @@ fi
 if g3k_manifest_lookup .versions.fence 2> /dev/null; then
   # data ecosystem sub-commons may not deploy fence ...
   gen3 kube-setup-fence
+elif g3k_manifest_lookup .versions.fenceshib 2> /dev/null; then
+  gen3 kube-setup-fenceshib
 else
   gen3_log_info "no manifest entry for fence"
 fi

--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -68,10 +68,6 @@ if g3kubectl get cronjob usersync >/dev/null 2>&1; then
     gen3 job run "${GEN3_HOME}/kube/services/jobs/usersync-cronjob.yaml"
 fi
 
-if g3kubectl get configmap manifest-google >/dev/null 2>&1; then
-  gen3 kube-setup-google
-fi
-
 if g3k_manifest_lookup .versions.sheepdog 2> /dev/null; then
   gen3 kube-setup-sheepdog
 else

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -33,4 +33,4 @@ gen3 roll fence-canary || true
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-canary-service.yaml"
 gen3_log_info "The fence service has been deployed onto the k8s cluster."
 
-gen3 kube_setup_google
+gen3 kube-setup-google

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -15,27 +15,22 @@ if [[ -d "$(gen3_secrets_folder)/creds.json" ]]; then # create database
   cd "${WORKSPACE}/${vpc_name}"
   if [[ ! -f .rendered_fence_db ]]; then
     gen3 job run fencedb-create
-    echo "Waiting 10 seconds for fencedb-create job"
+    gen3_log_info "Waiting 10 seconds for fencedb-create job"
     sleep 10
     gen3 job logs fencedb-create || true
     gen3 job run useryaml
     gen3 job logs useryaml || true
-    echo "Leaving setup jobs running in background"
-    cd "$(gen3_secrets_folder)"
+    gen3_log_info "Leaving setup jobs running in background"
   fi
   # avoid doing the previous block more than once or when not necessary ...
   touch "$(gen3_secrets_folder)/.rendered_fence_db"
 fi
-
-# migrate the database
-gen3_log_info "migrating fence db ..."
-gen3 job run fence-db-migrate --wait
 
 # deploy fence
 gen3 roll fence
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-service.yaml"
 gen3 roll fence-canary || true
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-canary-service.yaml"
-gen3_log_info "The fence services has been deployed onto the k8s cluster."
+gen3_log_info "The fence service has been deployed onto the k8s cluster."
 
 gen3 kube_setup_google

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -27,12 +27,15 @@ if [[ -d "$(gen3_secrets_folder)/creds.json" ]]; then # create database
   touch "$(gen3_secrets_folder)/.rendered_fence_db"
 fi
 
+# migrate the database
+gen3_log_info "migrating fence db ..."
+gen3 job run fence-db-migrate --wait
+
 # deploy fence
 gen3 roll fence
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-service.yaml"
 gen3 roll fence-canary || true
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-canary-service.yaml"
+gen3_log_info "The fence services has been deployed onto the k8s cluster."
 
-cat <<EOM
-The fence services has been deployed onto the k8s cluster.
-EOM
+gen3 kube_setup_google

--- a/gen3/bin/kube-setup-google.sh
+++ b/gen3/bin/kube-setup-google.sh
@@ -4,17 +4,54 @@
 #
 
 source "${GEN3_HOME}/gen3/lib/utils.sh"
-gen3_load "gen3/lib/kube-setup-init"
+gen3_load "gen3/gen3setup"
 
-isEnabled="$(g3kubectl get configmap manifest-google -o json | jq -e -r .data.enabled)"
-if [[ "yes" == "$isEnabled" ]]; then
-  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-manage-keys-cronjob.yaml"
-  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-manage-account-access-cronjob.yaml"
-  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-init-proxy-groups-cronjob.yaml"
-  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml"
-  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml"
+cronList=(
+  "${GEN3_HOME}/kube/services/jobs/google-manage-keys-cronjob.yaml"
+  "${GEN3_HOME}/kube/services/jobs/google-manage-account-access-cronjob.yaml"
+  "${GEN3_HOME}/kube/services/jobs/google-init-proxy-groups-cronjob.yaml"
+  "${GEN3_HOME}/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml"
+  "${GEN3_HOME}/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml"
+)
+
+# lib --------------------
+
+goog_launch() {
+  local path
+  for path in "${cronList[@]}"; do
+    gen3 job run "$path"
+  done
   gen3 roll google-sa-validation
   g3kubectl apply -f "${GEN3_HOME}/kube/services/google-sa-validation/google-sa-validation-service.yaml"
+}
+
+goog_stop() {
+  local path
+  local jobName
+  for path in "${cronList[@]}"; do
+    if jobName="$(gen3 gitops filter "$path" | yq -r .metadata.name)" && [[ -n "$jobName" ]]; then
+      g3kubectl delete job "$jobName" > /dev/null 2>&1
+    fi
+  done
+}
+
+# main ----------------------
+
+isEnabled="$(g3kubectl get configmap manifest-google -o json 2> /dev/null | jq -e -r .data.enabled)"
+
+
+if [[ "yes" == "$isEnabled" ]]; then
+  command="launch"
+  if [[ $# -gt 0 && "$1" =~ ^-*stop$ ]]; then
+    command="stop"
+    shift
+  fi
+
+  if [[ "launch" == "$command" ]]; then
+    goog_launch
+  elif [[ "stop" == "$command" ]]; then
+    goog_stop
+  fi
 else
   gen3_log_info "google cron jobs are not enabled in the manifest"
 fi

--- a/gen3/bin/kube-setup-google.sh
+++ b/gen3/bin/kube-setup-google.sh
@@ -3,21 +3,18 @@
 # Initializes the Gen3 k8s cronjobs.
 #
 
-set -e
-
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/lib/kube-setup-init"
 
-
-gen3 job run "${GEN3_HOME}/kube/services/jobs/google-manage-keys-cronjob.yaml"
-
-gen3 job run "${GEN3_HOME}/kube/services/jobs/google-manage-account-access-cronjob.yaml"
-
-gen3 job run "${GEN3_HOME}/kube/services/jobs/google-init-proxy-groups-cronjob.yaml"
-
-gen3 job run "${GEN3_HOME}/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml"
-
-gen3 job run "${GEN3_HOME}/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml"
-
-gen3 roll google-sa-validation
-g3kubectl apply -f "${GEN3_HOME}/kube/services/google-sa-validation/google-sa-validation-service.yaml"
+isEnabled="$(g3kubectl get configmap manifest-google -o json | jq -e -r .data.enabled)"
+if [[ "yes" == "$isEnabled" ]]; then
+  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-manage-keys-cronjob.yaml"
+  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-manage-account-access-cronjob.yaml"
+  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-init-proxy-groups-cronjob.yaml"
+  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml"
+  gen3 job run "${GEN3_HOME}/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml"
+  gen3 roll google-sa-validation
+  g3kubectl apply -f "${GEN3_HOME}/kube/services/google-sa-validation/google-sa-validation-service.yaml"
+else
+  gen3_log_info "google cron jobs are not enabled in the manifest"
+fi

--- a/gen3/bin/kube-setup-secrets.sh
+++ b/gen3/bin/kube-setup-secrets.sh
@@ -217,7 +217,7 @@ if [[ -f "$(gen3_secrets_folder)/creds.json" ]]; then # update fence secrets
       echo "job will also attempt to load old configuration into fence-config.yaml..."
       echo "NOTE: Some default config values from fence-config.yaml will be replaced"
       echo "      Run \"gen3 joblogs config-fence\" for details"
-      gen3 runjob config-fence CONVERT_OLD_CFG "true"
+      gen3 job run config-fence CONVERT_OLD_CFG "true"
 
       # dump fence-config secret into file so user can edit.
       let count=1

--- a/gen3/lib/logs/raw.sh
+++ b/gen3/lib/logs/raw.sh
@@ -113,20 +113,27 @@ ENESTED
           else echo ""
           fi
         )
+        $(
+          if [[ "$statusMin" -gt 0 || "$statusMax" -lt 1000 ]]; then
+            cat - <<ENESTED
+        { 
+          "range": {
+            "message.http_status_code": {
+              "gte": $statusMin,
+              "lte": $statusMax
+            }
+          }
+        },
+ENESTED
+          else echo ""
+          fi
+        )
         { 
           "range": {
             "timestamp": {
               "gte": "$startDate",
               "lte": "$endDate",
               "format": "yyyy/MM/dd HH:mm"
-            }
-          }
-        },
-        { 
-          "range": {
-            "message.http_status_code": {
-              "gte": $statusMin,
-              "lte": $statusMax
             }
           }
         }

--- a/gen3/lib/testData/default/expectedFenceResult.yaml
+++ b/gen3/lib/testData/default/expectedFenceResult.yaml
@@ -120,3 +120,32 @@ spec:
             limits:
               cpu: 0.3
               memory: 1200Mi
+      initContainers:
+      - name: fence-init
+        image: quay.io/cdis/fence:2.0.2
+        imagePullPolicy: Always
+        env:
+          - name: PYTHONPATH
+            value: /var/www/fence
+        volumeMounts:
+          - name: "config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence-config.yaml"
+            subPath: fence-config.yaml
+          - name: "fence-google-app-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_app_creds_secret.json"
+            subPath: fence_google_app_creds_secret.json
+          - name: "fence-google-storage-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_storage_creds_secret.json"
+            subPath: fence_google_storage_creds_secret.json
+          - name: "fence-yaml"
+            mountPath: "/var/www/fence/user.yaml"
+            subPath: user.yaml
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - |
+            echo "Running db migration: fence-create migrate"
+            fence-create migrate

--- a/gen3/lib/testData/default/expectedFenceResult.yaml
+++ b/gen3/lib/testData/default/expectedFenceResult.yaml
@@ -147,5 +147,9 @@ spec:
         args:
           - "-c"
           - |
-            echo "Running db migration: fence-create migrate"
-            fence-create migrate
+            if fence-create migrate --help > /dev/null 2>&1; then
+              echo "Running db migration: fence-create migrate"
+              fence-create migrate
+            else
+              echo "Db migration not available in this version of fence"
+            fi

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -174,3 +174,32 @@ spec:
             limits:
               cpu: 0.3
               memory: 1200Mi
+      initContainers:
+      - name: fence-init
+        image: quay.io/cdis/fence:master
+        imagePullPolicy: Always
+        env:
+          - name: PYTHONPATH
+            value: /var/www/fence
+        volumeMounts:
+          - name: "config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence-config.yaml"
+            subPath: fence-config.yaml
+          - name: "fence-google-app-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_app_creds_secret.json"
+            subPath: fence_google_app_creds_secret.json
+          - name: "fence-google-storage-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_storage_creds_secret.json"
+            subPath: fence_google_storage_creds_secret.json
+          - name: "fence-yaml"
+            mountPath: "/var/www/fence/user.yaml"
+            subPath: user.yaml
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - |
+            echo "Running db migration: fence-create migrate"
+            fence-create migrate

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -201,5 +201,9 @@ spec:
         args:
           - "-c"
           - |
-            echo "Running db migration: fence-create migrate"
-            fence-create migrate
+            if fence-create migrate --help > /dev/null 2>&1; then
+              echo "Running db migration: fence-create migrate"
+              fence-create migrate
+            else
+              echo "Db migration not available in this version of fence"
+            fi

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -174,3 +174,32 @@ spec:
             limits:
               cpu: 0.3
               memory: 1200Mi
+      initContainers:
+      - name: fence-init
+        GEN3_FENCE_IMAGE
+        imagePullPolicy: Always
+        env:
+          - name: PYTHONPATH
+            value: /var/www/fence
+        volumeMounts:
+          - name: "config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence-config.yaml"
+            subPath: fence-config.yaml
+          - name: "fence-google-app-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_app_creds_secret.json"
+            subPath: fence_google_app_creds_secret.json
+          - name: "fence-google-storage-creds-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_google_storage_creds_secret.json"
+            subPath: fence_google_storage_creds_secret.json
+          - name: "fence-yaml"
+            mountPath: "/var/www/fence/user.yaml"
+            subPath: user.yaml
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - |
+            echo "Running db migration: fence-create migrate"
+            fence-create migrate

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -201,5 +201,9 @@ spec:
         args:
           - "-c"
           - |
-            echo "Running db migration: fence-create migrate"
-            fence-create migrate
+            if fence-create migrate --help > /dev/null 2>&1; then
+              echo "Running db migration: fence-create migrate"
+              fence-create migrate
+            else
+              echo "Db migration not available in this version of fence"
+            fi


### PR DESCRIPTION
* add init container to fence db migrate
* move kube-setup-google callout to kube-setup-fence
* add `kube-setup-google --stop` command to stop google jobs
* tweak `gen3 logs raw` to be more resilient when index gets setup with non-number status_code field