### PR TITLE
chore(qa): Whitelist JIRA Cloud endpoint to facilitate automatic jira-creation jobs

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -4,6 +4,7 @@
 192.170.230.164
 accounts.google.com
 achecker.ca
+ctds-planx.atlassian.net
 api-bionimbus-pdc.opensciencedatacloud.org
 api.immport.org
 api.login.yahoo.com


### PR DESCRIPTION
Whitelisting as this is blocking some automation:
```
WARNING:root:Got ConnectionError [('Connection aborted.', OSError(0, 'Error'))] errno:None on GET https://ctds-planx.atlassian.net/rest/api/2/serverInfo
```