### PR TITLE
fix(gitops-prometheus): Added new clusterrole to gitops to allow kube…

### DIFF
--- a/gen3/bin/kube-setup-roles.sh
+++ b/gen3/bin/kube-setup-roles.sh
@@ -40,6 +40,8 @@ if [[ -z "$JENKINS_HOME" ]]; then
   # only do this if we are running in the default namespace
   if [[ "$ctxNamespace" == "default" || "$ctxNamespace" == "null" ]]; then
     g3kubectl apply -f "${GEN3_HOME}/kube/services/jenkins/clusterrolebinding-devops.yaml"
+    g3kubectl apply -f "${GEN3_HOME}/kube/services/jenkins/gitops-prometheus-viewer.yaml"
+    g3kubectl apply -f "${GEN3_HOME}/kube/services/jenkins/gitops-sa-rolebinding.yaml"
   fi
 else
   gen3_log_info "Not setting up roles in Jenkins: $JENKINS_HOME"

--- a/kube/services/jenkins/gitops-prometheus-viewer.yaml
+++ b/kube/services/jenkins/gitops-prometheus-viewer.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gitops-prometheus-viewer
+rules:
+- apiGroups: [""]
+  resources: ["namespaces","services"]
+  verbs: ["get", "list"]

--- a/kube/services/jenkins/gitops-sa-rolebinding.yaml
+++ b/kube/services/jenkins/gitops-sa-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gitops-sa-prometheus
+subjects:
+- kind: ServiceAccount
+  name: gitops-sa
+  namespace: default
+  apiGroup: ""
+roleRef:
+  kind: ClusterRole
+  name: gitops-prometheus-viewer
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
### New Features
Added new clusterrole to gitops to allow kube-setup-revproxy to successfully find prometheus

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
