### PR TITLE
chore(section508): Whitelist datastage domains to check section 508 c…

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -51,7 +51,6 @@ ftp.sanger.ac.uk
 ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
-datastage.io
 gist.githubusercontent.com
 git.bionimbus.org
 git.io

--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -51,6 +51,7 @@ ftp.sanger.ac.uk
 ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
+datastage.io
 gist.githubusercontent.com
 git.bionimbus.org
 git.io

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -14,6 +14,7 @@
 .completegenomics.com
 .cpan.org
 .datacommons.io
+.datastage.io
 .docker.com
 .docker.io
 .dockerproject.org


### PR DESCRIPTION
This is required to verify compliance of a given gen3 commons with Section 508.
Starting with gen3.datastage.io as a test.

(more info: https://webaim.org/standards/508/checklist)

JIRA: https://ctds-planx.atlassian.net/browse/PXP-5023
