### PR TITLE
fix(qa): Whitelist CleverSafe endpoint to unblock CI tests

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -13,6 +13,7 @@ archive.cloudera.com
 archive.linux.duke.edu
 bay.uchicago.edu
 bionimbus.tabix.oicrsofteng.org
+bionimbus-objstore-cs.opensciencedatacloud.org
 bits.netbeans.org
 cdis.slack.com
 centos.chicago.waneq.com


### PR DESCRIPTION
Facing issues with my CleverSafe CI tests here:
https://github.com/uc-cdis/gen3-qa/pull/442

Failure:
```This proxy and the remote host failed to negotiate a mutually acceptable security settings
 for handling your request. It is possible that the remote host does not support
 secure connections, or the proxy is not satisfied with the 
host security credentials.</p>\n\n<p>Your cache administrator is 
<a href="mailto:webmaster?subject=CacheErrorInfo%20-%20ERR_SECURE_CONNECT_FAIL&amp;
body=CacheHost%3A%20squid-auto-qaplanetv1%0D%0AErrPage%3A%20
ERR_SECURE_CONNECT_FAIL%0D%0AErr%3A%20(71)%20Protocol%20error...
<div id="footer">\n<p>Generated Tue, 18 Aug 2020 22:08:57 
GMT by squid-auto-qaplanetv1 (squid/4.10)</p>\n<!-- ERR_SECURE_CONNECT_FAIL -->
```