### PR TITLE
chore(usersync): Fix usersync for Fence PR #810 (Prometheus client integration)

### DIFF
--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -78,7 +78,7 @@ spec:
         imagePullPolicy: Always
         env:
           - name: prometheus_multiproc_dir
-            value: /var/tmp/uwsgi_flask_metrics
+            value: /tmp
           - name: PYTHONPATH
             value: /var/www/fence
           - name: SYNC_FROM_DBGAP


### PR DESCRIPTION
This is blocking this PR: https://github.com/uc-cdis/fence/pull/810/files

```
Running fence-create dbgap-sync with user.yaml - see /tmp/fence-create-output_kcmGnI
Traceback (most recent call last):
  File "/usr/local/bin/fence-create", line 2, in <module>
    from bin.fence_create import main
  File "/fence/bin/fence_create.py", line 10, in <module>
    from fence.jwt import keys
  File "/fence/fence/__init__.py", line 60, in <module>
    multiprocess.MultiProcessCollector(registry)
  File "/usr/local/lib/python3.6/site-packages/prometheus_client/multiprocess.py", line 23, in __init__
    raise ValueError('env prometheus_multiproc_dir is not set or not a directory')
ValueError: env prometheus_multiproc_dir is not set or not a directory
```