### PR TITLE
chore(qa): Update acronymbot to be compatible with private repos

### DIFF
--- a/kube/services/acronymbot/acronymbot-deploy.yaml
+++ b/kube/services/acronymbot/acronymbot-deploy.yaml
@@ -28,6 +28,11 @@ spec:
             secretKeyRef:
               name: acronymbot-g3auto
               key: 'slacktoken.json'
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: acronymbot-g3auto
+              key: "githubtoken.json"
         imagePullPolicy: Always
         resources:
           requests:


### PR DESCRIPTION
Adopt new secret to be able to fetch acronyms.txt (JSON) from private repo.