### PR TITLE
chore(elb-internal): support for lb_type:internal

### DIFF
--- a/kube/services/revproxy/revproxy-service-elb.yaml
+++ b/kube/services/revproxy/revproxy-service-elb.yaml
@@ -9,7 +9,8 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
     # supported in k8s 1.9
     service.beta.kubernetes.io/aws-load-balancer-ssl-negotiation-policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
-$LOGGING_CONFIG
+    # see kube-setup-revproxy
+$MORE_ELB_CONFIG
 spec:
   selector:
     app: revproxy

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -98,6 +98,7 @@ resource "aws_subnet" "eks_private" {
      "Environment", "${var.vpc_name}",
      "Organization", "${var.organization_name}",
      "kubernetes.io/cluster/${var.vpc_name}", "owned",
+     "kubernetes.io/role/internal-elb", "1",
     )
   }"
 
@@ -126,7 +127,7 @@ resource "aws_subnet" "eks_public" {
      "Environment", "${var.vpc_name}",
      "Organization", "${var.organization_name}",
      "kubernetes.io/cluster/${var.vpc_name}", "shared",
-     "kubernetes.io/role/elb", "",
+     "kubernetes.io/role/elb", "1",
      "KubernetesCluster", "${var.vpc_name}",
     )
   }"


### PR DESCRIPTION
deploy internal ELB like this:
* delete the existing lb if necessary - `g3kubectl delete service revproxy-service-elb`
* tag the `eks_private*` subnets with `key: kubernetes.io/role/internal-elb, value: 1`
* set `lb_type: "internal"` in the `global` section of the manifest
* `gen3 kube-setup-revproxy`
* now you have a load balancer with private IP addresses - update DNS
