### PR TITLE
Chore/wts fail fast

### DIFF
--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -223,7 +223,7 @@ gen3 kube-wait4-pods || true
 
 if g3k_manifest_lookup .versions.wts 2> /dev/null; then
   # this tries to kubectl exec into fence
-  gen3 kube-setup-wts || true
+  gen3 kube-setup-wts
 else
   gen3_log_info "not deploying wts - no manifest entry for .versions.wts"
 fi

--- a/gen3/bin/kube-setup-wts.sh
+++ b/gen3/bin/kube-setup-wts.sh
@@ -48,21 +48,26 @@ EOM
 }
 
 setup_creds() {
-  echo "check wts secret"
+  gen3_log_info "check wts secret"
   if ! g3kubectl describe secret wts-g3auto | grep appcreds.json > /dev/null 2>&1; then
       local credsPath="$(gen3_secrets_folder)/g3auto/wts/appcreds.json"
       if [ -f "$credsPath" ]; then
           gen3 secrets sync
           return 0
       fi
-      new_client > "$credsPath"
+      if ! new_client > "$credsPath"; then
+        rm "$credsPath"
+        gen3_log_err "Failed to setup WTS client"
+        return 1
+      fi
       gen3 secrets sync
   fi
 
   if ! g3kubectl describe secret wts-g3auto | grep dbcreds.json > /dev/null 2>&1; then
-      echo "create database"
+      gen3_log_info "create database"
       if ! gen3 db setup wts; then
-          echo "Failed setting up database for workspace token service"
+          gen3_log_err "Failed setting up database for workspace token service"
+          return 1
       fi
       gen3 secrets sync
   fi
@@ -81,18 +86,20 @@ if [[ -z "$JENKINS_HOME" ]]; then
 
   namespace="$(gen3 db namespace)"
   g3k_kv_filter ${GEN3_HOME}/kube/services/wts/rolebinding-wts.yaml WTS_BINDING "name: wts-binding-$namespace" CURRENT_NAMESPACE "namespace: $namespace" | g3kubectl apply -f -
-  setup_creds || true
+  setup_creds
 elif ! g3kubectl describe secret wts-g3auto | grep appcreds.json > /dev/null 2>&1; then
   # JENKINS test setup needs to re-create the wts client after wiping the fence db
-  (
-    if dbCreds="$(gen3 secrets decode wts-g3auto dbcreds.json)" && clientInfo="$(gen3 kube-setup-wts new-client)"; then
-        g3kubectl delete secret wts-g3auto
-        g3kubectl create secret generic wts-g3auto "--from-literal=dbcreds.json=$dbCreds" "--from-literal=appcreds.json=$clientInfo"
-    fi
-  )
+  gen3_log_info "kube-setup-wts trying to reset client"
+  if dbCreds="$(gen3 secrets decode wts-g3auto dbcreds.json)" && clientInfo="$(new_client)"; then
+      g3kubectl delete secret wts-g3auto
+      g3kubectl create secret generic wts-g3auto "--from-literal=dbcreds.json=$dbCreds" "--from-literal=appcreds.json=$clientInfo"
+  else
+    gen3_log_err "kube-setup-wts failed to setup new client"
+    exit 1
+  fi
 fi
 
 g3kubectl apply -f "${GEN3_HOME}/kube/services/wts/wts-service.yaml"  
 gen3 roll wts
 
-echo "The wts services has been deployed onto the k8s cluster."
+gen3_log_info "The wts services has been deployed onto the k8s cluster."

--- a/kube/services/ssjdispatcher/ssjdispatcher-deploy.yaml
+++ b/kube/services/ssjdispatcher/ssjdispatcher-deploy.yaml
@@ -53,6 +53,8 @@ spec:
         env:
           - name: AWS_REGION
             value: us-east-1
+          - name: AWS_STS_REGIONAL_ENDPOINTS
+            value: regional  
           - name: GEN3_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
* fix `gen3 gitops configmaps key1 key2 ...`
* make `kube-setup-wts` fail fast on failure to setup OIDC client with fence
* add `AWS_STS_REGIONAL_ENDPOINTS=regional` environment to `ssjdispatcher`

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

* fix `gen3 gitops configmaps key1 key2 ...`
* make `kube-setup-wts` fail fast on failure to setup OIDC client with fence
* add `AWS_STS_REGIONAL_ENDPOINTS=regional` environment to `ssjdispatcher`

### Dependency updates


### Deployment changes
