### PR TITLE
fix(qa): Better ReadinessProbe for gen3qa-check-bucket-access job

### DIFF
--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -37,7 +37,7 @@ spec:
         - containerPort: 4444
         readinessProbe:
           httpGet:
-            path: /status
+            path: /wd/hub
             port: 4444
           successThreshold: 2
           initialDelaySeconds: 5


### PR DESCRIPTION
Tiny fix to guarantee the Selenium sidecar will be ready to run the test when the command is executed.