### PR TITLE
chore(qa): Upgrade jq to 1.6 on gen3-qa-worker / jenkins agent

### DIFF
--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -5,7 +5,7 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install python and pip and aws cli
-RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip jq less vim gettext-base
+RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip less vim gettext-base
 RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade && python -m pip install lxml --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
 RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade
@@ -50,6 +50,9 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" \
           google-cloud-sdk-cbt \
           kubectl \
           zsh
+
+# Install jq 1.6
+RUN wget https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && chmod +x jq-linux64 && mv jq-linux64 /usr/bin/jq
 
 # Copy sh script responsible for installing Python
 COPY install-python3.6.sh /tmp/install-python3.6.sh


### PR DESCRIPTION
We need jq 1.6 to support some gen3 release automation tasks.