### PR TITLE
Chore(load_test): Add Nginx rate limit to help Fence with its RPS throughput

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env sh
 set -e
 
+if [ ! -z $NGINX_RATE_LIMIT ]; then
+  # Add rate_limit config
+  rate_limit_conf="\ \ \ \ limit_req_zone $binary_remote_addr zone=one:10m rate=${NGINX_RATE_LIMIT}r/s;"
+  sed -i "/http\ {/a ${rate_limit_conf}" /etc/nginx/nginx.conf
+fi
+
 # Get the maximum upload file size for Nginx, default to 0: unlimited
 USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
 # Generate Nginx config for maximum upload file size

--- a/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 if [ ! -z $NGINX_RATE_LIMIT ]; then
   # Add rate_limit config
-  rate_limit_conf="\ \ \ \ limit_req_zone $binary_remote_addr zone=one:10m rate=${NGINX_RATE_LIMIT}r/s;"
+  rate_limit_conf="\ \ \ \ limit_req_zone \$binary_remote_addr zone=one:10m rate=${NGINX_RATE_LIMIT}r/s;"
   sed -i "/http\ {/a ${rate_limit_conf}" /etc/nginx/nginx.conf
 fi
 


### PR DESCRIPTION
The load testing exercises revealed certain RPS thresholds in which fence would struggle to produce responses with a reasonable latency. In order to avoid a scenario where fence would still receive a surge of requests while being overwhelmed, this Nginx config should prevent the unnecessary workload from reaching the underlying service.
This approach allows the cluster admin to leverage this feature through a parameterized mechanism, i.e., managed through an optional variable added to the `env` block of the k8s deployment descriptor:
https://github.com/uc-cdis/cloud-automation/blob/master/kube/services/fence/fence-deploy.yaml

**Results:**
Example of `nginx.conf` when the `NGINX_RATE_LIMIT ` environment variable is not set:
```
kc exec -it fence-deployment-679d6958df-gswht -- grep -A2 "http {" /etc/nginx/nginx.conf
http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;
```
Example of `nginx.conf` with the `NGINX_RATE_LIMIT ` environment variable configured against `fence-deployment`:
```
$ kc get deployment fence-deployment -o yaml | grep -C1 NGINX_RATE_LIMIT
      - env:
        - name: NGINX_RATE_LIMIT
          value: "6"`
```
From the pod:
```
$ kc exec -it fence-deployment-7965f6d84f-w987f -- grep -A2 "http {" /etc/nginx/nginx.conf
http {
    limit_req_zone $binary_remote_addr zone=one:10m rate=6r/s;
    include       /etc/nginx/mime.types;
```