### PR TITLE
code added to get route tables automatically for VPC peering connection

### DIFF
--- a/CSOC_Documentation.md
+++ b/CSOC_Documentation.md
@@ -63,7 +63,7 @@ A VPC peering connection is used for the communication between the admin VM in t
 
   `gen3 approve_vpcpeering_request <child_vpc_name>`
 
-  The underneath script basically looks for a new VPC peering request, if there is a request in a pending state, it is accepted, tagged and  an appropriate route to the csoc_main_vpc private subnet route table is added.
+  The underneath script basically looks for a new VPC peering request, if there is a request in a pending state, it is accepted, tagged and  an appropriate route to the csoc_main_vpc private subnet route table is added. This scirpt accepts an optional flag `--get-route-table` which programtically gets the route table id(s) of the VPC which is accepting the peering request.
 
 *  Manual Process: Once the VPC Peering connection request is made, the CSOC admin need to do the following (use this process only if `automatic process` explained above give errors):
 	*	Verify the VPC  peering request and accept it. Make sure the VPC peering connection is active. At this time you can give a name to the peering connection for future reference.

--- a/CSOC_Documentation.md
+++ b/CSOC_Documentation.md
@@ -63,7 +63,7 @@ A VPC peering connection is used for the communication between the admin VM in t
 
   `gen3 approve_vpcpeering_request <child_vpc_name>`
 
-  The underneath script basically looks for a new VPC peering request, if there is a request in a pending state, it is accepted, tagged and  an appropriate route to the csoc_main_vpc private subnet route table is added. This scirpt accepts an optional flag `--get-route-table` which programtically gets the route table id(s) of the VPC which is accepting the peering request.
+  The underneath script basically looks for a new VPC peering request, if there is a request in a pending state, it is accepted, tagged and  an appropriate route to the csoc_main_vpc private subnet route table is added. This script accepts an optional flag `--get-route-table` which programmatically gets the route table id(s) of the VPC which is accepting the peering request.
 
 *  Manual Process: Once the VPC Peering connection request is made, the CSOC admin need to do the following (use this process only if `automatic process` explained above give errors):
 	*	Verify the VPC  peering request and accept it. Make sure the VPC peering connection is active. At this time you can give a name to the peering connection for future reference.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,8 +122,8 @@ node {
       if(!skipUnitTests) {
         sh 'pip3 install boto3 --upgrade'
         sh 'pip3 install kubernetes --upgrade'
-        sh 'python -m pytest cloud-automation/apis_configs/'
-        sh 'python -m pytest cloud-automation/gen3/lib/dcf/'
+        sh 'python3 -m pytest cloud-automation/apis_configs/'
+        sh 'python3 -m pytest cloud-automation/gen3/lib/dcf/'
         sh 'cd cloud-automation/tf_files/aws/modules/common-logging && python3 -m pytest testLambda.py'
         sh 'cd cloud-automation/files/lambda && python3 -m pytest test-security_alerts.py'
         sh 'cd cloud-automation/kube/services/jupyterhub && python3 -m pytest test-jupyterhub_config.py'

--- a/gen3/bin/approve_vpcpeering_request.sh
+++ b/gen3/bin/approve_vpcpeering_request.sh
@@ -1,23 +1,45 @@
 #!/bin/bash
-if [ $# -ne 1 ]; then
+if [ $# -lt 1 ]; then
     echo "USAGE: $0 name_of_child_vpc"
     exit 1
 fi
 vpcpeering_pending_acceptence=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --output text)
 if [ -n "$vpcpeering_pending_acceptence" ]; then
-child_vpc_name=$1
-vpcpeerconnid=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].VpcPeeringConnectionId' --output text)
-vpccidrblock=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].RequesterVpcInfo.CidrBlock' --output text)
 
-aws ec2 accept-vpc-peering-connection --vpc-peering-connection-id $vpcpeerconnid
-aws ec2 create-tags --resources $vpcpeerconnid --tags Key=Name,Value="VPC peering between $child_vpc_name and csoc_main_vpc"
-echo "The vpc peering connection request for id $vpcpeerconnid was accepted"
+    child_vpc_name=$1
+    vpcpeerconnid=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].VpcPeeringConnectionId' --output text)
+    vpccidrblock=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].RequesterVpcInfo.CidrBlock' --output text)
+    acceptervpcid=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].AccepterVpcInfo.VpcId' --output text)
+    ROUTE_TABLES=(rtb-23b6685f rtb-rtb-7ee06301)
+    if [ $# -eq 2 ]; then
+        while test $# -gt 0; do
+            case "$2" in
+            --get-route-table)
+                shift
+                ROUTE_TABLES=($(aws ec2 describe-route-tables --filters Name=vpc-id,Values=${acceptervpcid} --query 'RouteTables[*].RouteTableId' --output text))
+                shift
+                ;;
+            *)
+                echo "$2 is not a recognized flag!"
+                exit 1
+                ;;
+            esac
+        done
+    fi
 
