### PR TITLE
fix(presigned-url-fence): Enabling Rate Limiting again

### DIFF
--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -201,4 +201,4 @@ spec:
             echo -e "ENABLE_DB_MIGRATION: false" > "/var/www/fence/fence-config-bonus1.yaml"
             python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config-step1.yaml
             python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-bonus1.yaml /var/www/fence/fence-config-step1.yaml > /var/www/fence/fence-config.yaml
-            bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi
+            /entrypoint.sh && /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi

--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -201,4 +201,4 @@ spec:
             echo -e "ENABLE_DB_MIGRATION: false" > "/var/www/fence/fence-config-bonus1.yaml"
             python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config-step1.yaml
             python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-bonus1.yaml /var/www/fence/fence-config-step1.yaml > /var/www/fence/fence-config.yaml
-            /entrypoint.sh && /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi
+            bash /entrypoint.sh && /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi

--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -47,7 +47,7 @@ spec:
             name: "fence-yaml-merge"
 # -----------------------------------------------------------------------------
 # DEPRECATED! Remove when all commons are no longer using local_settings.py
-#             for fence.
+#             for fence
 # -----------------------------------------------------------------------------
         - name: old-config-volume
           secret:


### PR DESCRIPTION
### Bug Fixes
The rate limit config had been accidentally disabled when the `command` override was introduced to this deployment (which suppresses the parent image's `entrypoint.sh` execution). Adding an extra call to this script to make sure the NGINX_RATE_LIMIT check is executed.