### PR TITLE
fix(qa): Enable communication between Selenium and dataguids.org

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -7,6 +7,7 @@ achecker.ca
 biodata-integration-tests.net
 biorender.com
 ctds-planx.atlassian.net
+dataguids.org
 api.immport.org
 api.login.yahoo.com
 api.snapcraft.io


### PR DESCRIPTION
dataguids.org has some JS code that performs an AJAX request against dataguids.org (hardcoded).
Ideally, this code should target the actual CI environment to properly test the DRS endpoints / indexd GUID lookup.

In the meantime, in order to unblock the remaining test scenarios, let us whitelist this domain to run the full test suite.