### PR TITLE
chore(qa): Do not use selectedTest PR label selection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,8 @@ node {
           kubectlNamespace,
           pipeConfig.serviceTesting.name,
           "",
-          "false"
+          "false",
+          ""
         )
       }
       stage('CleanS3') {


### PR DESCRIPTION
Adding an empty string just to comply with the method signature.
This repo does not leverage the PR labelling magic.