### PR TITLE
DO NOT MERGE BEFORE TESTING: chore(qa): Update selenium/standalone-chrome sidecar img

### DIFF
--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -111,7 +111,7 @@ spec:
         - name: dockersock
           mountPath: "/var/run/docker.sock"
       - name: selenium
-        image: selenium/standalone-chrome:3.14
+        image: selenium/standalone-chrome:4.0.0
         ports:
         - containerPort: 4444
         readinessProbe:

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -116,11 +116,7 @@ spec:
         - containerPort: 4444
         readinessProbe:
           httpGet:
-            path: /wd/hub/sessions
-            port: 4444
-        readinessProbe:
-          httpGet:
-            path: /wd/hub/sessions
+            path: /status
             port: 4444
         imagePullPolicy: Always
       volumes:


### PR DESCRIPTION
Testing steps:
1. SSH to qaplanetv1
2. Edit the Jenkins k8s deployment ` kubectl edit deployment jenkins-deployment`
3. Change this line here:
```
      - image: selenium/standalone-chrome:3.14
```
4. Apply version `4.0.0`.
5. The jenkins pod will be restarted. Once it starts running,
create at least 5 PRs against `cdis-manifest` and monitor the results. 