### PR TITLE
fix(qa): Use g3kubectl instead of kubectl for qa-restart-selenium script

### DIFF
--- a/files/scripts/qa-restart-selenium.sh
+++ b/files/scripts/qa-restart-selenium.sh
@@ -25,4 +25,4 @@ if [[ -z "$USER" ]]; then
 fi
 
 source "${GEN3_HOME}/gen3/gen3setup.sh"
-g3kubectl delete pods $(kubectl get pods | grep selenium | awk '{ print $1 }')
+g3kubectl delete pods $(g3kubectl get pods | grep selenium | awk '{ print $1 }')


### PR DESCRIPTION
The script is still failing due to one `kubectl` cmd that was left in the script by mistake 🤦 
```
qaplanetv1@cdistest_dev_admin:~$ cat qa-restart-selenium.log
error: You must be logged in to the server (Unauthorized)
error: resource(s) were provided, but no name, label selector, or --all flag specified
```

### Bug Fixes
Replacing `kubectl` with `g3kubectl`,