### PR TITLE
add(force): for node drain

### DIFF
--- a/gen3/bin/workers-cycle.sh
+++ b/gen3/bin/workers-cycle.sh
@@ -13,7 +13,7 @@ SCRIPT=$(basename ${BASH_SOURCE[0]})
 function drain_node(){
   local instanceName=${1}
   gen3_log_info "Draining ${instanceName}"
-  g3kubectl drain ${instanceName} --ignore-daemonsets --delete-local-data
+  g3kubectl drain ${instanceName} --ignore-daemonsets --delete-local-data --force
 }
 
 


### PR DESCRIPTION
Description about what this pull request does.


### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- `kubectl node drain` commands now have the `--force` flag for draining deleting "Pods not managed by ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet"  like hatchery pods.

### Dependency updates


### Deployment changes

