### PR TITLE
fix(qa): Max values per tag limit exceeded in InfluxDB

### DIFF
--- a/kube/services/influxdb/influxdb-deployment.yaml
+++ b/kube/services/influxdb/influxdb-deployment.yaml
@@ -23,6 +23,12 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/influxdb
           name: influxdb-data
+        command: ["/bin/bash"]
+        args:
+          - "-c"
+          - |
+            echo "max-values-per-tag = 0" >> "/etc/influxdb/influxdb.conf"
+            ./init-influxdb.sh
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler

--- a/kube/services/influxdb/influxdb-deployment.yaml
+++ b/kube/services/influxdb/influxdb-deployment.yaml
@@ -23,12 +23,9 @@ spec:
         volumeMounts:
         - mountPath: /var/lib/influxdb
           name: influxdb-data
-        command: ["/bin/bash"]
-        args:
-          - "-c"
-          - |
-            echo "max-values-per-tag = 0" >> "/etc/influxdb/influxdb.conf"
-            ./init-influxdb.sh
+        env:
+          - name: "INFLUXDB_DATA_MAX_VALUES_PER_TAG"
+            value: "0"
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       schedulerName: default-scheduler


### PR DESCRIPTION
Recent load testing operations are failing due to the following error:
```
time="2020-10-05T18:54:40Z" level=error 
msg="InfluxDB: Couldn't write stats" error="{\"error\":\"partial write: max-values-per-tag limit exceeded (100021/100000): 
measurement=\\\"http_reqs\\\" tag=\\\"name\\\" 
value=\\\"https://qa-niaid.planx-pla.net/study-viewer/clinical_trials\\\" dropped=240\"}\n"
```

### Improvements
- Resolve Influx DB limit based on measurement tag (`max-values-per-tag limit exceeded `)
