### PR TITLE
fix(qa): Minor fix for bucket-manifest create-jenkins function

### DIFF
--- a/gen3/bin/bucket-manifest.sh
+++ b/gen3/bin/bucket-manifest.sh
@@ -18,7 +18,7 @@ gen3_create_aws_batch_jenkins() {
   local temp_bucket=$(echo "${prefix}-temp-bucket" | head -c63)
   cat - > "./paramFile.json" <<EOF
 {
-    "job_id": "${job_id}",
+    "job_id": "${jobId}",
     "bucket_name": "${temp_bucket}"
 }
 EOF

--- a/gen3/bin/bucket-manifest.sh
+++ b/gen3/bin/bucket-manifest.sh
@@ -16,13 +16,12 @@ saName=$(echo "${prefix}-sa" | head -c63)
 gen3_create_aws_batch_jenkins() {
   local prefix="${hostname//./-}-bucket-manifest-${jobId}"
   local temp_bucket=$(echo "${prefix}-temp-bucket" | head -c63)
-  cat - > "$paramFile" <<EOF
+  cat - > "./paramFile.json" <<EOF
 {
     "job_id": "${job_id}",
     "bucket_name": "${temp_bucket}"
 }
 EOF
-  echo $paramFile > ./paramFile.json 
   gen3_create_aws_batch $@
 }
 


### PR DESCRIPTION
Minor fix to lay down a paramFile.json containing some key data to be used by the Jenkins CI tests while executing the bucket-manifest CLI command.

Testing:
```
jenkins-dcp@cdistest_dev_admin:~$ gen3 bucket-manifest create-jenkins cdistest-public-test-bucket
jenkins-dcp-planx-pla-net-bucket-manifest-3g3w
ERROR: 18:13:41 - No fence_bot aws credential block in fence_config.yaml
jenkins-dcp@cdistest_dev_admin:~$ cat paramFile.json
{
    "job_id": "3g3w",
    "bucket_name": "jenkins-dcp-planx-pla-net-bucket-manifest-3g3w-temp-bucket"
}
```