### PR TITLE
Fix(QA): Fix runIntegrationTests call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node {
           kubectlNamespace,
           pipeConfig.serviceTesting.name,
           "",
-          ""
+          "false"
         )
       }
       stage('CleanS3') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,7 @@ node {
         testHelper.runIntegrationTests(
           kubectlNamespace,
           pipeConfig.serviceTesting.name,
+          "",
           ""
         )
       }


### PR DESCRIPTION
The signature of the runIntegrationTests method changed due to:
https://github.com/uc-cdis/cdis-jenkins-lib/pull/68/commits/11b32b02a05b32acf553a852b170dc61c8c8fcac

and since `cloud-automation` has its own Jenkinsfile , it is not calling the function with all the expected parameters.