### PR TITLE
chore(instance type): made it a variable

### DIFF
--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -36,6 +36,7 @@ module "cdis_vpc" {
   squid_instance_drive_size      = "${var.ha-squid_instance_drive_size}"
   squid_bootstrap_script         = "${var.ha-squid_bootstrap_script}"
   squid_extra_vars               = "${var.ha-squid_extra_vars}"
+  single_squid_instance_type     = "${var.single_squid_instance_type}"
 }
 
 # logs bucket for elb logs

--- a/tf_files/aws/commons/kube.tf
+++ b/tf_files/aws/commons/kube.tf
@@ -228,4 +228,7 @@ resource "aws_iam_policy" "configbucket_reader" {
   name                        = "bucket_reader_cdis-gen3-users_${var.vpc_name}"
   description                 = "Read cdis-gen3-users/${var.config_folder}"
   policy                      = "${data.aws_iam_policy_document.configbucket_reader.json}"
+  lifecycle {
+    ignore_changes = ["policy"]
+  }
 }

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -389,3 +389,8 @@ variable "indexd_engine" {
   description = "Engine to deploy the db instance"
   default     = "postgres"
 }
+
+variable "single_squid_instance_type" {
+  description = "Instance type for the single proxy instance"
+  default     = "t2.micro"
+}

--- a/tf_files/aws/modules/squid/cloud.tf
+++ b/tf_files/aws/modules/squid/cloud.tf
@@ -192,7 +192,7 @@ resource "aws_instance" "proxy" {
   count                  = "${var.deploy_single_proxy ? 1 : 0 }"
   ami                    = "${aws_ami_copy.squid_ami.id}"
   subnet_id              = "${var.env_public_subnet_id}"
-  instance_type          = "t2.micro"
+  instance_type          = "${var.instance_type}"
   monitoring             = true
   source_dest_check      = false
   key_name               = "${var.ssh_key_name}"
@@ -232,7 +232,8 @@ systemctl restart awslogs
 EOF
 
   lifecycle {
-    ignore_changes = ["ami", "key_name"]
+    ignore_changes = ["ami", "key_name"],
+    create_before_destroy = true
   }
 }
 

--- a/tf_files/aws/modules/squid/variables.tf
+++ b/tf_files/aws/modules/squid/variables.tf
@@ -44,3 +44,8 @@ variable "deploy_single_proxy" {
 variable "zone_id" {
   description = "Route53 zone in which to create a new record for cloud-proxy.internal.io"
 }
+
+variable "instance_type" {
+  description = "Instance type of the squid instance"
+  default     = "t2.micro"
+}

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -11,6 +11,7 @@ module "squid_proxy" {
   env_log_group        = "${aws_cloudwatch_log_group.main_log_group.name}"
   ssh_key_name         = "${var.ssh_key_name}"
   deploy_single_proxy  = "${var.deploy_single_proxy}"
+  instance_type = "${var.single_squid_instance_type}"
 }
 
 

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -100,3 +100,7 @@ variable "squid_cluster_max_size" {
   description = "If ha squid is enabled and you want to set your own max size"
   default     = 3
 }
+
+variable "single_squid_instance_type" {
+  description = "Single squid instance type"
+}

--- a/tf_files/aws/squid_vm/root.tf
+++ b/tf_files/aws/squid_vm/root.tf
@@ -14,6 +14,7 @@ module "squid_vm" {
   env_vpc_id       = "${var.env_vpc_id}"
   env_vpc_cidr        = "${var.env_vpc_cidr}"
   env_public_subnet_id = "${var.env_public_subnet_id}"
+  instance_type    = "${var.instance_type}"
 
   # put other variables here ...
 }

--- a/tf_files/aws/squid_vm/variables.tf
+++ b/tf_files/aws/squid_vm/variables.tf
@@ -26,6 +26,7 @@ variable "env_vpc_id" {
   #default = "vpc-e2b51d99"
 }
 
+/*
 variable "env_instance_profile" {
   #default = "common_name_cloudwatch_access_profile"
 }
@@ -33,7 +34,6 @@ variable "env_instance_profile" {
 variable "env_log_group" {
   #default = "common_name"
 }
-
 
 data "aws_iam_policy_document" "squid_logging_cloudwatch" {
   statement {
@@ -50,4 +50,10 @@ data "aws_iam_policy_document" "squid_logging_cloudwatch" {
     effect    = "Allow"
     resources = ["*"]
   }
+}
+*/
+
+variable "instance_type" {
+  description = "Instance type for the squid instance"
+  default     = "t2.micro"
 }

--- a/tf_files/aws/squid_vm/variables.tf
+++ b/tf_files/aws/squid_vm/variables.tf
@@ -26,33 +26,6 @@ variable "env_vpc_id" {
   #default = "vpc-e2b51d99"
 }
 
-/*
-variable "env_instance_profile" {
-  #default = "common_name_cloudwatch_access_profile"
-}
-
-variable "env_log_group" {
-  #default = "common_name"
-}
-
-data "aws_iam_policy_document" "squid_logging_cloudwatch" {
-  statement {
-    actions = [
-      "logs:CreateLogGroup",
-      "logs:CreateLogStream",
-      "logs:GetLogEvents",
-      "logs:PutLogEvents",
-      "logs:DescribeLogGroups",
-      "logs:DescribeLogStreams",
-      "logs:PutRetentionPolicy",
-    ]
-
-    effect    = "Allow"
-    resources = ["*"]
-  }
-}
-*/
-
 variable "instance_type" {
   description = "Instance type for the squid instance"
   default     = "t2.micro"


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Single squid instance type is a variable.

### Breaking Changes


### Bug Fixes


### Improvements
- The instance product of this module has now `deploy_before_destroy` enabled.

### Dependency updates


### Deployment changes

