### PR TITLE
fix(load_test): Fix nginx config by adding instructions to the correct file

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/entrypoint.sh
@@ -5,8 +5,10 @@ if [ ! -z $NGINX_RATE_LIMIT ]; then
   # Add rate_limit config
   rate_limit_conf="\ \ \ \ limit_req_zone \$binary_remote_addr zone=one:10m rate=${NGINX_RATE_LIMIT}r/s;"
   sed -i "/http\ {/a ${rate_limit_conf}" /etc/nginx/nginx.conf
-  limit_req_config="\ \ \ \ \ \ \ \ limit_req zone=one;"
-  sed -i "/location\ \/\ {/a ${limit_req_config}" /etc/nginx/conf.d/uwsgi.conf
+  if [ -f /etc/nginx/sites-available/uwsgi.conf ]; then
+    limit_req_config="\ \ \ \ \ \ \ \ limit_req zone=one;"
+    sed -i "/location\ \/\ {/a ${limit_req_config}" /etc/nginx/sites-available/uwsgi.conf
+  fi
 fi
 
 # Get the maximum upload file size for Nginx, default to 0: unlimited


### PR DESCRIPTION
Lessons learned:
Do not add any configuration to `/etc/nginx/conf.d/uwsgi.conf`.
Add them to `/etc/nginx/sites-available/uwsgi.conf` instead so the symbolic link can be created successfully:
`ln -s /etc/nginx/sites-available/uwsgi.conf /etc/nginx/conf.d/uwsgi
.conf`

This is a bug fix to the changes introduced in:
https://github.com/uc-cdis/cloud-automation/pull/1052
and
https://github.com/uc-cdis/cloud-automation/pull/1053

TESTING
--
```
$ kc get pods | grep fence
fence-deployment-8474db57cb-tkblq                        1/1     Running             0          2m18s

$ kc exec -it fence-deployment-8474db57cb-tkblq -- curl http://localhost/_status
Healthy

$ kc get pod fence-deployment-8474db57cb-tkblq -o yaml | grep image
    image: quay.io/cdis/fence:chore_rate_limit_test
```

Configuration in place:
--
```
$ kc exec -it fence-deployment-8474db57cb-tkblq -- grep -A2 "location / {" /etc/nginx/conf.d/uwsgi.conf
    location / {
        limit_req zone=one;
        uwsgi_param REMOTE_ADDR $http_x_forwarded_for if_not_empty;

$ kc exec -it fence-deployment-8474db57cb-tkblq -- grep -A2 "http {" /etc/nginx/nginx.conf
http {
    limit_req_zone $binary_remote_addr zone=one:10m rate=7r/s;
    include       /etc/nginx/mime.types;
```