### PR TITLE
chore(covid19_job): increase the access token life time

### DIFF
--- a/files/scripts/covid19-etl-job.sh
+++ b/files/scripts/covid19-etl-job.sh
@@ -54,7 +54,7 @@ SAFE_JOB_NAME=${JOB_NAME//_/-} # `_` to `-`
 
 # default token life is 3600 sec. some jobs need the token to last longer.
 # also skip access-token cache since jobs need fresh tokens
-EXP=28800 # 8 hours
+EXP=72000 # 1 day
 ACCESS_TOKEN="$(gen3 api access-token $USER $EXP true)"
 
 # temporary file for the job


### PR DESCRIPTION
Temporary increase the token lifetime since some project requires much longer to finish for the first run time