### PR TITLE
(PXP-6861): configure Metadata Service creds in kube-setup-ssjdispatcher

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|^./.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-10-12T23:42:18Z",
+  "generated_at": "2020-10-13T16:27:08Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -566,13 +566,13 @@
       {
         "hashed_secret": "185a71a740ef6b9b21c84e6eaa47b89c7de181ef",
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 154,
         "type": "Base64 High Entropy String"
       },
       {
         "hashed_secret": "329b7cd8191942bedd337107934d365c43a86e6c",
         "is_verified": false,
-        "line_number": 155,
+        "line_number": 154,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|^./.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-10-09T17:32:47Z",
+  "generated_at": "2020-10-12T23:42:18Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -436,15 +436,21 @@
     ],
     "gen3/bin/kube-setup-ssjdispatcher.sh": [
       {
-        "hashed_secret": "d3df8a3b08a9de43b73eca1302d50e7a0e5b360f",
-        "is_verified": false,
-        "line_number": 115,
-        "type": "Secret Keyword"
-      },
-      {
         "hashed_secret": "9f29ed52bc91ba45b309d5234e95edc7ca5286fd",
         "is_verified": false,
         "line_number": 117,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "7992309146efaa8da936e34b0bd33242cd0e9f93",
+        "is_verified": false,
+        "line_number": 184,
+        "type": "Secret Keyword"
+      },
+      {
+        "hashed_secret": "d3df8a3b08a9de43b73eca1302d50e7a0e5b360f",
+        "is_verified": false,
+        "line_number": 197,
         "type": "Secret Keyword"
       }
     ],

--- a/doc/kube-setup-ssjdispatcher.md
+++ b/doc/kube-setup-ssjdispatcher.md
@@ -12,6 +12,7 @@ in `creds.json`.
 * create an upload bucket
 * create sns and sqs
 * setup indexd creds
+* setup metadata service creds if they are present
 
 If `auto` is provided as the bucket name, then the script constructs a
 safe name for the bucket.  The caller must configure the `DATA_UPLOAD_BUCKET` in `fence-config-public`.

--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -74,10 +74,6 @@ else
   gen3_log_info "no manifest entry for fence"
 fi
 
-if g3k_manifest_lookup .versions.ssjdispatcher 2>&1 /dev/null; then
-  gen3 kube-setup-ssjdispatcher
-fi
-
 if g3kubectl get cronjob etl >/dev/null 2>&1; then
     gen3 job run etl-cronjob
 fi
@@ -191,6 +187,10 @@ else
 fi
 
 gen3 kube-setup-metadata
+
+if g3k_manifest_lookup .versions.ssjdispatcher 2>&1 /dev/null; then
+  gen3 kube-setup-ssjdispatcher
+fi
 
 gen3 kube-setup-revproxy
 

--- a/gen3/bin/kube-setup-ssjdispatcher.sh
+++ b/gen3/bin/kube-setup-ssjdispatcher.sh
@@ -120,6 +120,9 @@ EOM
     /bin/rm "$credsBak"
     updateIndexd=true
   fi
