### PR TITLE
chore(fence-migrate): setup-fence runs migrate job

### DIFF
--- a/gen3/bin/job.sh
+++ b/gen3/bin/job.sh
@@ -6,7 +6,7 @@ g3k_wait4job(){
   local jobName
   jobName="$1"
   if [[ -z "$jobName" ]]; then
-    echo "gen3 job wait4 JOB-NAME"
+    gen3_log_err "gen3 job wait4 requires JOB-NAME"
     return 1
   fi
   local COUNT
@@ -17,7 +17,7 @@ g3k_wait4job(){
       exit 1
     fi
     if [[ $(g3kubectl get jobs "$jobName" -o json | jq -r '.status.failed') != null ]]; then
-      echo "job fail"
+      gen3_log_err "job fail"
       exit 1
     fi
     gen3_log_info "waiting for $jobName to finish"

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -27,6 +27,11 @@ if [[ -f "$(gen3_secrets_folder)/creds.json" && -z "$JENKINS_HOME" ]]; then # cr
   touch "$(gen3_secrets_folder)/.rendered_fence_db"
 fi
 
+# run db migration job
+gen3_log_info "Launching db migrate job"
+gen3 job run fence-db-migrate -w || true
+gen3 job logs fence-db-migrate -f || true
+
 # deploy fence
 gen3 roll fence
 # deploy presigned-url-fence

--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -195,5 +195,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            echo -e "ENABLE_DB_MIGRATION: false" > "/var/www/fence/fence-config-bonus1.yaml"
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config-step1.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-bonus1.yaml /var/www/fence/fence-config-step1.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi


### PR DESCRIPTION
### New Features

### Breaking Changes


### Bug Fixes


### Improvements

* kube-setup-fence runs migrate job, so we can disable db migration in fence-config-public.yaml in all our commons if we want to ...
* disable migration in presigned-url deployment


### Dependency updates


### Deployment changes

