### PR TITLE
chore(domain): switched to www.google.com

### DIFF
--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -78,7 +78,7 @@ variable "iam-serviceaccount" {
 
 variable "domain_test" {
   description = "url for the lambda function to check for the proxy"
-  default     = "gen3.org"
+  default     = "www.google.com"
 }
 
 variable "ha_squid" {

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -93,7 +93,7 @@ variable "availability_zones" {
 
 variable "domain_test" {
   description = "Domain for the lambda function to check for the proxy"
-  default     = "gen3.org"
+  default     = "www.google.com"
 }
 
 variable "ha_squid" {


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- Switched the domain used to check for internet access from the VPC where commons' kubernetes workers live. The previous default one returned 302 (redirection) codes forcing the check to switch the active instances every minute. www.google.com return 200 which is acceptable as a working internet connection.

### Improvements


### Dependency updates


### Deployment changes

