### PR TITLE
chore(QA): python36 in jenkins

### DIFF
--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -4,6 +4,8 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+adduser _apt --force-badname
+
 # install python and pip and aws cli
 RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3.6 python3-pip build-essential zip unzip jq less vim gettext-base
 RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -16,6 +16,17 @@ RUN apt-get update \
      r-base \
      libssl-dev \
      libcurl4-openssl-dev \
+     zlib1g-dev \
+     libncurses5-dev \
+     libncursesw5-dev \
+     libreadline-dev \
+     libsqlite3-dev \
+     libgdbm-dev \
+     libdb5.3-dev \
+     libbz2-dev \
+     libexpat1-dev \
+     liblzma-dev \
+     tk-dev \
      ca-certificates \
      curl \
      gnupg2 \

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/jenkins:2-debian-10
+FROM jenkins/jenkins:2.219
 
 USER root
 

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -4,10 +4,8 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN adduser _apt --force-badname
-
 # install python and pip and aws cli
-RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3.6 python3-pip build-essential zip unzip jq less vim gettext-base
+RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip jq less vim gettext-base
 RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
 RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade
@@ -35,6 +33,21 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
           google-cloud-sdk-cbt \
           kubectl \
           zsh
+
+# Copy sh script responsible for installing Python
+COPY install-python3.6.sh /root/tmp/install-python3.6.sh
+
+# Run the script responsible for installing Python 3.6.1 and link it to /usr/bin/python3
+RUN chmod +x /root/tmp/install-python3.6.sh; sync && \
+	./root/tmp/install-python3.6.sh && \
+	rm -rf /root/tmp/install-python3.6.sh && \
+	ln -s /Python-3.6.1/python /usr/bin/python3
+
+# Install pip3 for Python 3.6.1
+RUN rm -rf /usr/local/lib/python3.6/site-packages/pip* && \
+	wget https://bootstrap.pypa.io/get-pip.py && \
+	python3 get-pip.py && \
+	rm get-pip.py
 
 #
 # install docker tools:

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -4,7 +4,7 @@ USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-adduser _apt --force-badname
+RUN adduser _apt --force-badname
 
 # install python and pip and aws cli
 RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3.6 python3-pip build-essential zip unzip jq less vim gettext-base

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,11 +1,11 @@
-FROM jenkins/jenkins:2.219
+FROM bitnami/jenkins:2-debian-10
 
 USER root
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install python and pip and aws cli
-RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip jq less vim gettext-base
+RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3.6 python3-pip build-essential zip unzip jq less vim gettext-base
 RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
 RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -52,7 +52,7 @@ COPY install-python3.6.sh /root/tmp/install-python3.6.sh
 RUN chmod +x /root/tmp/install-python3.6.sh; sync && \
 	./root/tmp/install-python3.6.sh && \
 	rm -rf /root/tmp/install-python3.6.sh && \
-	ln -s /Python-3.6.1/python /usr/bin/python3
+	ln -s /Python-3.6.1/python /usr/bin/python3.6
 
 # Install pip3 for Python 3.6.1
 RUN rm -rf /usr/local/lib/python3.6/site-packages/pip* && \

--- a/Docker/Jenkins/install-python3.6.sh
+++ b/Docker/Jenkins/install-python3.6.sh
@@ -1,0 +1,7 @@
+wget https://www.python.org/ftp/python/3.6.1/Python-3.6.1.tar.xz
+tar xf Python-3.6.1.tar.xz
+rm Python-3.6.1.tar.xz
+cd Python-3.6.1
+./configure 
+make 
+make altinstall


### PR DESCRIPTION
Python3.6 is required to run some QA automation that depends on `gen3sdk-python`.