### PR TITLE
chore(qa): Try to improve the stability of Selenium with maxSessions:2

### DIFF
--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -112,6 +112,9 @@ spec:
           mountPath: "/var/run/docker.sock"
       - name: selenium
         image: selenium/standalone-chrome:3.14
+        env:
+          - name: NODE_MAX_SESSION
+            value: 2
         ports:
         - containerPort: 4444
         readinessProbe:


### PR DESCRIPTION
### Improvements
The Selenium side car is currently operating with 1 single sessions in its `/opt/selenium/config.json`, which is generated by:
```start-selenium-node.sh:/opt/bin/generate_config > /opt/selenium/config.json```

Using the following environment variable:
```
seluser@jenkins-pod:/opt/bin$ cat generate_config
#!/bin/bash
..
cat <<_EOF
{
...
  "maxSession": $NODE_MAX_SESSION,
```

Let us bump this up to `2` and monitor the pipeline to see if we can mitigate the current intermittent issues:
```
invalid session id (Driver info: chromedriver=2.43.600233 (523efee95e3d68b8719b3a1c83051aa63aa6b10d),platform=Linux 4.14.173-137.229.amzn2.x86_64 x86_64)
Stacktrace
invalid session id
```
and
```
chrome not reachable (Session info: headless chrome=70.0.3538.77) (Driver info: chromedriver=2.43.600233
```

This might help as temporary patch to increase stability while other major pipeline improvements are still being planned / implemented.