### PR TITLE
chore(qa-cronjob): roll or shutdown - not both

### DIFF
--- a/files/scripts/qa-cronjob.sh
+++ b/files/scripts/qa-cronjob.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
 # Enforce repo sync on $HOME/cloud-automation and $HOME/cdis-manifest
-# Run as cron job in qa-* user accounts:
+# Run as cron job in qa-* user accounts.
+# Set GEN3_SHUTDOWN=no to roll all instead of shutdown.
 #
 # vpc_name="qaplanetv1"
 # 1   1   *   *   *    (if [ -f $HOME/cloud-automation/files/scripts/qa-cronjob.sh ]; then bash $HOME/cloud-automation/files/scripts/qa-cronjob.sh; else echo "no qa-cronjob.sh"; fi) > $HOME/qa-cronjob.log 2>&1
@@ -27,5 +28,9 @@ fi
 
 source "${GEN3_HOME}/gen3/gen3setup.sh"
 gen3 gitops enforce
-gen3 roll all
-gen3 shutdown namespace
+# Either roll all or shutdown - don't do both ...
+if [[ "$GEN3_SHUTDOWN" == "no" ]]; then
+  gen3 roll all
+else
+  gen3 shutdown namespace
+fi


### PR DESCRIPTION
Improve the qa-cronjob:

* either `roll all` or `shutdown` - not both
* support for `$GEN3_SHUTDOWN` environment variable toggle

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
