### PR TITLE
fix(ambassador): deployment selector

### DIFF
--- a/kube/services/ambassador-gen3/ambassador-gen3-deploy.yaml
+++ b/kube/services/ambassador-gen3/ambassador-gen3-deploy.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   name: ambassador-gen3-deployment
 spec:
+  selector:
+    # Only select pods based on the 'app' label
+    matchLabels:
+      app: ambassador-gen3
   template:
     metadata:
       annotations:

--- a/kube/services/ambassador/ambassador-deploy.yaml
+++ b/kube/services/ambassador/ambassador-deploy.yaml
@@ -4,6 +4,10 @@ kind: Deployment
 metadata:
   name: ambassador-deployment
 spec:
+  selector:
+    # Only select pods based on the 'app' label
+    matchLabels:
+      app: ambassador
   template:
     metadata:
       annotations:


### PR DESCRIPTION
fix for: gen3 roll ambassador
the ambassador deployment did not have an explicit selector specified - which breaks under weird circumstances