### PR TITLE
chore(sower-netpolicies): Added networkpolicy so sowerjobs can reach …

### DIFF
--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: revproxy-deployment
   annotations:
-    gen3.io/network-ingress: "portal"
+    gen3.io/network-ingress: "portal,sowerjob"
 spec:
   selector:
     # Only select pods based on the 'app' label


### PR DESCRIPTION
### New Features
Added netpolicy rule for sowerjobs to reach revproxy and utilize internal routing

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