+    echo "Route Table: ${ROUTE_TABLES[*]}"
 
-aws ec2 create-route --route-table-id rtb-23b6685f --destination-cidr-block $vpccidrblock --vpc-peering-connection-id $vpcpeerconnid
-aws ec2 create-route --route-table-id rtb-7ee06301 --destination-cidr-block $vpccidrblock --vpc-peering-connection-id $vpcpeerconnid
+    aws ec2 accept-vpc-peering-connection --vpc-peering-connection-id $vpcpeerconnid
+    aws ec2 create-tags --resources $vpcpeerconnid --tags Key=Name,Value="VPC peering between $child_vpc_name and csoc_main_vpc"
+    echo "The vpc peering connection request for id $vpcpeerconnid was accepted"
 
-echo "The route for the child vpc $child_vpc_name cidr $vpccidrblock was added"
-exit 1
-else echo "CSOC AWS account haven't received the VPC peering request yet"
+    for table_id in "${ROUTE_TABLES[@]}"; do
+        aws ec2 create-route --route-table-id $table_id --destination-cidr-block $vpccidrblock --vpc-peering-connection-id $vpcpeerconnid
+    done
+
+    echo "The route for the child vpc $child_vpc_name cidr $vpccidrblock was added"
+    exit 1
+else
+    echo "CSOC AWS account haven't received the VPC peering request yet"
 fi
+

--- a/gen3/bin/approve_vpcpeering_request.sh
+++ b/gen3/bin/approve_vpcpeering_request.sh
@@ -10,7 +10,7 @@ if [ -n "$vpcpeering_pending_acceptence" ]; then
     vpcpeerconnid=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].VpcPeeringConnectionId' --output text)
     vpccidrblock=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].RequesterVpcInfo.CidrBlock' --output text)
     acceptervpcid=$(aws ec2 describe-vpc-peering-connections --filters Name=status-code,Values=pending-acceptance --query 'VpcPeeringConnections[*].AccepterVpcInfo.VpcId' --output text)
-    ROUTE_TABLES=(rtb-23b6685f rtb-rtb-7ee06301)
+    ROUTE_TABLES=(rtb-23b6685f rtb-7ee06301)
     if [ $# -eq 2 ]; then
         while test $# -gt 0; do
             case "$2" in

--- a/tf_files/README.md
+++ b/tf_files/README.md
@@ -28,7 +28,8 @@ gen3 workon cdistest devplanetv1
 ### VPC peering request acceptance by CSOC admin VM
 When we launch a new data commons; it fails when we run the `gen3 tfapply` for the first time. At this point, we need to login to the csoc_admin VM and run the following command:
 gen3 approve_vpcpeering_request <child_vpc_name>
-The underneath script basically looks for a new VPC peering request, if any accepts it, tags it and create an appropriate route to the csoc_main_vpc private subnet route table. This scirpt accepts an optional flag `--get-route-table` which programtically gets the route table id(s) of the VPC which is accepting the peering request.
+The underneath script basically looks for a new VPC peering request, if any accepts it, tags it and create an appropriate route to the csoc_main_vpc private subnet route table. This script accepts an optional flag `--get-route-table` which programmatically gets the route table id(s) of the VPC which is accepting the peering request.
+
 
 Once this is completed successfully, we can run the `gen3 tfplan` and `gen3 tfapply` again.
 

--- a/tf_files/README.md
+++ b/tf_files/README.md
@@ -28,7 +28,8 @@ gen3 workon cdistest devplanetv1
 ### VPC peering request acceptance by CSOC admin VM
 When we launch a new data commons; it fails when we run the `gen3 tfapply` for the first time. At this point, we need to login to the csoc_admin VM and run the following command:
 gen3 approve_vpcpeering_request <child_vpc_name>
-The underneath script basically looks for a new VPC peering request, if any accepts it, tags it and create an appropriate route to the csoc_main_vpc private subnet route table.
+The underneath script basically looks for a new VPC peering request, if any accepts it, tags it and create an appropriate route to the csoc_main_vpc private subnet route table. This scirpt accepts an optional flag `--get-route-table` which programtically gets the route table id(s) of the VPC which is accepting the peering request.
+
 Once this is completed successfully, we can run the `gen3 tfplan` and `gen3 tfapply` again.
 
 ## tf_files/aws/data_bucket


### PR DESCRIPTION
Jira Ticket: [DDI-106](https://occ-data.atlassian.net/browse/DDI-106)

- This script take an optional flag "--get-route-table" to find the route table id of the VPC which is accepting the peering request

### New Features
Added new optional flag "--get-route-table"

### Improvements
when the older script was taking manual entries for route table, this will allow an option to programmatically get route table(s) from the accepter VPC
