### PR TITLE
chore: increase guppy wait time for es proxy

### DIFF
--- a/gen3/bin/kube-setup-guppy.sh
+++ b/gen3/bin/kube-setup-guppy.sh
@@ -12,7 +12,7 @@ gen3 kube-setup-aws-es-proxy || true
 
 COUNT=0
 while [[ 'true' != $(g3kubectl get pods --selector=app=esproxy -o json | jq -r '.items[].status.containerStatuses[0].ready' | tr -d '\n') ]]; do
-  if [[ COUNT -gt 10 ]]; then
+  if [[ COUNT -gt 50 ]]; then
     echo "wait too long for esproxy"
     exit 1
   fi


### PR DESCRIPTION
### Improvements
- Increase Guppy wait time for ES proxy to 250s (50 cycles)
