### PR TITLE
chore(qa): Add k8s deployment descriptor for qa-bot

### DIFF
--- a/kube/services/qabot/qabot-deploy.yaml
+++ b/kube/services/qabot/qabot-deploy.yaml
@@ -1,0 +1,64 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: qabot-deployment
+spec:
+  selector:
+    # Only select pods based on the 'app' label
+    matchLabels:
+      app: qabot
+  revisionHistoryLimit: 2
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: qabot
+        netnolimit: "yes"
+    spec:
+      containers:
+      - name: qabot
+        image: "quay.io/cdis/qa-bot:latest"
+        env:
+        - name: SLACK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: qabot-g3auto
+              key: "slacktoken.json"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: qabot-g3auto
+              key: "githubtoken.json"
+        - name: JENKINS_JOB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: qabot-g3auto
+              key: "jenkins_job_token.json"
+        - name: JENKINS1_USER_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: qabot-g3auto
+              key: "jenkins1_user_api_token.json"
+        - name: JENKINS2_USER_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: qabot-g3auto
+              key: "jenkins2_user_api_token.json"
+        imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 1
+          limits:
+            cpu: 2
+            memory: 512Mi
+        volumeMounts:
+        - name: slacktoken
+          mountPath: "/secret/githubtoken.json"
+      volumes:
+      - name: slacktoken
+        secret:
+          secretName: qabot-g3auto

--- a/kube/services/qabot/qabot-deploy.yaml
+++ b/kube/services/qabot/qabot-deploy.yaml
@@ -38,7 +38,7 @@ spec:
             secretKeyRef:
               name: qabot-g3auto
               key: "jenkins_job_token.json"
-        - name: JENKINS1_USER_API_TOKEN
+        - name: JENKINS_USER_API_TOKEN
           valueFrom:
             secretKeyRef:
               name: qabot-g3auto


### PR DESCRIPTION
Augment `qa-bot`'s capabilities so it can invoke Jenkins jobs as part of some basic ChatOps initiative.