### PR TITLE
chore(dashboard): deprecate user setup

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-07-28T21:39:49Z",
+  "generated_at": "2020-07-30T16:28:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -264,13 +264,13 @@
       {
         "hashed_secret": "40304f287a52d99fdbe086ad19dbdbf9cc1b3897",
         "is_verified": false,
-        "line_number": 34,
+        "line_number": 40,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "e7064f0b80f61dbc65915311032d27baa569ae2a",
         "is_verified": false,
-        "line_number": 35,
+        "line_number": 41,
         "type": "Secret Keyword"
       }
     ],

--- a/gen3/bin/kube-setup-dashboard.sh
+++ b/gen3/bin/kube-setup-dashboard.sh
@@ -17,6 +17,12 @@ setup_dashboard_service() {
     gen3_log_info "not deploying dashboard service - no manifest entry"
     return 0
   fi
+  local saName="dashboard-sa"
+  g3kubectl create sa "$saName" > /dev/null 2>&1 || true
+  if ! [[ -f "$(gen3_secrets_folder)/creds.json" && -z "$JENKINS_HOME" ]]; then # create database
+    gen3_log_info "kube-setup-dashboard skipping full db setup in non-admin environment"
+    return 0
+  fi
 
   local secret
   local secretsFolder="$(gen3_secrets_folder)/g3auto/dashboard"
@@ -58,39 +64,17 @@ setup_dashboard_service() {
       gen3_log_err "maybe failed to create bucket ${bucketName}, but maybe not, because the terraform script is flaky"
     fi
 
-    if true; then # transitioning to use role+service account, but
-      # continue creating IAM user until the dashboard updates
-      # necessary for IAM-linked service accounts are available.
-      #
-      local userName
-      userName="dashboard-${environment}-bot"
-      if aws iam get-user --user-name "$userName" > /dev/null 2>&1; then
-        gen3_log_err "${userName} iam user already exists - probably in use by another namespace - copy the creds from there to $(gen3_secrets_folder)/g3auto/dashboard"
-        return 1
-      elif ! gen3 awsuser create "$userName"; then
-        gen3_log_err "failed to create ${userName} iam user"
-        return 1
-      fi
-      gen3 s3 attach-bucket-policy "$bucketName" --read-only --user-name "${userName}"
-    
-      local creds
-      creds="$(gen3 secrets decode "${userName}-g3auto" "awsusercreds.json")"
-      jq -r -n --argjson creds "${creds}" '.AWS=$creds' > "${secretsFolder}/creds.json"
-    fi
-
     local hostname
     hostname="$(gen3 api hostname)"
-
     jq -r -n --arg bucket "${bucketName}" --arg hostname "${hostname}" '.bucket=$bucket | .prefix=$hostname' > "${secretsFolder}/config.json"
     gen3 secrets sync 'setup dashboard credentials'
   fi
 
   local roleName
-  local saName="dashboard-sa"
   roleName="$(gen3 api safe-name dashboard)" || return 1
     
   if ! gen3 awsrole info "$roleName" > /dev/null; then # setup role
-    bucketName="$((gen3 secrets decode dashboard-g3auto config.json || echo ERROR) | jq -r .bucket)" || return 1
+    bucketName="$( (gen3 secrets decode dashboard-g3auto config.json || echo ERROR) | jq -r .bucket)" || return 1
     gen3 awsrole create "$roleName" "$saName" || return 1
     #echo gen3 s3 attach-bucket-policy "$bucketName" --read-only --role-name "${roleName}"
     gen3 s3 attach-bucket-policy "$bucketName" --read-only --role-name "${roleName}"
@@ -100,15 +84,11 @@ setup_dashboard_service() {
     gen3 s3 attach-bucket-policy "$bucketName" --read-write --role-name "${gitopsRoleName}"
   fi
 
-  gen3_log_info "rolling dashboard service"
   g3kubectl apply -f "${GEN3_HOME}/kube/services/dashboard/dashboard-service.yaml"
-  gen3 roll dashboard
 }
 
 if g3k_manifest_lookup .versions.dashboard > /dev/null 2>&1; then
-  if [[ -f "$(gen3_secrets_folder)/creds.json" && -z "$JENKINS_HOME" ]]; then # create database
-    setup_dashboard_service
-  else
-    gen3 roll dashboard
-  fi
+  gen3_log_info "rolling dashboard service"
+  setup_dashboard_service
+  gen3 roll dashboard
 fi

--- a/kube/services/dashboard/dashboard-deploy.yaml
+++ b/kube/services/dashboard/dashboard-deploy.yaml
@@ -43,10 +43,7 @@ spec:
         - name: config-volume
           secret:
             secretName: "dashboard-g3auto"
-      # SA linked IAM role support - uncomment this
-      # after the new dashboard code with WebToken auth
-      # support rolls out:
-      #serviceAccountName: dashboard-sa
+      serviceAccountName: dashboard-sa
       securityContext:
         fsGroup: 1001
       containers:
@@ -63,9 +60,6 @@ spec:
           - name: "config-volume"
             readOnly: true
             mountPath: "/etc/gen3"
-            # Switch to this after full transition to SA-linked IAM role:
-            #mountPath: "/etc/gen3/config.json"
-            #subPath: "config.json"
         resources:
           requests:
             cpu: 0.3


### PR DESCRIPTION
Jira Ticket: [PXP-6336](https://ctds-planx.atlassian.net/browse/PXP-6336)

* kube-setup-dashboard no longer creates an IAM user - new dashboard deployments must run 2020.08 or newer docker image, existing deployments should continue to work fine with user IAM creds

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
