### PR TITLE
Chore/api version

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-08-11T21:27:15Z",
+  "generated_at": "2020-08-11T21:37:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -314,19 +314,19 @@
       {
         "hashed_secret": "40304f287a52d99fdbe086ad19dbdbf9cc1b3897",
         "is_verified": false,
-        "line_number": 26,
+        "line_number": 32,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "d3df8a3b08a9de43b73eca1302d50e7a0e5b360f",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 49,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "9f29ed52bc91ba45b309d5234e95edc7ca5286fd",
         "is_verified": false,
-        "line_number": 45,
+        "line_number": 51,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2020-07-30T16:28:16Z",
+  "generated_at": "2020-08-11T21:27:15Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -390,13 +390,13 @@
       {
         "hashed_secret": "d3df8a3b08a9de43b73eca1302d50e7a0e5b360f",
         "is_verified": false,
-        "line_number": 112,
+        "line_number": 115,
         "type": "Secret Keyword"
       },
       {
         "hashed_secret": "9f29ed52bc91ba45b309d5234e95edc7ca5286fd",
         "is_verified": false,
-        "line_number": 114,
+        "line_number": 117,
         "type": "Secret Keyword"
       }
     ],

--- a/doc/logs.md
+++ b/doc/logs.md
@@ -264,6 +264,14 @@ Retrieve the number of unique users for the given commons and date range.
 $ gen3 logs history users "start=-7 days" "vpc=bhcprodv2"
 ```
 
+### `gen3 logs history byuser`
+
+Retrieve hit counts for the top 100 users.
+
+```
+$ gen3 logs history byuser "start=-4 days" "end=-3 days" "vpc=bhcprodv2"
+```
+
 ### `gen3 logs snapshot`
 
 Snapshot the logs of currently running pods excluding jupyterhub to `.gz` files.

--- a/files/dashboard/workspace-public/README.md
+++ b/files/dashboard/workspace-public/README.md
@@ -1,0 +1,19 @@
+# TL;DR
+
+Little landing page for the workspace.gen3.org parent account.
+[This document](https://docs.google.com/document/d/10_Rv-HWAvjvt8QQhA_0e5GIdI2M0rOBDvc5IA5zd8M0/edit#heading=h.ra5thdn8e3xr) provides an overview of the multi-account workspace design.
+
+## Deployment
+
+Deploy the workspace app to the root of the dashboard `Public/` space:
+```
+mkdir -p "$(gen3 gitops folder)/dashboard/Public"
+rsync -av "$GEN3_HOME/files/dashboard/workspace-public/src/" "$(gen3 gitops folder)/dashboard/Public/"
+gen3 dashboard gitops-sync
+```
+
+Configure the reverse proxy to redirect non-api traffic to the dashboard:
+```
+jq -r '.global.portal_app = "GEN3-WORKSPACE-PARENT"' < "$(g3k_manifest_path)" | tee "$(g3k_manifest_path).new"
+mv "(g3k_manifest_path).new" "(g3k_manifest_path)"
+```

--- a/files/dashboard/workspace-public/src/index.html
+++ b/files/dashboard/workspace-public/src/index.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+
+</head>
+<body>
+  <h1>Gen3 Workspaces</h1>
+
+<p>
+  This is the parent Gen3 workspace domain.  
+  Login to your group's domain to launch applications.
+</p>
+<a href="/user/login/google?redirect=/user/user">Google Login</a>
+</body>
+</html>

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -36,10 +36,15 @@ fi
 
 # deploy fence
 gen3 roll fence
-# deploy presigned-url-fence
-gen3 roll presigned-url-fence
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-service.yaml"
-g3kubectl apply -f "${GEN3_HOME}/kube/services/presigned-url-fence/presigned-url-fence-service.yaml"
+
+portalApp="$(g3k_manifest_lookup .global.portal_app)"
+if ! [[ "$portalApp" =~ ^GEN3-WORKSPACE ]]; then
+  # deploy presigned-url-fence
+  gen3 roll presigned-url-fence
+  g3kubectl apply -f "${GEN3_HOME}/kube/services/presigned-url-fence/presigned-url-fence-service.yaml"
+fi
+
 gen3 roll fence-canary || true
 g3kubectl apply -f "${GEN3_HOME}/kube/services/fence/fence-canary-service.yaml"
 gen3_log_info "The fence service has been deployed onto the k8s cluster."

--- a/gen3/bin/kube-setup-ssjdispatcher.sh
+++ b/gen3/bin/kube-setup-ssjdispatcher.sh
@@ -90,6 +90,9 @@ EOM
     gen3_log_info "creating IAM role for ssj: $roleName, linking to sa $saName"
     gen3 awsrole create "$roleName" "$saName" || return 1
     aws iam attach-role-policy --role-name "$roleName" --policy-arn 'arn:aws:iam::aws:policy/AmazonSQSFullAccess' 1>&2
+  else
+    # update the annotation - just to be thorough
+    gen3 awsrole sa-annotate "$saName" "$roleName"
   fi
   if ! gen3 awsrole info "$roleNameForJob" > /dev/null; then # setup role
     gen3_log_info "creating IAM role for ssj job: $roleNameForJob, linking to sa $saNameForJob"

--- a/gen3/bin/logs.sh
+++ b/gen3/bin/logs.sh
@@ -56,6 +56,9 @@ if [[ -z "$GEN3_SOURCE_ONLY" ]]; then
         "users")
           gen3_logs_user_count "$@"
           ;;
+        "byuser")
+          gen3_logs_user_histogram "$@"
+          ;;
         "daily")
           gen3_logs_history_daily "$@"
           ;;

--- a/gen3/bin/netpolicy.sh
+++ b/gen3/bin/netpolicy.sh
@@ -126,7 +126,7 @@ EOM
   done
   (cat - <<EOM
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "apps/v1",
     "kind": "NetworkPolicy",
     "metadata": {
         "name": "$name"

--- a/gen3/bin/netpolicy.sh
+++ b/gen3/bin/netpolicy.sh
@@ -126,7 +126,7 @@ EOM
   done
   (cat - <<EOM
 {
-    "apiVersion": "apps/v1",
+    "apiVersion": "networking.k8s.io/v1",
     "kind": "NetworkPolicy",
     "metadata": {
         "name": "$name"

--- a/gen3/bin/netpolicy.sh
+++ b/gen3/bin/netpolicy.sh
@@ -26,7 +26,7 @@ gen3_net_external_access() {
   cidrList="$(mktemp "$XDG_RUNTIME_DIR/cidrList.ndjson_XXXXXX")"
   cat - > "$basePolicy" <<EOM
 {
-    "apiVersion": "extensions/v1beta1",
+    "apiVersion": "networking.k8s.io/v1",
     "kind": "NetworkPolicy",
     "metadata": {
         "name": "netpolicy-external-egress"

--- a/gen3/lib/testData/bogusExpectedResult.yaml
+++ b/gen3/lib/testData/bogusExpectedResult.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sheepdog-deployment

--- a/gen3/lib/testData/bogusInput.yaml
+++ b/gen3/lib/testData/bogusInput.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sheepdog-deployment

--- a/gen3/lib/testData/default/expectedFenceResult.yaml
+++ b/gen3/lib/testData/default/expectedFenceResult.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fence-deployment

--- a/gen3/lib/testData/default/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/default/expectedSheepdogResult.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sheepdog-deployment

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fence-deployment

--- a/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sheepdog-deployment

--- a/kube/services/acronymbot/acronymbot-deploy.yaml
+++ b/kube/services/acronymbot/acronymbot-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: acronymbot-deployment

--- a/kube/services/ambassador-gen3/ambassador-gen3-deploy.yaml
+++ b/kube/services/ambassador-gen3/ambassador-gen3-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador-gen3-deployment

--- a/kube/services/ambassador/ambassador-deploy.yaml
+++ b/kube/services/ambassador/ambassador-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambassador-deployment

--- a/kube/services/ambtest/ambtest-deploy.yaml
+++ b/kube/services/ambtest/ambtest-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ambtest-deployment

--- a/kube/services/arborist/arborist-deploy-2.yaml
+++ b/kube/services/arborist/arborist-deploy-2.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: arborist-deployment

--- a/kube/services/arborist/arborist-deploy.yaml
+++ b/kube/services/arborist/arborist-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: arborist-deployment

--- a/kube/services/arranger-dashboard/arranger-dashboard-deploy.yaml
+++ b/kube/services/arranger-dashboard/arranger-dashboard-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: arranger-dashboard-deployment

--- a/kube/services/arranger/arranger-deploy.yaml
+++ b/kube/services/arranger/arranger-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: arranger-deployment

--- a/kube/services/auspice/auspice-deploy.yaml
+++ b/kube/services/auspice/auspice-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: auspice-deployment

--- a/kube/services/autoscaler/kube-node-drainer-asg-status-updater-de.yaml
+++ b/kube/services/autoscaler/kube-node-drainer-asg-status-updater-de.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: kube-node-drainer-asg-status-updater
   namespace: kube-system

--- a/kube/services/autoscaler/kube-node-drainer-ds.yaml
+++ b/kube/services/autoscaler/kube-node-drainer-ds.yaml
@@ -1,5 +1,5 @@
 kind: DaemonSet
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: kube-node-drainer-ds
   namespace: kube-system

--- a/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: aws-es-proxy-deployment

--- a/kube/services/dashboard/dashboard-deploy.yaml
+++ b/kube/services/dashboard/dashboard-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "dashboard"

--- a/kube/services/datasim/datasim-deploy.yaml
+++ b/kube/services/datasim/datasim-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: datasim-deployment

--- a/kube/services/fence/fence-canary-deploy.yaml
+++ b/kube/services/fence/fence-canary-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fence-canary-deployment

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fence-deployment

--- a/kube/services/fenceshib/fenceshib-canary-deploy.yaml
+++ b/kube/services/fenceshib/fenceshib-canary-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fenceshib-canary-deployment

--- a/kube/services/fenceshib/fenceshib-deploy.yaml
+++ b/kube/services/fenceshib/fenceshib-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fenceshib-deployment

--- a/kube/services/fluentd/fluentd.yaml
+++ b/kube/services/fluentd/fluentd.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: fluentd

--- a/kube/services/gdcapi/gdcapi-deploy.yaml
+++ b/kube/services/gdcapi/gdcapi-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gdcapi-deployment

--- a/kube/services/google-sa-validation/google-sa-validation-deploy.yaml
+++ b/kube/services/google-sa-validation/google-sa-validation-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: google-sa-validation

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: guppy-deployment

--- a/kube/services/hatchery/hatchery-deploy.yaml
+++ b/kube/services/hatchery/hatchery-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hatchery-deployment

--- a/kube/services/indexd/indexd-canary-deploy.yaml
+++ b/kube/services/indexd/indexd-canary-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1 
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   name: indexd-canary-deployment

--- a/kube/services/indexd/indexd-deploy.yaml
+++ b/kube/services/indexd/indexd-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: indexd-deployment

--- a/kube/services/influxdb/influxdb-deployment.yaml
+++ b/kube/services/influxdb/influxdb-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
+++ b/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jenkins-worker-deployment

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jenkins-deployment

--- a/kube/services/jupyterhub/jupyterhub-prepuller.yaml
+++ b/kube/services/jupyterhub/jupyterhub-prepuller.yaml
@@ -1,6 +1,6 @@
 # Prepuller for images used by notebooks
 # Should be synced with jupyterhub-config
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: jupyterhub-prepuller

--- a/kube/services/manifestservice/manifestservice-deploy.yaml
+++ b/kube/services/manifestservice/manifestservice-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: manifestservice-deployment

--- a/kube/services/mariner/mariner-deploy.yaml
+++ b/kube/services/mariner/mariner-deploy.yaml
@@ -1,5 +1,5 @@
 # used ssjdispatcher deployment spec as a base
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mariner-deployment

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metadata-deployment

--- a/kube/services/nb2/nb2-deploy.yaml
+++ b/kube/services/nb2/nb2-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1 
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   name: shiny-nb2

--- a/kube/services/peregrine/peregrine-canary-deploy.yaml
+++ b/kube/services/peregrine/peregrine-canary-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: peregrine-canary-deployment

--- a/kube/services/peregrine/peregrine-deploy.yaml
+++ b/kube/services/peregrine/peregrine-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: peregrine-deployment

--- a/kube/services/pidgin/pidgin-deploy.yaml
+++ b/kube/services/pidgin/pidgin-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pidgin-deployment

--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: portal-deployment

--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: presigned-url-fence-deployment

--- a/kube/services/qa-dashboard/qa-dashboard-deployment.yaml
+++ b/kube/services/qa-dashboard/qa-dashboard-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: qa-metrics-deployment

--- a/kube/services/revproxy/gen3.nginx.conf/portal-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/portal-service.conf
@@ -5,7 +5,7 @@
 
               #
               # Go into maintenance mode when both are true:
-              #  - MAINTENANCE_MODE enironment variable is set
+              #  - MAINTENANCE_MODE environment variable is set
               #  - devmode cookies is not set
               #
               set $maintenance_mode "$maintenance_mode_env";

--- a/kube/services/revproxy/gen3.nginx.conf/portal-workspace-parent.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/portal-workspace-parent.conf
@@ -1,0 +1,6 @@
+          location / {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+              rewrite ^/(.*)$ /dashboard/Public/index.html redirect;
+          }

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -193,13 +193,16 @@ server {
 
   server_tokens off;
   more_clear_headers "X-Powered-By" "Server"
-  more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubdomains; preload";
   more_set_headers "X-Frame-Options: SAMEORIGIN";
   more_set_headers "X-Content-Type-Options: nosniff";
   more_set_headers "X-Xss-Protection: 1; mode=block";
 
   if ($http_x_forwarded_proto = "http") { return 301 https://$host$request_uri; }
-  
+  #
+  # Strict-Transport-Security only applys for https traffic - set after testing protocol
+  #
+  more_set_headers "Strict-Transport-Security: max-age=63072000; includeSubdomains; ";
+
   # check request against ip black list
   include /etc/nginx/manifest-revproxy/blacklist.conf;
   

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: revproxy-deployment

--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kube/services/sftp/sftp-deploy.yaml
+++ b/kube/services/sftp/sftp-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sftp-deployment

--- a/kube/services/sheepdog/sheepdog-canary-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-canary-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sheepdog-canary-deployment

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sheepdog-deployment

--- a/kube/services/shiny/shiny-deploy.yaml
+++ b/kube/services/shiny/shiny-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shiny-deployment

--- a/kube/services/sower/sower-deploy.yaml
+++ b/kube/services/sower/sower-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: sower-deployment

--- a/kube/services/spark/spark-deploy.yaml
+++ b/kube/services/spark/spark-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: spark-deployment

--- a/kube/services/ssjdispatcher/ssjdispatcher-deploy.yaml
+++ b/kube/services/ssjdispatcher/ssjdispatcher-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ssjdispatcher-deployment

--- a/kube/services/statsd-exporter/statsd-exporter-deploy.yaml
+++ b/kube/services/statsd-exporter/statsd-exporter-deploy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "statsd-exporter"

--- a/kube/services/status-api/status-api-deploy.yaml
+++ b/kube/services/status-api/status-api-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: status-api-deployment

--- a/kube/services/tube/tube-deploy.yaml
+++ b/kube/services/tube/tube-deploy.yaml
@@ -1,7 +1,7 @@
 ---
 # tube deployment - only for testing
 # normally use tube via: gen3 job run etl
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: tube-deployment

--- a/kube/services/userapi/userapi-deploy.yaml
+++ b/kube/services/userapi/userapi-deploy.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: userapi-deployment

--- a/kube/services/wts/wts-deploy.yaml
+++ b/kube/services/wts/wts-deploy.yaml
@@ -1,5 +1,5 @@
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wts-deployment

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -73,7 +73,7 @@ variable "jupyter_asg_min_size" {
 }
 
 variable "iam-serviceaccount" {
-  default = false
+  default = true
 }
 
 variable "domain_test" {


### PR DESCRIPTION
Jira Ticket: [PXP-6579](https://ctds-planx.atlassian.net/browse/PXP-6579)

* enable sa-iam-role stuff by default in terraform eks
* bump k8s deployments to `apps/v1` apiVersion
* basic workspace-parent account landing page, and couple hooks to bypass portal when `portal_app` set to `GEN3-WORKSPACE-PARENT`
* `gen3 logs history byuser` command to get list of top 100 users over some time range
* `revproxy` tweak handling of `Strict-Transport-Security` header - there's a covid19 security scan jira someplace

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

* enable sa-iam-role stuff by default in terraform eks
* bump k8s deployments to `apps/v1` apiVersion
* basic workspace-parent account landing page, and couple hooks to bypass portal when `portal_app` set to `GEN3-WORKSPACE-PARENT`
* `gen3 logs history byuser` command to get list of top 100 users over some time range
* `revproxy` tweak handling of `Strict-Transport-Security` header - there's a covid19 security scan jira someplace

### Dependency updates


### Deployment changes
