### PR TITLE
chore(pybase): Adopt parent img from quay to avoid pull rate limit errors

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
+++ b/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile written by Sebastian Ramirez <tiangolo@gmail.com> at https://github.com/tiangolo/uwsgi-nginx-docker
 
-FROM python:3.6-alpine3.7
+FROM quay.io/cdis/python:3.6-alpine3.7
 
 # Standard set up Nginx Alpine
 # https://github.com/nginxinc/docker-nginx/blob/f3fc4d5753f0ebb9107738183b9c5cea1bf3f618/mainline/alpine/Dockerfile


### PR DESCRIPTION
Adopting a copy of the image stored in our own Quay repo to avoid the following build error:

```
Could not pull base image: API error (500): toomanyrequests: You have reached your pull rate limit. 
You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
Improvements
```

### Improvements
- Adopt quay.io image to avoid API error (500): toomanyrequests produced by Dockerhub.
