### PR TITLE
chore(qa): Whitelist biodata integration tests domain

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -4,6 +4,7 @@
 192.170.230.164
 accounts.google.com
 achecker.ca
+biodata-integration-tests.net
 ctds-planx.atlassian.net
 api.immport.org
 api.login.yahoo.com


### PR DESCRIPTION
Must whitelist the following domain:
`https://biodata-integration-tests.net`