### PR TITLE
fix(kubeconfig): export the file on its respective location

### DIFF
--- a/gen3/bin/report-tool.sh
+++ b/gen3/bin/report-tool.sh
@@ -20,7 +20,8 @@ gen3_load "gen3/lib/kube-setup-init"
 
 export vpc_name="$(grep 'vpc_name=' $HOME/.bashrc |cut -d\' -f2)"
 export GEN3_HOME="$HOME/cloud-automation"
-export KUBECONFIG="$HOME/${vpc_name}/kubeconfig"
+#export KUBECONFIG="$HOME/${vpc_name}/kubeconfig"
+export KUBECONFIG="$(gen3_secrets_folder)/kubeconfig"
 PATH="${PATH}:/usr/local/bin"
 
 #aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,PrivateIpAddress,Tags[?Key==`Name`].Value]' --filter "Name=tag:Name,Values=*${vpc_name}"


### PR DESCRIPTION
Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
- Report tool would fail if kubeconfig file is located at a different folder than `${HOME}/${vpc_name}/kubeconfig`. It is now loaded from the location returned by gen3.

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
