### PR TITLE
COVID19 "nb-etl" no "command" overwrite

### DIFF
--- a/kube/services/jobs/nb-etl-cronjob.yaml
+++ b/kube/services/jobs/nb-etl-cronjob.yaml
@@ -30,6 +30,3 @@ spec:
                 limits:
                   cpu: 0.5
                   memory: 512Mi
-              command: ["/bin/bash"]
-              args:
-                - "/seir-forecast/run_seir_forecast.sh"

--- a/kube/services/jobs/nb-etl-job.yaml
+++ b/kube/services/jobs/nb-etl-job.yaml
@@ -24,6 +24,3 @@ spec:
           limits:
             cpu: 0.5
             memory: 512Mi
-        command: ["/bin/bash"]
-        args:
-          - "/seir-forecast/run_seir_forecast.sh"


### PR DESCRIPTION

### Improvements
- COVID19 "nb-etl": do not overwrite "command" and "args" from Dockerfile
