### PR TITLE
chore(whitelist-cognito): add .amazoncognito.com to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -1,5 +1,6 @@
 .alpinelinux.org
 .amazonaws.com
+.amazoncognito.com
 .apache.org
 .archive.canonical.com
 .bioconductor.org


### PR DESCRIPTION
Add .amazoncognito.com to squid web_wildcard_whitelist, so that Fence can use Cognito as an IdP