### PR TITLE
chore(revproxy): cache- no-store for ambassador

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/ambassador-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/ambassador-service.conf
@@ -10,7 +10,8 @@
               if ($saved_set_cookie != "") {
                   add_header Set-Cookie $saved_set_cookie always;
               }
-
+              add_header Cache-Control "no-store";
+              
               proxy_set_header REMOTE_USER $remoteUser;
               error_page 403 = @errorworkspace;
 


### PR DESCRIPTION
* revproxy sets `cache-control: no-store` for `lw-workspace/proxy`

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
* revproxy sets `cache-control: no-store` for `lw-workspace/proxy`

### Dependency updates


### Deployment changes
