### PR TITLE
whitelisting internalstaging datastage for load testing purposes

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -62,6 +62,7 @@ hooks.slack.com
 http.us.debian.org
 ifconfig.io
 internet2.edu
+internalstaging.datastage.io
 k8s.gcr.io
 keyservice.opensciencedatacloud.org
 ks.osdc.io


### PR DESCRIPTION
The load testing exercise is triggering a behavior where a new inbound request pointing to the environment's external address is produced against the reverse proxy.
Trying this new configuration to observe the load test results.