### PR TITLE
chore(logs): Send nginx access log entries to stdout

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/nginx.conf
+++ b/Docker/python-nginx/python3.6-alpine3.7/nginx.conf
@@ -33,6 +33,7 @@ http {
           '"http_useragent": "$http_user_agent", '
           '"message": "$request"}';
 
+    access_log  /dev/stdout  json;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Keep nginx access log entries inline with Fence's app logs.

TODO:

- [x] Build Fence image with new parent image and make sure there are no regressions.

Evidence:
```
jenkins-brain@cdistest_dev_admin:~$ kc logs fence-deployment-54fc575888-bjrfn -c fence | tail -n2
{"gen3log": "nginx", "date_access": "2020-12-21T22:13:05+00:00", "user_id": "-", 
"request_id": "-", "session_id": "-", "visitor_id": "-", "network_client_ip": "-", "network_bytes_write": 9096, 
"response_secs": 0.000, "http_status_code": 200, "http_request": "/aggregated_metrics", "http_verb": 
"GET", "http_referer": "-", "http_useragent": "Prometheus/2.7.1", 
"message": "GET /aggregated_metrics HTTP/1.1"}

--

jenkins-brain@cdistest_dev_admin:~$ kc get pod  fence-deployment-54fc575888-bjrfn -o yaml | grep image
    image: quay.io/cdis/fence:chore_test_new_parent_img
```

- [ ] Create new `cloud-automation` release to tag a new base image to be used by `fence`, `sheepdog`, `indexd`, etc. etc.