### PR TITLE
chore(revproxy): /workspace-authorize/ endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-08-21T18:30:30Z",
+  "generated_at": "2020-08-31T19:23:24Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -566,7 +566,7 @@
       {
         "hashed_secret": "e029d4904cc728879d70030572bf37d4510367cb",
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 22,
         "type": "JSON Web Token"
       }
     ],

--- a/kube/services/revproxy/README.md
+++ b/kube/services/revproxy/README.md
@@ -78,6 +78,12 @@ When determining which release to direct a client to, the revproxy goes through 
 The [modsecurity](https://modsecurity.org) web application firewall
 support in recent [cdis nginx](https://github.com/uc-cdis/docker-nginx) load configuration rules via the `manifest-modsec` configmap.  The default [OWASP](https://www.modsecurity.org/crs/) based rules are in `cloud-automation/gen3/lib/manifestDefaults/modsec/`.  [This document (waf.md)](../../../doc/waf.md) has more details.
 
+### Workspace Parent Deployment
+
+When the manifests `global.portal_app` property is set to `GEN3-WORKSPACE-PARENT`, then `kube-setup-revproxy` assumes that we are deploying a multi-account workspace parent rather than a traditional Gen3 commons.  In this mode the reverse proxy deploys the `portal-workspace-parent` nginx configuration with different rules than the normal portal configuration.
+* redirects unmapped traffic to `/dashboard/Public/index.html` - a custom webapp - possibly based on the code in [cloud-automation/files/dashboard/workspace-public/](../../../files/dashboard/workspace-public/)
+* a `/workspace-authorize/` endpoint that redirects clients to a subdomain's `/wts/oath2/authorize` endpoint where the subdomain is identified from the state query parameter
+
 ### Other stuff
 
 Too lazy to document this stuff.

--- a/kube/services/revproxy/gen3.nginx.conf/portal-workspace-parent.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/portal-workspace-parent.conf
@@ -1,6 +1,10 @@
-          location / {
-              if ($csrf_check !~ ^ok-\S.+$) {
-                return 403 "failed csrf check";
-              }
-              rewrite ^/(.*)$ /dashboard/Public/index.html redirect;
-          }
+        location /workspace-authorize/ {
+            js_content gen3_workspace_authorize_handler;
+        }
+
+        location / {
+            if ($csrf_check !~ ^ok-\S.+$) {
+              return 403 "failed csrf check";
+            }
+            rewrite ^/(.*)$ /dashboard/Public/index.html redirect;
+        }

--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -253,3 +253,29 @@ function checkBlackList(req,res) {
   }
   return "ok"; // + "-" + ipAddrStr + "-" + blackListStr;
 }
+
+
+/**
+ * Handle the js_content callout from /workspace-authorize.
+ * Basically - redirect to a subdomain /wts/authorize endpoint
+ * based on the state=SUBDOMAIN-... query parameter with
+ * some guards to stop attacks.
+ * 
+ * @param {*} req 
+ * @param {*} res 
+ */
+function gen3_workspace_authorize_handler(req) {
+  var subdomain = '';
+  var query = req.variables["args"] || "";
+  var matchGroups = null;
+
+  if (matchGroups = query.match(/(^state=|&state=)(\w+)-/)) {
+    subdomain = matchGroups[2];
+    var location = "https://" + subdomain + "." + req.variables["host"] +
+      "/wts/oauth2/authorize?" + query;
+    req.return(302, location);
+  } else {
+    req.headersOut["Content-Type"] = "application/json"
+    req.return(400, '{ "status": "redirect failed validation ' + req.uri + '" }');
+  }
+}

--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -276,6 +276,6 @@ function gen3_workspace_authorize_handler(req) {
     req.return(302, location);
   } else {
     req.headersOut["Content-Type"] = "application/json"
-    req.return(400, '{ "status": "redirect failed validation ' + req.uri + '" }');
+    req.return(400, '{ "status": "redirect failed validation" }');
   }
 }


### PR DESCRIPTION
Jira Ticket: [PXP-6630](https://ctds-planx.atlassian.net/browse/PXP-6630)

* introduce `/workspace-authorize/` endpoint when running in `GEN3-WORKSPACE-PARENT` mode - enabled via the `global.portal_app` manifest property.  Endpoint supports a multi-account apps deployment, by allowing multiple workspace accounts (all sub-domains of the parent account - which deploys the `/workspace-authorize/` endpoint) to share the same redirect endpoint for OIDC authorize flows with data commons.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

* introduce `/workspace-authorize/` endpoint when running in `GEN3-WORKSPACE-PARENT` mode - enabled via the `global.portal_app` manifest property.  Endpoint supports a multi-account apps deployment, by allowing multiple workspace accounts (all sub-domains of the parent account - which deploys the `/workspace-authorize/` endpoint) to share the same redirect endpoint for OIDC authorize flows with data commons.

### Dependency updates


### Deployment changes
