### PR TITLE
chore(qa): Enable ALL tests for cloud-automation PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ node {
           kubectlNamespace,
           pipeConfig.serviceTesting.name,
           "",
-          "false"
+          "true"
         )
       }
       stage('CleanS3') {


### PR DESCRIPTION
To improve the testing coverage for all cloud-automation changes, we are enabling the full set of test suites for every PR.