### PR TITLE
Configure guppy to listen to port 8000 in anticipation of PSP

### DIFF
--- a/kube/services/ambassador-gen3/ambassador-gen3-admin-service.yaml
+++ b/kube/services/ambassador-gen3/ambassador-gen3-admin-service.yaml
@@ -6,10 +6,11 @@ metadata:
     app: ambassador-gen3-admin
   name: ambassador-gen3-admin
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: ambassador-gen3-admin
     port: 8977
     targetPort: 8877
+    nodePort: null
   selector:
     app: ambassador-gen3

--- a/kube/services/ambassador/ambassador-rbac.yaml
+++ b/kube/services/ambassador/ambassador-rbac.yaml
@@ -6,11 +6,12 @@ metadata:
     service: ambassador-admin
   name: ambassador-admin
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: ambassador-admin
     port: 8877
     targetPort: 8877
+    nodePort: null
   selector:
     service: ambassador
 ---

--- a/kube/services/arborist/arborist-service.yaml
+++ b/kube/services/arborist/arborist-service.yaml
@@ -10,8 +10,10 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/arranger/arranger-service.yaml
+++ b/kube/services/arranger/arranger-service.yaml
@@ -10,4 +10,5 @@ spec:
       port: 80
       targetPort: 3000 
       name: http
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/aws-es-proxy/aws-es-proxy-service.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-service.yaml
@@ -10,5 +10,6 @@ spec:
       port: 9200 
       targetPort: 9200
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP
 

--- a/kube/services/fence/fence-service.yaml
+++ b/kube/services/fence/fence-service.yaml
@@ -11,8 +11,10 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/fenceshib/fenceshib-service.yaml
+++ b/kube/services/fenceshib/fenceshib-service.yaml
@@ -11,8 +11,10 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/gdcapi/gdcapi-service.yaml
+++ b/kube/services/gdcapi/gdcapi-service.yaml
@@ -10,9 +10,11 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP
 

--- a/kube/services/guppy/guppy-deploy.yaml
+++ b/kube/services/guppy/guppy-deploy.yaml
@@ -52,17 +52,19 @@ spec:
           livenessProbe:
             httpGet:
               path: /_status
-              port: 80
+              port: 8000
             initialDelaySeconds: 30
             periodSeconds: 60
             timeoutSeconds: 30
           readinessProbe:
             httpGet:
               path: /_status
-              port: 80
+              port: 8000
           ports:
-          - containerPort: 80
+          - containerPort: 8000
           env:
+          - name: GUPPY_PORT
+            value: "8000"
           - name: GUPPY_CONFIG_FILEPATH
             value: /guppy/guppy_config.json
           - name: GEN3_ES_ENDPOINT

--- a/kube/services/guppy/guppy-service.yaml
+++ b/kube/services/guppy/guppy-service.yaml
@@ -8,6 +8,7 @@ spec:
   ports:
     - protocol: TCP
       port: 80
-      targetPort: 80 
+      targetPort: 8000
+      nodePort: null
       name: http
-  type: NodePort
+  type: ClusterIP

--- a/kube/services/indexd/indexd-service.yaml
+++ b/kube/services/indexd/indexd-service.yaml
@@ -20,9 +20,11 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP
 

--- a/kube/services/jupyterhub/jupyterhub-service.yaml
+++ b/kube/services/jupyterhub/jupyterhub-service.yaml
@@ -10,4 +10,5 @@ spec:
       port: 8000
       targetPort: 8000
       name: proxy
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/mariner/mariner-service.yaml
+++ b/kube/services/mariner/mariner-service.yaml
@@ -10,4 +10,5 @@ spec:
       port: 80
       targetPort: 80
       name: http
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/portal/portal-service.yaml
+++ b/kube/services/portal/portal-service.yaml
@@ -10,8 +10,10 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443 
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/presigned-url-fence/presigned-url-fence-service.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-service.yaml
@@ -11,8 +11,10 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/qa-dashboard/qa-dashboard-service.yaml
+++ b/kube/services/qa-dashboard/qa-dashboard-service.yaml
@@ -10,8 +10,10 @@ spec:
       port: 80
       targetPort: 3030
       name: http
+      nodePort: null
     - name: https
       port: 443
       protocol: TCP
       targetPort: 443
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/sheepdog/sheepdog-service.yaml
+++ b/kube/services/sheepdog/sheepdog-service.yaml
@@ -11,9 +11,11 @@ spec:
       port: 80
       targetPort: 80
       name: http
+      nodePort: null
     - protocol: TCP
       port: 443
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP
 

--- a/kube/services/spark/spark-service.yaml
+++ b/kube/services/spark/spark-service.yaml
@@ -10,28 +10,35 @@ spec:
       port: 80
       targetPort: 80
       name: http
+      nodePort: null
     - protocol: TCP
       port: 9000
       targetPort: 9000
       name: hdfs
+      nodePort: null
     - protocol: TCP
       port: 8030
       targetPort: 8030
       name: yarn-scheduler
+      nodePort: null
     - protocol: TCP
       port: 8031
       targetPort: 8031
       name: yarn-resource-tracker
+      nodePort: null
     - protocol: TCP
       port: 8032
       targetPort: 8032
       name: yarn-address-manager
+      nodePort: null
     - protocol: TCP
       port: 22
       targetPort: 22
       name: ssl
+      nodePort: null
     - protocol: TCP
       port: 7077
       targetPort: 7077
       name: spark-master
-  type: NodePort
+      nodePort: null
+  type: ClusterIP

--- a/kube/services/userapi/userapi-service.yaml
+++ b/kube/services/userapi/userapi-service.yaml
@@ -10,9 +10,11 @@ spec:
       port: 80
       targetPort: 80 
       name: http
+      nodePort: null
     - protocol: TCP 
       port: 443 
       targetPort: 443
       name: https
-  type: NodePort
+      nodePort: null
+  type: ClusterIP
 


### PR DESCRIPTION
Jira Ticket: [PXP-6506](https://ctds-planx.atlassian.net/browse/PXP-PXP-6506)

### Deployment changes
Change guppy deployment to listen on port  8000 in the container to avoid privilege escalation. This is important so guppy deployments will still work after we enforce PodSecurityPolicies that prevents privilege escalations. 
