### PR TITLE
fix(bug): replace - for _ when creating databases

### DIFF
--- a/gen3/bin/db.sh
+++ b/gen3/bin/db.sh
@@ -544,7 +544,7 @@ gen3_db_restore() {
     return 1
   fi
 
-  local dbname="${serviceName}_$(gen3_db_namespace)_restore_$(date -u +%Y%m%d_%H%M%S)"
+  local dbname="$(echo ${serviceName}_$(gen3_db_namespace)_restore_$(date -u +%Y%m%d_%H%M%S) | tr - _)"
   if [[ "$dryRun" == false ]]; then
     gen3_log_info "creating database $dbname"
     # create the db as the root user, then grant permissions to the service user


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features

### Breaking Changes


### Bug Fixes
- When creating databases, the script uses the current user name. When the user has hyphens in the name, like iam-anuser, postgres doesn't like it and the script bails.
  This patch would replace hyphens for underscores before creating databases when  `db_restore`ing.

### Improvements


### Dependency updates


### Deployment changes

