### PR TITLE
chore(squid): dap.digitalgov.gov

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -40,6 +40,7 @@ cran.stat.ucla.edu
 cran.wustl.edu
 cri-app02.bsd.uchicago.edu
 csc.mcs.sdsmt.edu
+dap.digitalgov.gov
 decider.oicrsofteng.org
 dl.bintray.com
 dl.google.com


### PR DESCRIPTION
Adding `dap.digitalgov.gov` to the squid whitelist
