### PR TITLE
chore(disable-metrics): Disable metrics aggregation loop

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/dockerrun.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/dockerrun.sh
@@ -90,46 +90,5 @@ fi
   run uwsgi --ini /etc/uwsgi/uwsgi.ini
 ) &
 
-if [[ $GEN3_DRYRUN == "False" ]]; then
-  (
-    while true; do
-      logrotate --force /etc/logrotate.d/nginx
-      sleep 86400
-    done
-  ) &
-fi
-
-if [[ $GEN3_DRYRUN == "False" ]]; then
-  (
-    ENABLE_SVC_METRICS_SCRAPING="false"
-
-    attempt=0
-    maxAttempts=10
-
-    while true; do
-
-      curl -s http://127.0.0.1:9117/metrics > /var/www/metrics/metrics.txt
-      curl -s http://127.0.0.1:9113/metrics >> /var/www/metrics/metrics.txt
-      curl -s http://127.0.0.1:4040/metrics >> /var/www/metrics/metrics.txt
-
-      if [ $attempt -lt $maxAttempts ]; then
-        if [ "ENABLE_SVC_METRICS_SCRAPING" == "false" ]; then      
-          service_metrics_endpoint=$(curl -L -s -o /dev/null -w "%{http_code}" -X GET http://localhost/metrics)
-
-          if [ "$service_metrics_endpoint" == 200 ]; then
-            ENABLE_SVC_METRICS_SCRAPING="true"
-          else
-            attempt=$(( $attempt + 1 ));
-          fi
-        else
-          curl -s http://127.0.0.1/metrics >> /var/www/metrics/metrics.txt
-        fi
-      fi
-
-      sleep 10
-    done
-  ) &
-fi
-
 run nginx -g 'daemon off;'
 wait

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,8 +122,8 @@ node {
       if(!skipUnitTests) {
         sh 'pip3 install boto3 --upgrade'
         sh 'pip3 install kubernetes --upgrade'
-        sh 'python -m pytest cloud-automation/apis_configs/'
-        sh 'python -m pytest cloud-automation/gen3/lib/dcf/'
+        sh 'python3 -m pytest cloud-automation/apis_configs/'
+        sh 'python3 -m pytest cloud-automation/gen3/lib/dcf/'
         sh 'cd cloud-automation/tf_files/aws/modules/common-logging && python3 -m pytest testLambda.py'
         sh 'cd cloud-automation/files/lambda && python3 -m pytest test-security_alerts.py'
         sh 'cd cloud-automation/kube/services/jupyterhub && python3 -m pytest test-jupyterhub_config.py'


### PR DESCRIPTION
🤕 Unfortunately, some metrics endpoints are failing and producing lots of log noise.