### PR TITLE
chore(qa): Install xml parser for Jenkins

### DIFF
--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # install python and pip and aws cli
 RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip jq less vim gettext-base
-RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade
+RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade && python -m pip install lxml --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
 RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade
 

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # install python and pip and aws cli
 RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip jq less vim gettext-base
-RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade
+RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade && python -m pip install lxml --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
 RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade
 


### PR DESCRIPTION
Quick test within the container:
```
Installing collected packages: lxml
Successfully installed lxml-4.5.2
```

```
jenkins@jenkins-deployment-755c6b9dfc-p7wvz:~/workspace/test-xml-read/output$ python -c "import lxml.etree; print(lxml.etree.fromstring(\"\"\"$(cat 90ff652b-dd6f-487c-9cb6-c06177fcbb6c-testsuite.xml)\"\"\").xpath('//ns2:test-suite/test-cases/test-case/@status', namespaces={'ns2': 'urn:model.allure.qatools.yandex.ru'}))"
['failed', 'failed', 'failed', 'failed', 'failed', 'failed', 'failed', 'failed', 'failed']
```