### PR TITLE
fix(qa): Fix Selenium k8s descriptors

### DIFF
--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -25,8 +25,24 @@ spec:
         ports:
         - containerPort: 4444
           protocol: TCP
-        readinessProbe:
+        livenessProbe:
+          failureThreshold: 3
           httpGet:
-            path: /wd/hub/sessions
+            path: /wd/hub/status
             port: 4444
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /wd/hub/status
+            port: 4444
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5      
       terminationGracePeriodSeconds: 30

--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
@@ -20,7 +20,7 @@ spec:
         - name: GRID_MAX_SESSION
           value: "20"
         image: selenium/hub:3.141
-        imagePullPolicy: always
+        imagePullPolicy: Always
         name: hub
         ports:
         - containerPort: 4444

--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
@@ -31,6 +31,6 @@ spec:
         - name: NODE_MAX_INSTANCES
           value: "2"
         image: selenium/node-chrome:3.141
-        imagePullPolicy: always
+        imagePullPolicy: Always
         name: node-chrome
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Applying changes due to the following errors:
```
$ kc apply -f selenium-hub-deployment.yaml
error: unable to recognize "selenium-hub-deployment.yaml": no matches for kind "Deployment" in version "v1"
--
$ kc apply -f selenium-hub-deployment.yaml
apiVersion: v1
The Deployment "selenium-hub" is invalid: spec.template.spec.containers[0].imagePullPolicy: Unsupported value: "always": supported values: "Always", "IfNotPresent", "Never"
```