### PR TITLE
Whitelist opportunityinsights.org

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -102,6 +102,7 @@ mran.microsoft.com
 neuro.debian.net
 neurodeb.pirsquared.org
 nginx.org
+opportunityinsights.org
 orcid.org
 pgp.mit.edu
 ppa.launchpad.net


### PR DESCRIPTION
Jira Ticket: COV-521

Whitelist opportunityinsights.org to ingest ATLAS dataset into the PRC (https://github.com/uc-cdis/covid19-tools/pull/131)