### PR TITLE
fix(tf-squid-module): add cross region support

### DIFF
--- a/tf_files/aws/modules/squid/variables.tf
+++ b/tf_files/aws/modules/squid/variables.tf
@@ -4,6 +4,15 @@ variable "ami_account_id" {
   default = "707767160287"
 }
 
+# the region containing the public source AMI
+variable "ami_region" {
+  default = "us-east-1"
+}
+
+# the name (pattern) of the public source AMI
+variable "ami_name" {
+  default = "ubuntu16-squid-1.0.2-*"
+}
 
 variable "csoc_cidr" {
   default = "10.128.0.0/20"


### PR DESCRIPTION
When deploying to a different AWS region than `us-east-1` the Terraform `aws_ami` data source cannot find the public AMI (as it is only available in `us-east-1`).
This PR adds a dedicated AWS provider configured to the `us-east-1` region to ensure the AMI can be found even if the deployment (and the base provider) is configured for another region.

It also tries to remove hard coded values by adding variables and using existing parameters.