### PR TITLE
chore(QA): Run section 508 compliance against .biodatacatalyst.nhlbi.nih.gov domain

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -3,6 +3,7 @@
 .apache.org
 .archive.canonical.com
 .bioconductor.org
+.biodatacatalyst.nhlbi.nih.gov
 .bitbucket.org
 .bsc.es
 .cancer.gov


### PR DESCRIPTION
This is required to verify compliance of our new BCat gen3 commons with Section 508.
The wild card should cover both preprod and prod.