### PR TITLE
chore(qa): Trying to restore the pipeline by downgrading Jenkins 

### DIFF
--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.230
+FROM jenkins/jenkins:2.219
 
 USER root
 


### PR DESCRIPTION
We are facing lots of intermittent failures so we might need to downgrade to help us narrow down the root cause of all the unstable test runs.