### PR TITLE
chore(usersync): stagger cron job time

### DIFF
--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -79,7 +79,10 @@ if g3kubectl get cronjob etl >/dev/null 2>&1; then
 fi
 
 if g3kubectl get cronjob usersync >/dev/null 2>&1; then
-    gen3 job cron usersync '@hourly'
+    # stagger usersync jobs, so they don't all hit
+    # NIH at the same time
+    ustart=$((20 + (RANDOM % 20)))
+    gen3 job cron usersync "$ustart * * * *"
 fi
 
 if g3k_manifest_lookup .versions.sheepdog 2> /dev/null; then


### PR DESCRIPTION
* stagger usersync cron job to run between 20th and 40th minute of each hour

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
* stagger usersync cron job to run between 20th and 40th minute of each hour


### Dependency updates


### Deployment changes
