### PR TITLE
chore: New service acronymbot

### DIFF
--- a/kube/services/acronymbot/acronymbot-deploy.yaml
+++ b/kube/services/acronymbot/acronymbot-deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: acronymbot-deployment
+spec:
+  selector:
+    # Only select pods based on the 'app' label
+    matchLabels:
+      app: acronymbot
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: acronymbot
+        GEN3_DATE_LABEL
+    spec:
+      containers:
+      - name: acronymbot
+        GEN3_ACRONYMBOT_IMAGE
+        env:
+        - name: SLACK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: acronymbot-g3auto
+              key: 'slacktoken.json'
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1
+          limits:
+            cpu: 2
+            memory: 512Mi
+        volumeMounts:
+        - name: slacktoken
+          mountPath: "/secret/slacktoken.json"
+      volumes:
+      - name: slacktoken
+        secret:
+          secretName: acronymbot-g3auto


### PR DESCRIPTION
New service: A Slack bot to expand CTDS acronyms.
To be executed in a dev commons only.

Implemented new Python-based Slack Bot.
Requires a k8s secret containing the slack api token.