### PR TITLE
chore(qa): Whitelist the NewRelic Collector endpoint to facilitate POC

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -94,6 +94,7 @@ mirrors.gigenet.com
 mirrors.lga7.us.voxel.net
 mirrors.nics.utk.edu
 mirrors.syringanetworks.net
+collector.newrelic.com
 neuro.debian.net
 neurodeb.pirsquared.org
 nginx.org


### PR DESCRIPTION
Whitelisting this endpoint to facilitate the POC involving Fence's APM monitoring.