### PR TITLE
fix(ci): Adopt new selenium4 var SE_NODE_MAX_CONCURRENT_SESSIONS to configure more sessions per node

### DIFF
--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: selenium-node-chrome
   namespace: default
 spec:
-  replicas: 5
+  replicas: 10
   selector:
     matchLabels:
       app: selenium-node-chrome
@@ -28,9 +28,7 @@ spec:
           value: "4442"
         - name: SE_EVENT_BUS_SUBSCRIBE_PORT
           value: "4443"
-        - name: NODE_MAX_SESSION
-          value: "5"
-        - name: NODE_MAX_INSTANCES
+        - name: SE_NODE_MAX_CONCURRENT_SESSIONS
           value: "3"
         image: selenium/node-chrome:4
         imagePullPolicy: Always


### PR DESCRIPTION
Fix this error:
```
ETL "after each" hook: finalize codeceptjs for "run ETL second time @etl" – "after each" hook: finalize codeceptjs for "run ETL second time @etl"
<1s
Error
org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: 6a9484aae701f02f8c5056b73bf86b80 Build info: version: '4.0.0-alpha-7', revision: 'f89bec1f87' System info: host: 'selenium-hub-5879985956-ztvsl', ip: '172.24.212.91', os.name: 'Linux', os.arch: 'amd64', os.version: '4.14.198-152.320.amzn2.x86_64', java.version: '1.8.0_275' Driver info: driver.version: unknown
```