### PR TITLE
UWSGI_PROCESSES=1 for fence init pod

### DIFF
--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -208,6 +208,8 @@ spec:
                 name: manifest-fence
                 key: fence-config-public.yaml
                 optional: true
+          - name: UWSGI_PROCESSES
+            value: 1
         volumeMounts:
           - name: "config-volume"
             readOnly: true


### PR DESCRIPTION
- May resolve fence migration startup issue -- if the migration issue is caused by two or more uwsgi processes in the fence-init pod attempting to run migrations simultaneously, as opposed to two or more fence-init pods attempting to run migrations simultaneously.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

