### PR TITLE
chore(qa): Tuning selenium grid (bump up slots/sessions across nodes)

### DIFF
--- a/kube/services/selenium/README.md
+++ b/kube/services/selenium/README.md
@@ -1,5 +1,17 @@
 # Selenium Hub
 
-This diagram describes the new setup:
+## This diagram describes the new setup:
 
 ![PlanX CI pipeline Selenium Hub setup](planx-pipeline-selenium-hub-setup.png)
+
+## How to access the grid console:
+
+On the Dev admin vm:
+```
+qaplanetv1@cdistest_dev_admin:~$ kc port-forward selenium-hub-75c47cdb96-jhqz9 4444:4444
+```
+
+On your local terminal:
+```
+gen3_lab % ssh -L localhost:4444:localhost:4444 qaplanetv1@cdistest_dev.csoc
+```

--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -16,7 +16,10 @@ spec:
         app: selenium-hub
     spec:
       containers:
-      - image: selenium/hub:3.141
+      - env:
+        - name: GRID_MAX_SESSION
+          value: "20"
+        image: selenium/hub:3.141
         imagePullPolicy: always
         name: hub
         ports:

--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -26,6 +26,10 @@ spec:
           value: selenium-hub
         - name: HUB_PORT_4444_TCP_PORT
           value: "4444"
+        - name: NODE_MAX_SESSION
+          value: "5"
+        - name: NODE_MAX_INSTANCES
+          value: "2"
         image: selenium/node-chrome:3.141
         imagePullPolicy: always
         name: node-chrome


### PR DESCRIPTION
We have reached our 10 slot threshold today. Let us bump this up to 20.
```
$ kc exec -it jenkins-deployment-cbfd8dd5b-pgssf  -c jenkins -- curl -vv http://selenium-hub:4444/wd/hub/status | grep message
    "message": "Hub has capacity",
$ kc exec -it jenkins-deployment-cbfd8dd5b-pgssf -c jenkins -- curl -vv http://selenium-hub:4444/grid/api/hub/status | grep -A4 slotCounts
  "slotCounts": {
    "free": 12,
    "total": 20
  },
  "success": true,
```