### PR TITLE
Add network policy netnolimit to metadataservice deployment

### DIFF
--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -22,6 +22,8 @@ spec:
         public: "yes"
         # allow access from workspaces
         userhelper: "yes"
+        # for network policy
+        netnolimit: "yes"
         GEN3_DATE_LABEL
     spec:
       affinity:


### PR DESCRIPTION
Fixes issues with network egress observed in metadataservice.
