### PR TITLE
Add get.helm.sh to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -54,6 +54,7 @@ ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
 gen3.org
+get.helm.sh
 gist.githubusercontent.com
 git.io
 go.googlesource.com


### PR DESCRIPTION
Jira Ticket: [PXP-6612](https://ctds-planx.atlassian.net/browse/PXP-6612)
### Dependency updates

Preparing to update helm to helm3, we need to add the new helm download url in squid 
