### PR TITLE
Revert "whitelisting internalstaging datastage for load testing purposes"

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -62,7 +62,6 @@ hooks.slack.com
 http.us.debian.org
 ifconfig.io
 internet2.edu
-internalstaging.datastage.io
 k8s.gcr.io
 keyservice.opensciencedatacloud.org
 ks.osdc.io


### PR DESCRIPTION
This produces misleading HTTP 200 requests with an HTML payload (as opposed to PreSigned URLs).

Reverts uc-cdis/cloud-automation#1050