### PR TITLE
Whitelist idph website for covid-19 etl job

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -123,7 +123,6 @@ sa-update.space-pro.be
 security.debian.org
 services.mathworks.com
 streaming.stat.iastate.edu
-www.dph.illinois.gov
 www.google.com
 www.mathworks.com
 www.oracle.com

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -23,6 +23,7 @@
 .docker.com
 .docker.io
 .dockerproject.org
+.dph.illinois.gov
 .elasticsearch.org
 .erlang-solutions.com
 .extjs.com


### PR DESCRIPTION

### Improvements
- Added .dph.illinois.gov to Squid whitelist, removed www.dph.illinois.gov
