### PR TITLE
COVID19 ETL memory 512Mi -> 1024Mi

### DIFF
--- a/kube/services/jobs/covid19-etl-job.yaml
+++ b/kube/services/jobs/covid19-etl-job.yaml
@@ -38,7 +38,7 @@ spec:
         resources:
           limits:
             cpu: 0.5
-            memory: 512Mi
+            memory: 1024Mi
         command: ["/bin/bash" ]
         args:
           - "-c"


### PR DESCRIPTION
Increase the covid19-etl-job max memory to unblock the JHU_TO_S3 job until ticket COV-463 is fixed.
