### PR TITLE
open-id discovery endpoints

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/fence-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/fence-service.conf
@@ -41,3 +41,14 @@ location /user/data/download {
     rewrite ^/user/(.*) /$1 break;
     proxy_pass $upstream;
 }
+
+# OpenID Connect Discovery Endpoints
+location /.well-known/ {
+    if ($csrf_check !~ ^ok-\S.+$) {
+      return 403 "failed csrf check";
+    }
+
+    set $proxy_service  "${fence_release_name}";
+    set $upstream http://${fence_release_name}-service$des_domain;
+    proxy_pass $upstream;
+}

--- a/kube/services/revproxy/gen3.nginx.conf/indexd-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/indexd-service.conf
@@ -1,10 +1,10 @@
 
-          # GA4GH endpoint for DOS resolver
+          # GA4GH endpoint for DOS resolver and DRS server
           location /ga4gh/ {
               if ($csrf_check !~ ^ok-\S.+$) {
                 return 403 "failed csrf check";
               }
-         
+
               set $proxy_service  "${indexd_release_name}"; 
               set $upstream http://${indexd_release_name}-service$des_domain;
               proxy_pass $upstream;
@@ -15,7 +15,7 @@
               if ($csrf_check !~ ^ok-\S.+$) {
                 return 403 "failed csrf check";
               }
-              
+
               set $proxy_service  "${indexd_release_name}";
               set $upstream http://${indexd_release_name}-service$des_domain;
               rewrite ^/index/(.*) /$1 break;
@@ -32,14 +32,14 @@
               set $authz_service "indexd_gateway";
               # be careful - sub-request runs in same context as this request
               auth_request /gen3-authz;
-              
+
               #
               # For some reason nginx breaks the proxy body
               # if we try to set Authorization from a perl_set variable
               # that samples the environment ... ugh!
               #
               set $indexd_password "Basic ${indexd_b64}";
-              
+
               # For testing:
               #add_header Set-Cookie "X-Frickjack=${indexd_password};Path=/;Max-Age=600";
               set $proxy_service  "${indexd_release_name}";
@@ -51,7 +51,7 @@
               proxy_set_header   X-SessionId "$session_id";
               proxy_set_header   X-VisitorId "$visitor_id";
               proxy_set_header   Authorization "$indexd_password";
-              
+
               proxy_pass $upstream;
               proxy_redirect http://$host/ https://$host/index-admin/;
           }


### PR DESCRIPTION
- Based on [RFC5785](https://tools.ietf.org/html/rfc5785), Fence's OIDC Discovery Endpoints should be exposed under `hostname/.well-known/openid-configuration` and `hostname/.well-known/jwks`
- At the same time, since we have users depending on these endpoints, we still want them to be accessible under `hostname/user/.well-known/openid-configuration` and `hostname/user/.well-known/jwks`
- Minor edit to comment in indexd endpoints

