### PR TITLE
chore(whitelist): add data commons domains to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -53,7 +53,6 @@ ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
 gist.githubusercontent.com
-git.bionimbus.org
 git.io
 go.googlesource.com
 golang.org
@@ -67,7 +66,6 @@ k8s.gcr.io
 keyservice.opensciencedatacloud.org
 ks.osdc.io
 lib.stat.cmu.edu
-login.bionimbus.org
 login.mathworks.com
 login.microsoftonline.com
 maven.restlet.org
@@ -122,7 +120,6 @@ sa-update.secnap.net
 sa-update.space-pro.be
 security.debian.org
 services.mathworks.com
-source.bionimbus.org
 streaming.stat.iastate.edu
 www.google.com
 www.mathworks.com

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -3,7 +3,10 @@
 .apache.org
 .archive.canonical.com
 .bioconductor.org
+.bionimbus.org
 .bitbucket.org
+.bloodpac.org
+.braincommons.org
 .bsc.es
 .cancer.gov
 .centos.org
@@ -28,12 +31,15 @@
 .hashicorp.com
 .jenkins-ci.org
 .k8s.io
+.kidsfirstdrc.org
 .letsencrypt.org
 .maven.org
 .metacpan.org
+.niaiddata.org
 .nih.gov
 .nodesource.com
 .novocraft.com
+.occ-data.org
 .oicr.on.ca
 .osuosl.org
 .perl.org


### PR DESCRIPTION
We need the gen3-fuse sidecar to be able to talk to external Data Commons

Removing the `*.bionimbus.org` entries from the `web_whitelist` because they conflict with the `.bionimbus.org` entry in the `web_wildcard_whitelist`