### PR TITLE
chore(ci): Wait a bit longer for data-portal pods to come up

### DIFF
--- a/gen3/bin/kube-wait4-pods.sh
+++ b/gen3/bin/kube-wait4-pods.sh
@@ -18,7 +18,7 @@ EOM
 }
 
 
-MAX_RETRIES=90
+MAX_RETRIES=120
 
 if [[ $# -gt 0 ]]; then
   if [[ "$1" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
data portal is taking too long to come up, e.g.,
```
portal-deployment-5f8b855448-dscnz                0/1     Running     0          4m14s
portal-deployment-5f8b855448-hqqmj                1/1     Running     1          15m
...
[32mINFO: 14:33:36 -[39m ------------
[32mINFO: 14:33:36 -[39m Waiting for pods to exit Pending state
[31mERROR: 14:33:36 - pods still not ready after 900 seconds - bailing out[39m
[31mERROR: 14:33:36 - containers are still waiting in this namespace[39m
[31mERROR: 14:33:36 - looks like not everything is healthy[39m
[31mERROR: 14:33:36 - the cluster does not look healthy[39m
```
 so let us increase the timeout until that can be improved.