### PR TITLE
fix(CI): Upgrade Jenkins to 2.253

### DIFF
--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.242
+FROM jenkins/jenkins:2.253
 
 USER root
 


### PR DESCRIPTION
Jenkins crashed and it couldn't come back up due to:
```
2020-08-19 04:59:00.802+0000 [id=26]	SEVERE	jenkins.InitReactorRunner$1#onTaskFailed: Failed Loading plugin Pipeline: Step API v2.22 (workflow-step-api)
java.io.IOException: Failed to load: Pipeline: Step API (2.22)
 - Update required: Structs Plugin (1.19) to be updated to 1.20 or higher
```
According to some research, upgrading to the latest Jenkins image fixes the issue.