### PR TITLE
Add 4 hour timeout for usersync job

### DIFF
--- a/gen3/lib/dcf/test_dcf.py
+++ b/gen3/lib/dcf/test_dcf.py
@@ -19,15 +19,15 @@ def test_aws_report():
     report = aws_refresh_report.aws_refresh_report(manifest, aws_log_file)
     assert report == """
     Number of files need to be copied 9. Total 0 (GiB)
-    Number of files were copied successfully via aws cli 3. Total 0.029831038788(GiB)
-    Number of files were copied successfully via gdc api 4. Total 0.000177421607077(GiB)
+    Number of files were copied successfully via aws cli 3. Total 0.029831038787961006(GiB)
+    Number of files were copied successfully via gdc api 4. Total 0.00017742160707712173(GiB)
     """
 
 def test_google_report():
     report = google_refresh_report.google_refresh_report(manifest, gs_log_dir)
     assert report ==  """
-    Number of files need to be copied 9. Total 6.1329169292(GiB)
-    Number of files were copied successfully 7. Total copied data 0.030008460395(GiB)
+    Number of files need to be copied 9. Total 6.132916929200292(GiB)
+    Number of files were copied successfully 7. Total copied data 0.030008460395038128(GiB)
     """
 
 def test_aws_validation():
@@ -38,5 +38,5 @@ def test_gs_validation():
 
 def test_redact():
     assert redaction.redaction(redaction_manifest, aws_redact_log, gs_redact_log) == """
-    Total files are removed from dcf buckets 7. Total 0.030008460395(GiB)
+    Total files are removed from dcf buckets 7. Total 0.030008460395038128(GiB)
     """

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -23,6 +23,8 @@ kind: Job
 metadata:
   name: usersync
 spec:
+  # Kill the job if it has not finished within 4 hours
+  activeDeadlineSeconds: 14400
   backoffLimit: 0
   template:
     metadata:

--- a/tf_files/aws/encrypted-rds/kube.tf
+++ b/tf_files/aws/encrypted-rds/kube.tf
@@ -2,6 +2,10 @@ terraform {
   backend "s3" {}
 }
 
+provider "aws" {
+  version = "= 3.28.0"
+}
+
 #
 # Only create db_fence if var.db_password_fence is set.
 # Sort of a hack during userapi to fence switch over.

--- a/tf_files/aws/encrypted-rds/kube.tf
+++ b/tf_files/aws/encrypted-rds/kube.tf
@@ -2,6 +2,8 @@ terraform {
   backend "s3" {}
 }
 
+# Pinning the aws version to avoid a bug in 3.29.0 
+# https://github.com/hashicorp/terraform-provider-aws/issues/17712
 provider "aws" {
   version = "= 3.28.0"
 }

--- a/tf_files/aws/rds/root.tf
+++ b/tf_files/aws/rds/root.tf
@@ -2,6 +2,10 @@ terraform {
   backend "s3" {}
 }
 
+provider "aws" {
+  version = "= 3.28.0"
+}
+
 module "aws_rds" {
   source                                             = "../modules/rds/"
   rds_instance_allocated_storage                     = "${var.rds_instance_allocated_storage}"


### PR DESCRIPTION
Usersync sometimes gets stuck and will hang for days. Adding a 4 hour timeout for usersync jobs.

https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup 

