### PR TITLE
chore(qa): 20 selenium nodes and 1 chrome instance per node

### DIFF
--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: selenium-node-chrome
   namespace: default
 spec:
-  replicas: 5
+  replicas: 20
   selector:
     matchLabels:
       app: selenium-node-chrome
@@ -29,7 +29,7 @@ spec:
         - name: NODE_MAX_SESSION
           value: "5"
         - name: NODE_MAX_INSTANCES
-          value: "2"
+          value: "1"
         image: selenium/node-chrome:3.141
         imagePullPolicy: Always
         name: node-chrome


### PR DESCRIPTION
We have faced numerous issues today related to:
```(node:5363) UnhandledPromiseRejectionWarning: unknown error: Session [88e1f9fbeef33c2b73233d76cf063007] was terminated due to BROWSER_TIMEOUT
```
Trying to bump up the number of nodes and avoid 2 chrome browsers running on the same pod/container.