### PR TITLE
Fix installation of 2to3 plugin for tiller cleanups

### DIFF
--- a/gen3/bin/kube-setup-tiller.sh
+++ b/gen3/bin/kube-setup-tiller.sh
@@ -6,10 +6,10 @@ gen3_load "gen3/lib/kube-setup-init"
     
 if g3kubectl get deployments/tiller-deploy --namespace=kube-system > /dev/null 2>&1; then
   if helm version --short | grep v3 > /dev/null 2>&1; then
+    if ! helm plugin list | grep 2to3 > /dev/null 2>&1; then
+      helm plugin install https://github.com/helm/helm-2to3.git
+    fi
     if ( g3kubectl --namespace=prometheus get deployment prometheus-server > /dev/null 2>&1) || ( g3kubectl --namespace=grafana get deployment grafana > /dev/null 2>&1); then
-      if ! helm plugin list | grep 2to3 > /dev/null 2>&1; then
-        helm plugin install https://github.com/helm/helm-2to3.git
-      fi
       if ! helm ls --namespace grafana | grep grafana > /dev/null 2>&1; then
         echo "Migrating grafana to helm3."
         helm 2to3 convert grafana 


### PR DESCRIPTION
### Bug Fixes
Fix of a bug when helm 2to3 plugin is not being installed properly and thus `kube-setup-tiller` will fail