### PR TITLE
chore(section508): Whitelist achecker.ca domain to check section 508 compliance

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -3,6 +3,7 @@
 172.16.191.254
 192.170.230.164
 accounts.google.com
+achecker.ca
 api-bionimbus-pdc.opensciencedatacloud.org
 api.immport.org
 api.login.yahoo.com

--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -51,7 +51,6 @@ ftp.sanger.ac.uk
 ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
-datastage.io
 gist.githubusercontent.com
 git.bionimbus.org
 git.io

--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -51,6 +51,7 @@ ftp.sanger.ac.uk
 ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
+datastage.io
 gist.githubusercontent.com
 git.bionimbus.org
 git.io

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -14,6 +14,7 @@
 .completegenomics.com
 .cpan.org
 .datacommons.io
+.datastage.io
 .docker.com
 .docker.io
 .dockerproject.org


### PR DESCRIPTION
The NodeJS module [`wcag`](https://github.com/cfpb/node-wcag)  leverages a web service (https://achecker.ca/) to perform Section 508 checks.

Jenkins must be able to talk to this web service.