+  local mdsCreds="$(grep ADMIN_LOGINS= < "$(gen3_secrets_folder)/g3auto/metadata/metadata.env" | cut -d '=' -f2)"
+  local mdsUser="$(echo $mdsCreds | cut -d ':' -f1)"
+  local mdsPassword="$(echo $mdsCreds | cut -d ':' -f2)"
   local ssjConfig="$(cat - <<EOM
 {
     "SQS": {
@@ -130,9 +133,16 @@ EOM
         "name": "indexing",
         "pattern": "s3://$bucketName/*",
         "imageConfig": {
-          "url": "http://indexd-service/index",
-          "username": "ssj",
-          "password": "${indexdPassword}"
+          "indexd": {
+            "url": "http://indexd-service/index",
+            "username": "ssj",
+            "password": "${indexdPassword}"
+          },
+          "metadataService": {
+            "url": "http://revproxy-service/mds",
+            "username": "${mdsUser}",
+            "password": "${mdsPassword}"
+          }
         },
         "RequestCPU": "500m",
         "RequestMem": "0.5Gi"

--- a/gen3/bin/kube-setup-ssjdispatcher.sh
+++ b/gen3/bin/kube-setup-ssjdispatcher.sh
@@ -157,7 +157,7 @@ setupIndexdConfig() {
 EOM
   )"
   cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-  jq -r --argjson indexdConfig "$indexdConfig" '.ssjdispatcher.JOBS.imageConfig.indexd=$indexdConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+  jq -r --argjson indexdConfig "$indexdConfig" '.ssjdispatcher.JOBS[] | select(.name=="indexing") | .imageConfig.indexd=$indexdConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
   /bin/rm "$credsBak"
 
   if [[ "$updateIndexd" != "false" ]]; then
@@ -166,6 +166,7 @@ EOM
 }
 
 setupMDSConfig() {
+  # XXX check that mds is deployed
   local credsBak="$(mktemp "$XDG_RUNTIME_DIR/creds.json_XXXXXX")"
   local mdsCreds="$(grep ADMIN_LOGINS= < "$(gen3_secrets_folder)/g3auto/metadata/metadata.env" | cut -d '=' -f2)"
   local mdsUser="$(echo $mdsCreds | cut -d ':' -f1)"
@@ -179,7 +180,7 @@ setupMDSConfig() {
 EOM
   )"
   cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-  jq -r --argjson mdsConfig "$mdsConfig" '.ssjdispatcher.JOBS.imageConfig.metadataService=$mdsConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+  jq -r --argjson mdsConfig "$mdsConfig" '.ssjdispatcher.JOBS[] | select(.name=="indexing") | .imageConfig.metadataService=$mdsConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
   /bin/rm "$credsBak"
 }
 

--- a/gen3/bin/kube-setup-ssjdispatcher.sh
+++ b/gen3/bin/kube-setup-ssjdispatcher.sh
@@ -109,6 +109,17 @@ EOM
   fi
 
   local credsBak="$(mktemp "$XDG_RUNTIME_DIR/creds.json_XXXXXX")"
+  local indexdPassword
+  local updateIndexd=false
+  # create new indexd user if necessary
+  if ! indexdPassword="$(jq -e -r .indexd.user_db.ssj < "$(gen3_secrets_folder)/creds.json" 2> /dev/null)" \
+    || [[ -z "$indexdPassword" && "$indexdPassword" == null ]]; then
+    indexdPassword="$(gen3 random)"
+    cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
+    jq -r --arg password "$indexdPassword" '.indexd.user_db.ssj=$password' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+    /bin/rm "$credsBak"
+    updateIndexd=true
+  fi
   local ssjConfig="$(cat - <<EOM
 {
     "SQS": {
@@ -118,7 +129,11 @@ EOM
       {
         "name": "indexing",
         "pattern": "s3://$bucketName/*",
-        "imageConfig": {},
+        "imageConfig": {
+          "url": "http://indexd-service/index",
+          "username": "ssj",
+          "password": "${indexdPassword}"
+        },
         "RequestCPU": "500m",
         "RequestMem": "0.5Gi"
       }
@@ -130,61 +145,91 @@ EOM
   cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
   jq -r --argjson ssjConfig "$ssjConfig" '.ssjdispatcher=$ssjConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
   /bin/rm "$credsBak"
-  # XXX run at end
-  # gen3 secrets sync "chore(ssjdispatcher): setup"
-}
-
-setupIndexdConfig() {
-  local credsBak="$(mktemp "$XDG_RUNTIME_DIR/creds.json_XXXXXX")"
-  local indexdPassword
-  local updateIndexd=false
-  # create new indexd user if necessary
-  if ! indexdPassword="$(jq -e -r .indexd.user_db.ssj < "$(gen3_secrets_folder)/creds.json" 2> /dev/null)" \
-    || [[ -z "$indexdPassword" && "$indexdPassword" == null ]]; then
-    indexdPassword="$(gen3 random)"
-    cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-    jq -r --arg password "$indexdPassword" '.indexd.user_db.ssj=$password' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
-    # XXX needed below?
-    /bin/rm "$credsBak"
-    updateIndexd=true
-  fi
-
-  local indexdConfig="$(cat - <<EOM
-{
-  "url": "http://indexd-service/index",
-  "username": "ssj",
-  "password": "${indexdPassword}"
-}
-EOM
-  )"
-  cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-  jq -r --argjson indexdConfig "$indexdConfig" '(.ssjdispatcher.JOBS[] | select(.name == "indexing") | .imageConfig.indexd)=$indexdConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
-  /bin/rm "$credsBak"
-
+  gen3 secrets sync "chore(ssjdispatcher): setup"
   if [[ "$updateIndexd" != "false" ]]; then
     gen3 job run indexd-userdb
   fi
 }
 
 setupMDSConfig() {
-  # XXX check that mds is deployed
-  local credsBak="$(mktemp "$XDG_RUNTIME_DIR/creds.json_XXXXXX")"
-  local mdsCreds="$(grep ADMIN_LOGINS= < "$(gen3_secrets_folder)/g3auto/metadata/metadata.env" | cut -d '=' -f2)"
-  local mdsUser="$(echo $mdsCreds | cut -d ':' -f1)"
-  local mdsPassword="$(echo $mdsCreds | cut -d ':' -f2)"
-  local mdsConfig="$(cat - <<EOM
+  local ssjCredsFile
+  local jobImageConfig
+  ssjCredsFile="$(gen3_secrets_folder)/creds.json"
+  # don't log nonexistence of $ssjCredsFile since that would have already been logged in setupSsjInfra function
+  [[ -f "$ssjCredsFile" ]] || return 0
+  if ! jobImageConfig="$(jq -r -e '.ssjdispatcher.JOBS[] | select(.name == "indexing").imageConfig' < "$ssjCredsFile" 2> /dev/null)"; then
+    gen3_log_info "skipping verifying or syncing metadata service creds because an \"indexing\" job image configuration could not be found in $ssjCredsFile"
+    return 0
+  fi
+
+  if ! g3k_manifest_lookup .versions.metadata > /dev/null 2>&1; then
+    gen3_log_info "skipping verifying or syncing metadata service creds because metadata service not in manifest"
+    return 0
+  fi
+
+  mdsCredsFile="$(gen3_secrets_folder)/g3auto/metadata/metadata.env"
+  if [[ ! -f "$mdsCredsFile" ]]; then
+    gen3_log_info "skipping verifying or syncing metadata service creds because metadata service creds file could not be found"
+    return 0
+  fi
+
+  local mdsCreds
+  local mdsUsername
+  local mdsPassword
+  # [[ $? == 1 ]] added here so that if `set -e -o pipefail` were used in the
+  # future and grep can't find "ADMIN_LOGINS=", kube-setup-ssjdispatcher won't
+  # exit with an error code, but will instead log a warning and exit with 0
+  mdsCreds="$( (grep 'ADMIN_LOGINS=' "$mdsCredsFile" 2> /dev/null || [[ $? == 1 ]]) | cut -s -d '=' -f2 2> /dev/null )"
+  mdsUsername="$(cut -s -d ':' -f1 <<< "$mdsCreds" 2> /dev/null)"
+  mdsPassword="$(cut -s -d ':' -f2 <<< "$mdsCreds" 2> /dev/null)"
+
+  if [[ -z $mdsCreds || -z $mdsUsername || -z $mdsPassword ]]; then
+    gen3_log_warn "could not parse metadata service basic auth creds from $mdsCredsFile"
+    return 0
+  fi
+
+  local ssjMdsCreds
+  # check that metadata service creds match those configured for ssjdispatcher
+  if ssjMdsCreds="$(jq -r -e '.metadataService' <<< "$jobImageConfig" 2> /dev/null)"; then
+    local ssjMdsUsername
+    local ssjMdsPassword
+    ssjMdsUsername="$(jq -r -e '.username' <<< "$ssjMdsCreds" 2> /dev/null)"
+    ssjMdsPassword="$(jq -r -e '.password' <<< "$ssjMdsCreds" 2> /dev/null)"
+    if [[ "$ssjMdsUsername" -ne "$mdsUsername" || "$ssjMdsPassword" -ne "$mdsPassword" ]]; then
+      if [[ -n "$JENKINS_HOME" ]]; then
+        gen3_log_err "metadata service creds already configured for ssjdispatcher are not up-to-date with the metadata service: $ssjCredsFile"
+        return 1
+      fi
+      gen3_log_warn "metadata service creds already configured for ssjdispatcher were not up-to-date with the metadata service before running kube-setup-ssjdispatcher: $ssjCredsFile"
+    else
+      gen3_log_info "metadata service creds configured for ssjdispatcher were verified to already be up-to-date with the metadata service"
+      return 0
+    fi
+  fi
+
+  if [[ -n "$JENKINS_HOME" ]]; then
+    gen3_log_info "running in jenkins, skipping setting up metadata service creds"
+    return 0
+  fi
+
+  gen3_log_info "setting up metadata service creds"
+  local mdsConfig
+  mdsConfig="$(cat - <<EOM
 {
   "url": "http://revproxy-service/mds",
-  "username": "${mdsUser}",
+  "username": "${mdsUsername}",
   "password": "${mdsPassword}"
 }
 EOM
   )"
-  cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-  jq -r --argjson mdsConfig "$mdsConfig" '(.ssjdispatcher.JOBS[] | select(.name == "indexing") | .imageConfig.metadataService)=$mdsConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+  local credsBak
+  credsBak="$(mktemp "$XDG_RUNTIME_DIR/creds.json_XXXXXX")"
+  cp "$ssjCredsFile" "$credsBak"
+  jq -r -e --argjson mdsConfig "$mdsConfig" '(.ssjdispatcher.JOBS[] | select(.name == "indexing") | .imageConfig.metadataService)=$mdsConfig' < "$credsBak" > "$ssjCredsFile"
   /bin/rm "$credsBak"
-}
 
