### PR TITLE
fix(qa): Define submission order for gentestdata

### DIFF
--- a/kube/services/jobs/gentestdata-job.yaml
+++ b/kube/services/jobs/gentestdata-job.yaml
@@ -5,6 +5,7 @@
 # TEST_PROGRAM "" \
 # TEST_PROJECT "" \
 # MAX_EXAMPLES "" \
+# GEN3_SUBMISSION_ORDER "" \
 # NOTE: "" indicates an optional argument. Leave as "" for default
 #
 # SUBMISSION_USER
@@ -15,6 +16,9 @@
 #
 # MAX_EXAMPLES(optional)
 #   Number of maximum examples for each node. Default 100
+#
+# GEN3_SUBMISSION_ORDER(optional)
+#   Node that defines the order of the data submission. Default SUR (submitted_unaligned_reads)
 #
 # Example
 # gen3 job run gentestdata TEST_PROGRAM jnkns TEST_PROJECT jenkins MAX_EXAMPLES 10 SUBMISSION_USER cdis.autotest@gmail.com
@@ -84,7 +88,7 @@ spec:
           - name: MAX_EXAMPLES
             GEN3_MAX_EXAMPLES|-value: "10"-|
           - name: SUBMISSION_ORDER
-            GEN3_MAX_EXAMPLES|-value: "submitted_unaligned_reads"-|
+            GEN3_SUBMISSION_ORDER|-value: "submitted_unaligned_reads"-|
         volumeMounts:
           - name: shared-data
             mountPath: /mnt/shared

--- a/kube/services/jobs/gentestdata-job.yaml
+++ b/kube/services/jobs/gentestdata-job.yaml
@@ -83,6 +83,8 @@ spec:
             GEN3_TEST_PROJECT|-value: "test"-|
           - name: MAX_EXAMPLES
             GEN3_MAX_EXAMPLES|-value: "10"-|
+          - name: SUBMISSION_ORDER
+            GEN3_MAX_EXAMPLES|-value: "submitted_unaligned_reads"-|
         volumeMounts:
           - name: shared-data
             mountPath: /mnt/shared
@@ -99,6 +101,9 @@ spec:
 
             mkdir -p /TestData
             data-simulator simulate --url $DICTIONARY_URL --path /TestData --program $TEST_PROGRAM --project $TEST_PROJECT --max_samples $MAX_EXAMPLES
+
+            echo "define submission order"
+            data-simulator submission_order --url $DICTIONARY_URL --path /TestData --node_name $SUBMISSION_ORDER
 
             echo "Preparing to submit data"
             data-simulator submitting_data --host https://$HOSTNAME --dir /TestData/ --project "$TEST_PROGRAM/$TEST_PROJECT" --access_token /mnt/shared/access_token.txt


### PR DESCRIPTION
Adding submission order command to existing `gentestdata` k8s job's sequence of commands.