### PR TITLE
fix(google-cron): slack hostname, not env name

### DIFF
--- a/gen3/lib/testData/default/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/default/expectedSheepdogResult.yaml
@@ -76,7 +76,7 @@ spec:
           - name: DICTIONARY_URL
             valueFrom:
               configMapKeyRef:
-                name: global
+                name: manifest-global
                 key: dictionary_url
           - name: REQUESTS_CA_BUNDLE
             #

--- a/kube/services/jobs/README.md
+++ b/kube/services/jobs/README.md
@@ -142,3 +142,4 @@ Add indexd users:
 * extend the `indexd.user_db` portion of `creds.json` with `username:password` entries (`gen3 random` is handy for generating passwords), and reset the `indexd_creds` secret
 * `gen3 runjob indexd-userdb`
 
+

--- a/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
@@ -117,8 +117,8 @@ spec:
               - name: gen3Env
                 valueFrom:
                     configMapKeyRef:
-                      name: global
-                      key: environment
+                      name: manifest-global
+                      key: hostname
             image: quay.io/cdis/awshelper:master
             volumeMounts:
               - name: shared-data

--- a/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
@@ -123,8 +123,8 @@ spec:
               - name: gen3Env
                 valueFrom:
                     configMapKeyRef:
-                      name: global
-                      key: environment
+                      name: manifest-global
+                      key: hostname
             image: quay.io/cdis/awshelper:master
             volumeMounts:
               - name: shared-data

--- a/kube/services/jobs/google-manage-account-access-cronjob.yaml
+++ b/kube/services/jobs/google-manage-account-access-cronjob.yaml
@@ -117,8 +117,8 @@ spec:
               - name: gen3Env
                 valueFrom:
                     configMapKeyRef:
-                      name: global
-                      key: environment
+                      name: manifest-global
+                      key: hostname
             image: quay.io/cdis/awshelper:master
             volumeMounts:
               - name: shared-data

--- a/kube/services/jobs/google-manage-keys-cronjob.yaml
+++ b/kube/services/jobs/google-manage-keys-cronjob.yaml
@@ -117,8 +117,8 @@ spec:
               - name: gen3Env
                 valueFrom:
                     configMapKeyRef:
-                      name: global
-                      key: environment
+                      name: manifest-global
+                      key: hostname
             image: quay.io/cdis/awshelper:master
             volumeMounts:
               - name: shared-data

--- a/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
@@ -117,8 +117,8 @@ spec:
               - name: gen3Env
                 valueFrom:
                     configMapKeyRef:
-                      name: global
-                      key: environment
+                      name: manifest-global
+                      key: hostname
             image: quay.io/cdis/awshelper:master
             volumeMounts:
               - name: shared-data


### PR DESCRIPTION
put hostname in slack messages from google cron jobs instead of environment name - we can run multiple commons in the same environment under different namespaces