### PR TITLE
chore(whitelist): quay.io wildcard

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -51,6 +51,7 @@
 .pypi.python.org
 .pythonhosted.org
 .pyx4me.com
+.quay.io
 .rcsb.org
 .rubygems.org
 .sa-update.pccc.com


### PR DESCRIPTION
update squid whitelist with quay.io wildcard - they'll change their cdn domain soon

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
