### PR TITLE
fix(nginx.conf): security tweaks PXP-5723

### DIFF
--- a/Docker/python-nginx/python2.7-alpine3.7/nginx.conf
+++ b/Docker/python-nginx/python2.7-alpine3.7/nginx.conf
@@ -29,7 +29,7 @@ http {
 	##
 	# SSL Settings
 	##
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
 	ssl_prefer_server_ciphers on;
 
 	##

--- a/Docker/sidecar/nginx.conf
+++ b/Docker/sidecar/nginx.conf
@@ -29,7 +29,7 @@ http {
 	##
 	# SSL Settings
 	##
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_protocols TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
 	ssl_prefer_server_ciphers on;
 
 	##

--- a/kube/services/netpolicy/gen3/services/revproxy_netpolicy.yaml
+++ b/kube/services/netpolicy/gen3/services/revproxy_netpolicy.yaml
@@ -19,6 +19,7 @@ spec:
          - port: 80
          - port: 8080
          - port: 81
+         - port: 82
          - port: 443
   egress:
     - to:

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -165,8 +165,18 @@ perl_set $mds_b64 'sub { $_ = $ENV{"MDS_AUTHZ"}; chomp; return "$_"; }';
 server {
   listen      82 default_server proxy_protocol;
   listen      83;
-  rewrite     ^   https://$host$request_uri? permanent;
+
+  server_tokens off;
+  more_set_headers "Server: gen3"
+  set $proxy_service  "noproxy";
+  set $access_token "none";
+  set $session_id "none";
+  set $visitor_id "none";
+  set $upstream http://443loopback;
+
+  return 301 https://$host$request_uri;
 }
+
 # Serve internet facing https requests and internal http requests here
 server {
   listen 81 proxy_protocol;
@@ -203,7 +213,7 @@ server {
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 
   # update service release cookie
-  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600";
+  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;;HttpOnly;Secure";
   
   if ($request_method = 'OPTIONS') {
     return 204;


### PR DESCRIPTION
### New Features

### Breaking Changes


### Bug Fixes
* handling of external requests to port 80 by the reverse proxy and network policy

### Improvements
* disable TLSv1 in old docker images
* service_releases cookie http-only, secure

### Dependency updates


### Deployment changes

