### PR TITLE
Revert "chore(QA): Run section 508 compliance against .biodatacatalyst.nhlbi.nih.gov domain"

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -3,7 +3,6 @@
 .apache.org
 .archive.canonical.com
 .bioconductor.org
-.biodatacatalyst.nhlbi.nih.gov
 .bitbucket.org
 .bsc.es
 .cancer.gov


### PR DESCRIPTION
Reverts uc-cdis/cloud-automation#1070