### PR TITLE
fix(netpolicy): fuse+ambassador rules

### DIFF
--- a/gen3/bin/kube-setup-networkpolicy.sh
+++ b/gen3/bin/kube-setup-networkpolicy.sh
@@ -105,11 +105,7 @@ net_apply_jupyter() {
   local notebookNamespace
   local name
   
-  #
-  # Disable this till we bump to k8s 1.11 - 
-  # the jupyter network policies rely on compound label selectors
-  #
-  if false && g3kubectl get namespace "$notebookNamespace" > /dev/null 2>&1; then
+  if g3kubectl get namespace "$notebookNamespace" > /dev/null 2>&1; then
     for name in "${GEN3_HOME}/kube/services/netpolicy/base/"*.yaml; do
       (yq -r . < "$name") | jq -r --arg namespace "$notebookNamespace" '.metadata.namespace=$namespace' | g3kubectl apply -f -
     done

--- a/gen3/lib/testData/default/expectedFenceResult.yaml
+++ b/gen3/lib/testData/default/expectedFenceResult.yaml
@@ -23,6 +23,7 @@ spec:
         # uses explicit proxy and AWS APIs
         netnolimit: "yes"
         public: "yes"
+        userhelper: "yes"
         date: "1522344094"
     spec:
       affinity:

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -25,6 +25,7 @@ spec:
         # uses explicit proxy and AWS APIs
         netnolimit: "yes"
         public: "yes"
+        userhelper: "yes"
         date: "1522344234"
     spec:
       affinity:

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -25,6 +25,7 @@ spec:
         # uses explicit proxy and AWS APIs
         netnolimit: "yes"
         public: "yes"
+        userhelper: "yes"
         GEN3_DATE_LABEL
     spec:
       affinity:

--- a/kube/services/netpolicy/user/notebook_netpolicy.yaml
+++ b/kube/services/netpolicy/user/notebook_netpolicy.yaml
@@ -13,5 +13,11 @@ spec:
         podSelector:
           matchLabels:
             app: "jupyter-hub"
+      - namespaceSelector:
+          matchLabels:
+            role: "gen3"
+        podSelector:
+          matchLabels:
+            app: "ambassador"
   policyTypes:
    - Ingress


### PR DESCRIPTION
* enable network policies in jupyter-* namespace (kubernetes is at 1.13+ now)
* allow jupyter ingress from ambassador
* mark fence as a `userhelper` service, so hatchery apps can get signed url's
