### PR TITLE
Chore/test custom gcp bucket manifest branch

### DIFF
--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -69,6 +69,7 @@ gen3_create_google_dataflow() {
   git checkout chore/migrate_to_poetry
   
   poetry install -vv --no-dev
+  poetry run poetry2setup > setup.py
 
   gcloud config set proxy/type http
   gcloud config set proxy/address cloud-proxy.internal.io

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -69,10 +69,11 @@ gen3_create_google_dataflow() {
   source venv/bin/activate
   git clone https://github.com/uc-cdis/google-bucket-manifest && cd google-bucket-manifest
   git checkout chore/migrate_to_poetry
-  pip install -r requirements.txt
+  
+  poetry install -vv --no-dev
 
   # Build a template
-  python bucket_manifest_pipeline.py --runner DataflowRunner  --project "$project" --bucket "$bucket" --temp_location gs://"$temp_bucket"/temp  --template_location gs://"$temp_bucket"/templates/pipeline_template --region us-central1 --setup_file ./setup.py --service_account_email "${service_account}"
+  poetry run python bucket_manifest_pipeline.py --runner DataflowRunner  --project "$project" --bucket "$bucket" --temp_location gs://"$temp_bucket"/temp  --template_location gs://"$temp_bucket"/templates/pipeline_template --region us-central1 --setup_file ./setup.py --service_account_email "${service_account}"
   gen3 cd
 
   local pubsub_topic_name=$(echo "${prefix}-pubsub_topic_name" | head -c63)

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -68,7 +68,7 @@ gen3_create_google_dataflow() {
   virtualenv venv
   source venv/bin/activate
   git clone https://github.com/uc-cdis/google-bucket-manifest && cd google-bucket-manifest
-  git checkout chore/potential_fix_for_gcp_bucket_manifest
+  git checkout chore/migrate_to_poetry
   pip install -r requirements.txt
 
   # Build a template

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -80,6 +80,7 @@ gen3_create_google_dataflow() {
   # however, this blocks the g3kubectl commands
   # (causes "Unable to connect to the server: Forbidden" error)
   # that is why it can only be declared after "g3kubectl get secret gcp-bucket-manifest-g3auto"
+  # and needs to be unset before we try any "g3kubectl commands", hence the unset later in this script
   export https_proxy='http://cloud-proxy.internal.io:3128'
 
   # Build a template
@@ -123,7 +124,8 @@ EOF
   #gen3 gitops filter $HOME/cloud-automation/kube/services/jobs/google-bucket-manifest-job.yaml PROJECT $project PUBSUB_SUB ${pubsub_sub} AUTHZ ${metadata_file} N_MESSAGES ${n_messages} OUT_BUCKET ${temp_bucket} | sed "s|sa-#SA_NAME_PLACEHOLDER#|$saName|g" | sed "s|gcp-bucket-manifest#PLACEHOLDER#|gcp-bucket-manifest-${jobId}|g" > ./google-bucket-manifest-${jobId}-job.yaml
   gen3 gitops filter $GEN3_HOME/kube/services/jobs/google-bucket-manifest-job.yaml PROJECT $project PUBSUB_SUB ${pubsub_sub_name} METADATA_FILE "${metadata_file}" N_MESSAGES $n_messages OUT_BUCKET $temp_bucket | sed "s|google-bucket-manifest#PLACEHOLDER#|google-bucket-manifest-${jobId}|g" > ./google-bucket-manifest-${jobId}-job.yaml
 
-  # unset https_proxy
+  # unset proxy, otherwise, this will break the g3k_manifest_init function
+  unset https_proxy
 
   gen3 secrets sync "initialize gcp-bucket-manifest/config.json"
   gen3 job run ./google-bucket-manifest-${jobId}-job.yaml

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -77,6 +77,8 @@ gen3_create_google_dataflow() {
   poetry run python bucket_manifest_pipeline.py --runner DataflowRunner  --project "$project" --bucket "$bucket" --temp_location gs://"$temp_bucket"/temp  --template_location gs://"$temp_bucket"/templates/pipeline_template --region us-central1 --setup_file ./setup.py --service_account_email "${service_account}"
   gen3 cd
 
+  unset https_proxy
+
   local pubsub_topic_name=$(echo "${prefix}-pubsub_topic_name" | head -c63)
   local pubsub_sub_name=$(echo "${prefix}-pubsub_sub_name" | head -c63)
   local dataflow_name=$(echo "${prefix}-dataflow_name" | head -c63)

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -71,11 +71,6 @@ gen3_create_google_dataflow() {
   poetry install -vv --no-dev
   poetry run poetry2setup > setup.py
 
-  # unblocks gsutil cp commands
-  gcloud config set proxy/type http
-  gcloud config set proxy/address cloud-proxy.internal.io
-  gcloud config set proxy/port 3128
-
   # the following proxy config unblocks apache_beam.runners.dataflow.internal.apiclient GCS upload operations
   # however, this blocks the g3kubectl commands
   # (causes "Unable to connect to the server: Forbidden" error)

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -66,7 +66,6 @@ gen3_create_google_dataflow() {
 
   # Download code to build a google template
   git clone https://github.com/uc-cdis/google-bucket-manifest && cd google-bucket-manifest
-  git checkout chore/migrate_to_poetry
   
   poetry install -vv --no-dev
   poetry run poetry2setup > setup.py

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -117,10 +117,11 @@ EOF
   fi
   n_messages="$(gsutil ls -r gs://${bucket}/** | wc -l)"
   #gen3 gitops filter $HOME/cloud-automation/kube/services/jobs/google-bucket-manifest-job.yaml PROJECT $project PUBSUB_SUB ${pubsub_sub} AUTHZ ${metadata_file} N_MESSAGES ${n_messages} OUT_BUCKET ${temp_bucket} | sed "s|sa-#SA_NAME_PLACEHOLDER#|$saName|g" | sed "s|gcp-bucket-manifest#PLACEHOLDER#|gcp-bucket-manifest-${jobId}|g" > ./google-bucket-manifest-${jobId}-job.yaml
-  gen3 gitops filter $GEN3_HOME/kube/services/jobs/google-bucket-manifest-job.yaml PROJECT $project PUBSUB_SUB ${pubsub_sub_name} METADATA_FILE "${metadata_file}" N_MESSAGES $n_messages OUT_BUCKET $temp_bucket | sed "s|google-bucket-manifest#PLACEHOLDER#|google-bucket-manifest-${jobId}|g" > ./google-bucket-manifest-${jobId}-job.yaml
 
   # unset proxy, otherwise, this will break the g3k_manifest_init function
   unset https_proxy
+
+  gen3 gitops filter $GEN3_HOME/kube/services/jobs/google-bucket-manifest-job.yaml PROJECT $project PUBSUB_SUB ${pubsub_sub_name} METADATA_FILE "${metadata_file}" N_MESSAGES $n_messages OUT_BUCKET $temp_bucket | sed "s|google-bucket-manifest#PLACEHOLDER#|google-bucket-manifest-${jobId}|g" > ./google-bucket-manifest-${jobId}-job.yaml
 
   gen3 secrets sync "initialize gcp-bucket-manifest/config.json"
   gen3 job run ./google-bucket-manifest-${jobId}-job.yaml

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -71,9 +71,7 @@ gen3_create_google_dataflow() {
   poetry install -vv --no-dev
   poetry run poetry2setup > setup.py
 
-  gcloud config set proxy/type http
-  gcloud config set proxy/address cloud-proxy.internal.io
-  gcloud config set proxy/port 3128
+  export https_proxy='http://cloud-proxy.internal.io:3128'
 
   # Build a template
   poetry run python bucket_manifest_pipeline.py --runner DataflowRunner  --project "$project" --bucket "$bucket" --temp_location gs://"$temp_bucket"/temp  --template_location gs://"$temp_bucket"/templates/pipeline_template --region us-central1 --setup_file ./setup.py --service_account_email "${service_account}"

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -65,12 +65,14 @@ gen3_create_google_dataflow() {
   gen3 cd
 
   # Download code to build a google template
-  virtualenv venv
-  source venv/bin/activate
   git clone https://github.com/uc-cdis/google-bucket-manifest && cd google-bucket-manifest
   git checkout chore/migrate_to_poetry
   
   poetry install -vv --no-dev
+
+  gcloud config set proxy/type http
+  gcloud config set proxy/address cloud-proxy.internal.io
+  gcloud config set proxy/port 3128
 
   # Build a template
   poetry run python bucket_manifest_pipeline.py --runner DataflowRunner  --project "$project" --bucket "$bucket" --temp_location gs://"$temp_bucket"/temp  --template_location gs://"$temp_bucket"/templates/pipeline_template --region us-central1 --setup_file ./setup.py --service_account_email "${service_account}"

--- a/gen3/bin/gcp-bucket-manifest.sh
+++ b/gen3/bin/gcp-bucket-manifest.sh
@@ -68,6 +68,7 @@ gen3_create_google_dataflow() {
   virtualenv venv
   source venv/bin/activate
   git clone https://github.com/uc-cdis/google-bucket-manifest && cd google-bucket-manifest
+  git checkout chore/potential_fix_for_gcp_bucket_manifest
   pip install -r requirements.txt
 
   # Build a template


### PR DESCRIPTION
Finally found the perfect combination to unblock both the Jenkins CI operations related to the `gsutil` CLI and the apache_beam GCS upload process that requires `https_proxy`.

The Jenkins CI job has now been configured with:
```
gcloud config set proxy/type http
gcloud config set proxy/address cloud-proxy.internal.io
gcloud config set proxy/port 3128
```
config: https://jenkins2.planx-pla.net/job/bucket-manifest-generation-ci/configure

AND the gen3 cli script has been improved to set and unset the `https_proxy` environment variable at the correct spots.

Also adopting the Poetry migration: https://github.com/uc-cdis/google-bucket-manifest/pull/11

### Bug Fixes
- Strategically set `https_proxy` to unblock apache beam's GCS upload operations and unset right before g3kubectl cmds.