### PR TITLE
fix(gen3-setup): no exit on aws-iam-auth install

### DIFF
--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -39,7 +39,7 @@ g3kubectl() {
   if [[ -n "$KUBECONFIG" ]] && grep -e heptio -e aws-iam "$KUBECONFIG" > /dev/null 2>&1 && [[ ! -x /usr/local/bin/aws-iam-authenticator ]]; then
     # Then it's EKS - we need to upgrade to aws-iam-authenticator - run with AWS creds!
     gen3_log_err "/usr/local/bin/aws-iam-authenticator not installed - run gen3 kube-setup-workvm as a user with sudo"
-    exit 1
+    return 1
   fi
   "$theKubectl" ${KUBECTL_NAMESPACE/[[:alnum:]-]*/--namespace=${KUBECTL_NAMESPACE}} "$@"
 }


### PR DESCRIPTION
Fix `g3kubectl` to call `return 1` instead of `exit 1` to avoid upgrade problems by the community and weird behavior on a new admin vm

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
