### PR TITLE
nb-etl-cronjob cron on Thursdays 6:00PM

### DIFF
--- a/kube/services/jobs/nb-etl-cronjob.yaml
+++ b/kube/services/jobs/nb-etl-cronjob.yaml
@@ -4,9 +4,8 @@ kind: CronJob
 metadata:
   name: nb-etl
 spec:
-  # 12:00 Chicago time
-  # 17:00 UTC time
-  schedule: "0 17 * * *"
+  # Weekly Thursday 6:00PM Chicago time == Friday 12:00AM UTC
+  schedule: "0 0 * * 5"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
   concurrencyPolicy: Forbid


### PR DESCRIPTION
JIRA: COV-736

### Improvements
- The nb-etl job now takes several days to run (5 days in QA) - change the schedule to weekly (Thursday 6:00PM Chicago time)
