### PR TITLE
fix(yaml-mount): don't check mount for useryaml

### DIFF
--- a/kube/services/jobs/useryaml-job.yaml
+++ b/kube/services/jobs/useryaml-job.yaml
@@ -117,11 +117,7 @@ spec:
           # Script always succeeds if it runs (echo exits with 0)
           - |
             if [ "$SYNC_FROM_DBGAP" = True ]; then
-              if [[ ! -f /mnt/shared/user.yaml ]]; then
-                fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml
-              else
-                fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /var/www/fence/user.yaml
-              fi
+              fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /var/www/fence/user.yaml
             else
               fence-create sync --arborist http://arborist-service --yaml /var/www/fence/user.yaml
             fi


### PR DESCRIPTION

1. useryaml job shouldn't have been checking /mnt/shared for the useryaml--that path is only relevant for the usersync job, where the pod has a shared mount with the aws helper pod, and the useryaml from s3 ends up in the shared mount. 

2. but also useryaml job should just always get the useryaml from the configmap (which gets mounted to /var/www/fence) and pass it in the --yaml arg. So change the if/else accordingly. 

3. (If dev wants to run just dbgap with no useryaml, use usersync job with ONLY_DBGAP set)


### Bug Fixes
fix useryaml job so it always gets useryaml from configmap instead of checking /mnt/shared, which is relevant only in user_sync_ job