### PR TITLE
fix: gen3 iam-serviceaccount fixes

### DIFF
--- a/gen3/bin/iam-serviceaccount.sh
+++ b/gen3/bin/iam-serviceaccount.sh
@@ -78,7 +78,7 @@ function create_assume_role_policy() {
   local issuer_url=$(aws eks describe-cluster \
                        --name ${vpc_name} \
                        --query cluster.identity.oidc.issuer \
-                       --output text)
+                       --output text | sed -e 's#^https://##')
 
   local issuer_hostpath=$(echo ${issuer_url}| cut -f 3- -d'/')
   local account_id=$(aws sts get-caller-identity --query Account --output text)

--- a/gen3/bin/iam-serviceaccount.sh
+++ b/gen3/bin/iam-serviceaccount.sh
@@ -447,7 +447,7 @@ function main() {
 
 
     role_json=$(create_role_with_policy "${policy_source}" "${role_name}")
-    role_arn=$(echo ${role_json} | jq -r '.Role.RoleArn')
+    role_arn=$(echo ${role_json} | jq -r '.Role.Arn')
     create_service_account ${role_arn}
     gen3_log_info "Role and service account created successfully"
     gen3_log_info "  Role Name: $(echo ${role_json} | jq '.Role.RoleName')"


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
- Using `gen3 iam-serviceaccount` results in `null` in service-account annotation. This is a fix for the issue.
- `gen3 iam-serviceaccount` produces wrong link (contains `https` part) in Federated part of trust policy. Fixed now.

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
