### PR TITLE
Add appcreds.json to secret on reset

### DIFF
--- a/gen3/bin/reset.sh
+++ b/gen3/bin/reset.sh
@@ -99,7 +99,7 @@ clear_wts_clientId() {
       dbCreds="$(gen3 secrets decode wts-g3auto dbcreds.json)"
       clientInfo="$(gen3 kube-setup-wts new-client)"
       g3kubectl delete secret wts-g3auto || true
-      if [[ -n "$dbCreds" && -n ]]; then
+      if [[ -n "$dbCreds" && -n "$clientInfo"]]; then
         g3kubectl create secret generic wts-g3auto "--from-literal=dbcreds.json=$dbCreds" "--from-literal=appcreds.json=$clientInfo"
       fi
   fi

--- a/gen3/bin/reset.sh
+++ b/gen3/bin/reset.sh
@@ -97,9 +97,10 @@ clear_wts_clientId() {
       gen3_log_info "Deleting wts secret appcreds.json key"
       local dbCreds
       dbCreds="$(gen3 secrets decode wts-g3auto dbcreds.json)"
+      clientInfo="$(gen3 kube-setup-wts new-client)"
       g3kubectl delete secret wts-g3auto || true
-      if [[ -n "$dbCreds" ]]; then
-        g3kubectl create secret generic wts-g3auto "--from-literal=dbcreds.json=$dbCreds"
+      if [[ -n "$dbCreds" && -n ]]; then
+        g3kubectl create secret generic wts-g3auto "--from-literal=dbcreds.json=$dbCreds" "--from-literal=appcreds.json=$clientInfo"
       fi
   fi
   gen3_log_info "All clear for wts"


### PR DESCRIPTION
### Bug Fixes
We have seen jenkins jobs for PR's fail intermittently. After diving into why the jenkins jobs were failing is because the `wts-g3auto` secret didn't contain the appcreds.json and was being mounted as a file instead. 

I am trying to copy whatever is here: 

https://github.com/uc-cdis/cloud-automation/blob/master/gen3/bin/kube-setup-wts.sh#L90 