### PR TITLE
fix(bucket-access): Removed verify bucket access job from kube-setup-…

### DIFF
--- a/gen3/bin/kube-setup-google.sh
+++ b/gen3/bin/kube-setup-google.sh
@@ -11,7 +11,6 @@ cronList=(
   "${GEN3_HOME}/kube/services/jobs/google-manage-account-access-cronjob.yaml"
   "${GEN3_HOME}/kube/services/jobs/google-init-proxy-groups-cronjob.yaml"
   "${GEN3_HOME}/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml"
-  "${GEN3_HOME}/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml"
 )
 
 # lib --------------------


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes
Removed verify bucket access job from kube-setup-google because the job is buggy and removes access it shouldn't

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
