### PR TITLE
chore(qa): Introduce InfluxDB to store CI Metrics.

### DIFF
--- a/kube/services/influxdb/README.md
+++ b/kube/services/influxdb/README.md
@@ -1,0 +1,3 @@
+# InfluxDB
+
+The InfluxDB pod must run on the same namespace as the Jenkins CI pod to receive CI Testing metrics pushed by CodeceptJS hooks.

--- a/kube/services/influxdb/influxdb-deployment.yaml
+++ b/kube/services/influxdb/influxdb-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: influxdb
+  name: influxdb
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: influxdb
+  template:
+    metadata:
+      labels:
+        app: influxdb
+    spec:
+      containers:
+      - image: docker.io/influxdb:1.8.0
+        imagePullPolicy: IfNotPresent
+        name: influxdb
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/influxdb
+          name: influxdb-data
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: influxdb-data
+        persistentVolumeClaim:
+          claimName: datadir-influxdb

--- a/kube/services/influxdb/influxdb-pvc.yaml
+++ b/kube/services/influxdb/influxdb-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: datadir-influxdb
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 40Gi
+  storageClassName: standard

--- a/kube/services/influxdb/influxdb-service.yaml
+++ b/kube/services/influxdb/influxdb-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: influxdb
+  name: influxdb
+  namespace: default
+spec:
+  ports:
+  - port: 8086
+    protocol: TCP
+    targetPort: 8086
+  selector:
+    app: influxdb
+  type: ClusterIP


### PR DESCRIPTION
This should address task PXP-5818 (Track number of retries and failures in the CI pipeline help prioritize the work around flaky tests)