+  gen3 secrets sync "chore(ssjdispatcher): set up metadata service creds"
+}
 
 # main -------------------
 
@@ -196,7 +241,6 @@ fi
 [[ -z "$GEN3_ROLL_ALL" ]] && gen3 kube-setup-secrets
 
 setupSsjInfra "$@"
-setupIndexdConfig
 setupMDSConfig
 gen3 roll ssjdispatcher
 g3kubectl apply -f "${GEN3_HOME}/kube/services/ssjdispatcher/ssjdispatcher-service.yaml"

--- a/gen3/bin/kube-setup-ssjdispatcher.sh
+++ b/gen3/bin/kube-setup-ssjdispatcher.sh
@@ -144,6 +144,7 @@ setupIndexdConfig() {
     indexdPassword="$(gen3 random)"
     cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
     jq -r --arg password "$indexdPassword" '.indexd.user_db.ssj=$password' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+    # XXX needed below?
     /bin/rm "$credsBak"
     updateIndexd=true
   fi
@@ -157,7 +158,7 @@ setupIndexdConfig() {
 EOM
   )"
   cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-  jq -r --argjson indexdConfig "$indexdConfig" '.ssjdispatcher.JOBS[] | select(.name=="indexing") | .imageConfig.indexd=$indexdConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+  jq -r --argjson indexdConfig "$indexdConfig" '(.ssjdispatcher.JOBS[] | select(.name == "indexing") | .imageConfig.indexd)=$indexdConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
   /bin/rm "$credsBak"
 
   if [[ "$updateIndexd" != "false" ]]; then
@@ -180,7 +181,7 @@ setupMDSConfig() {
 EOM
   )"
   cp "$(gen3_secrets_folder)/creds.json" "$credsBak"
-  jq -r --argjson mdsConfig "$mdsConfig" '.ssjdispatcher.JOBS[] | select(.name=="indexing") | .imageConfig.metadataService=$mdsConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
+  jq -r --argjson mdsConfig "$mdsConfig" '(.ssjdispatcher.JOBS[] | select(.name == "indexing") | .imageConfig.metadataService)=$mdsConfig' < "$credsBak" > "$(gen3_secrets_folder)/creds.json"
   /bin/rm "$credsBak"
 }
 


### PR DESCRIPTION
Jira Ticket: [PXP-6861](https://ctds-planx.atlassian.net/browse/PXP-6861)

This PR extends `kube-setup-ssjdispatcher` so that if the Metadata Service is deployed and MDS basic auth creds are present, add those MDS creds to SSJDispatcher's secret. See related [indexs3client PR ](https://github.com/uc-cdis/indexs3client/pull/29) requiring SSJDispatcher to pass it MDS creds. Going forward, the [SSJDispatcher service will require MDS creds to start](https://ctds-planx.atlassian.net/browse/PXP-6977).

Note that the addition of MDS creds will not break the "old" SSJDispatcher/indexs3client combination (i.e. versions of SSJDispatcher/indexs3client not requiring MDS creds).

### New Features
- Configure Metadata Service basic auth creds in kube-setup-ssjdispatcher
