### PR TITLE
chore(load_test): Add optional nginx config to handle wsgi/fence throughput

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
@@ -5,6 +5,8 @@ if [ ! -z $NGINX_RATE_LIMIT ]; then
   # Add rate_limit config
   rate_limit_conf="\ \ \ \ limit_req_zone \$binary_remote_addr zone=one:10m rate=${NGINX_RATE_LIMIT}r/s;"
   sed -i "/http\ {/a ${rate_limit_conf}" /etc/nginx/nginx.conf
+  limit_req_config="\ \ \ \ \ \ \ \ limit_req zone=one;"
+  sed -i "/location\ \/\ {/a ${limit_req_config}" /etc/nginx/conf.d/uwsgi.conf
 fi
 
 # Get the maximum upload file size for Nginx, default to 0: unlimited


### PR DESCRIPTION
The load testing exercises revealed certain RPS thresholds in which fence would struggle to produce responses with a reasonable latency. In order to avoid a scenario where fence would still receive a surge of requests while being overwhelmed, this Nginx config should prevent the unnecessary workload from reaching the underlying service.
This approach allows the cluster admin to leverage this feature through a parameterized mechanism, i.e., managed through an optional variable added to the env block of the k8s deployment descriptor:
https://github.com/uc-cdis/cloud-automation/blob/master/kube/services/fence/fence-deploy.yaml

This change is a complement of the PR below:
https://github.com/uc-cdis/cloud-automation/pull/1052

This code injects some missing configuration that must be added to the `location /` block of `/etc/nginx/conf.d/uwsgi.conf`.

Result:
```
$ kc exec -it fence-deployment-5d655df47c-sl5jb -- grep -A2 "location / {" /etc/nginx/conf.d/uwsgi.conf
    location / {
        limit_req zone=one;
        uwsgi_param REMOTE_ADDR $http_x_forwarded_for if_not_empty;
```