### PR TITLE
fix(gen3qa-run): Improve polling logic to wait for Selenium to be ready

### DIFF
--- a/gen3/bin/gen3qa-run.sh
+++ b/gen3/bin/gen3qa-run.sh
@@ -67,10 +67,11 @@ case "$test" in
     jobPodCreationDate=$(g3kubectl get pod $podName -o jsonpath='{.metadata.creationTimestamp}')
     echo "Found pod ${podName}. Creation date: ${jobPodCreationDate}"
 
+    attempt=0
+    maxAttempts=12
+    
     while true
     do
-      attempt=0
-      maxAttempts=12
       jobPodStatus=$(g3kubectl get pod $podName -o jsonpath='{.status.phase}')
       echo "Pod ${podName} status is: ${jobPodStatus}"
       if [ "$jobPodStatus" == "Running" ]; then


### PR DESCRIPTION
Better polling logic to determine when the `selenium` sidecar is FULLY READY / up and running.