### PR TITLE
Pybase: don't wait for wsgi.sock

### DIFF
--- a/Docker/python-nginx/python2.7-alpine3.7/dockerrun.sh
+++ b/Docker/python-nginx/python2.7-alpine3.7/dockerrun.sh
@@ -87,16 +87,6 @@ if [ -f ./wsgi.py ] && [ "$GEN3_DEBUG" = "True" ]; then
 fi
 
 (
-  # Wait for nginx to create uwsgi.sock in a sub-process
-  count=0
-  while [ ! -e /var/run/gen3/uwsgi.sock ] && [ $count -lt 10 ]; do
-    echo "... waiting for /var/run/gen3/uwsgi.sock to appear"
-    sleep 2
-    count="$(($count+1))"
-  done
-  if [ ! -e /var/run/gen3/uwsgi.sock ]; then
-    echo "WARNING: /var/run/gen3/uwsgi.sock does not exist!!!"
-  fi
   run uwsgi --ini /etc/uwsgi/uwsgi.ini
 ) &
 run nginx -g 'daemon off;'

--- a/Docker/python-nginx/python3.6-alpine3.7/dockerrun.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/dockerrun.sh
@@ -87,16 +87,6 @@ if [ -f ./wsgi.py ] && [ "$GEN3_DEBUG" = "True" ]; then
 fi
 
 (
-  # Wait for nginx to create uwsgi.sock in a sub-process
-  count=0
-  while [ ! -e /var/run/gen3/uwsgi.sock ] && [ $count -lt 10 ]; do
-    echo "... waiting for /var/run/gen3/uwsgi.sock to appear"
-    sleep 2
-    count="$(($count+1))"
-  done
-  if [ ! -e /var/run/gen3/uwsgi.sock ]; then
-    echo "WARNING: /var/run/gen3/uwsgi.sock does not exist!!!"
-  fi
   run uwsgi --ini /etc/uwsgi/uwsgi.ini
 ) &
 


### PR DESCRIPTION
The block that waits for `wsgi.sock` to appear is before `run uwsgi --ini /etc/uwsgi/uwsgi.ini` so it makes us wait 20 seconds for something that will not happen (since the app hasn't started yet). Remove it doesn't seem to cause issues

### Improvements
- Base python 2 and 3 images: don't wait for wsgi.sock to appear, speed up app start up
