### PR TITLE
fix(qa): chmod docker.sock in gen3-qa-worker init container

### DIFF
--- a/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
+++ b/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
@@ -18,6 +18,27 @@ spec:
       securityContext:
         runAsUser: 1000
         fsGroup: 1000
+      initContainers:
+      - args:
+        - -c
+        - |
+          # fix permissions for /var/run/docker.sock
+          chmod 666 /var/run/docker.sock
+          echo "done"
+        command:
+        - /bin/bash
+        image: quay.io/cdis/awshelper:master
+        imagePullPolicy: Always
+        name: awshelper
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: dockersock
       containers:
       #
       # See for details on running docker in a pod:


### PR DESCRIPTION
That should issues like the one below (gen3 CLI features that need to instrument the underlying Docker daemon running at the ec / kube node level):
```
pushing arborist img to AWS ECR...
Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.40/auth: dial unix /var/run/docker.sock: connect: permission denied
pushing gen3-statics img to AWS ECR...
Got permission denied while trying to connect to the Docker daemon socket at unix:///var/run/docker.sock: Post http://%2Fvar%2Frun%2Fdocker.sock/v1.40/images/create?fromImage=quay.io%2Fcdis%2Fgen3-statics&tag=2020.07: dial unix /var/run/docker.sock: connect: permission denied
```