### PR TITLE
csoc-free commons issue in manifest.json template

### DIFF
--- a/doc/csoc-free-commons-steps.md
+++ b/doc/csoc-free-commons-steps.md
@@ -280,7 +280,7 @@ mkdir -p ${HOME}/cdis-manifest/commons-test.planx-pla.net
     "sheepdog": "quay.io/cdis/sheepdog:master",
     "spark": "quay.io/cdis/gen3-spark:master",
     "manifestservice": "quay.io/cdis/manifestservice:master",
-    "wts": "quay.io/cdis/workspace-token-service:master",
+    "wts": "quay.io/cdis/workspace-token-service:master"
   },
   "arborist": {
     "deployment_version": "2"


### PR DESCRIPTION
gen3 roll all bailed out, stating that all comonents do not have a defined version and will therefor not be deployed.
Removing the additional , fixed this behaviour.