### PR TITLE
chore(qa): Bumping up Selenium session request timeout

### DIFF
--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -17,9 +17,12 @@ spec:
     spec:
       containers:
       - env:
+        - name: GRID_MAX_SESSION
           value: "42"
         - name: GRID_BROWSER_TIMEOUT
           value: "0"
+        - name: SE_SESSION_REQUEST_TIMEOUT
+          value: "480"
         image: selenium/hub:4
         imagePullPolicy: Always
         name: hub


### PR DESCRIPTION
In several recent CI failures we are experiencing:
```
ETL "after each" hook: finalize codeceptjs for "run ETL second time @etl" – "after each" hook: finalize codeceptjs for "run ETL second time @etl"
<1s
Error
org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: 6a9484aae701f02f8c5056b73bf86b80 Build info: version: '4.0.0-alpha-7', revision: 'f89bec1f87' System info: host: 'selenium-hub-5879985956-ztvsl', ip: '172.24.212.91', os.name: 'Linux', os.arch: 'amd64', os.version: '4.14.198-152.320.amzn2.x86_64', java.version: '1.8.0_275' Driver info: driver.version: unknown
``` 
According to the Selenium Hub logs, the session was created at:
`19:45:48` -> `"eventName": "Added session into local session map","attributes": {"logger": "org.openqa.selenium.grid.sessionmap.local.LocalSessionMap","session.id": "6a9484aae701f02f8c5056b73bf86b80"}}
2:24`
And it was reaped (terminated) at:
`19:51:12` -> `"eventName": "Deleted session from local session map","attributes": {"logger": "org.openqa.selenium.grid.sessionmap.local.LocalSessionMap","session.id": "6a9484aae701f02f8c5056b73bf86b80"}}`

So the ETL test must be taking longer than 5 minutes to complete so the `after` hook of the Scenario cannot terminate the session gracefully. Trying 8 minutes for now but we need more pragmatic metrics / logs to determine the ideal timeframe.
