### PR TITLE
chore(squid): wildcard opensciencedatacloud

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -5,7 +5,6 @@
 accounts.google.com
 achecker.ca
 ctds-planx.atlassian.net
-api-bionimbus-pdc.opensciencedatacloud.org
 api.immport.org
 api.login.yahoo.com
 api.snapcraft.io
@@ -66,7 +65,6 @@ http.us.debian.org
 ifconfig.io
 internet2.edu
 k8s.gcr.io
-keyservice.opensciencedatacloud.org
 ks.osdc.io
 lib.stat.cmu.edu
 login.mathworks.com

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -43,6 +43,7 @@
 .novocraft.com
 .occ-data.org
 .oicr.on.ca
+.opensciencedatacloud.org
 .osuosl.org
 .perl.org
 .planx-pla.net


### PR DESCRIPTION
squid wildcard for `.opensciencedatacloud.org`