### PR TITLE
Add additional metrics to dashboard service

### DIFF
--- a/files/dashboard/usage-reports/src/base.css
+++ b/files/dashboard/usage-reports/src/base.css
@@ -18,7 +18,6 @@ body {
   height: 100%;
   min-height: 320px;
   font-size: 12px;
-  box-sizing: border-box;
 }
 
 h1,h2,h3,h4 {

--- a/files/dashboard/usage-reports/src/dataHelper.js
+++ b/files/dashboard/usage-reports/src/dataHelper.js
@@ -277,6 +277,41 @@ class UniqueUsersHandler {
   }
 }
 
+/**
+ * Handler for download by provider report
+ */
+export class ESAggregationsHandler {
+  constructor(service) {
+    this.service = service;
+  }
+
+  buildPathDateList(dateRange) {
+    let prefix = `${this.service}`;
+    return basicBuildPathList(prefix, dateRange);
+  }
+
+  fetchData(pathDateList) {
+    return fetchBucketsSummary(pathDateList, "aggs"
+      ).then(
+        (data) => {
+          return {
+            reportType: `${this.service}`,
+            service: 'all',
+            data
+          };
+        }
+      );
+  }
+
+  massageData(fetchedData) {
+    return {
+      ... fetchedData,
+      massage: addPercentColumn(
+        Object.entries(fetchedData.data).sort((a,b) => numCompare(a[0],b[0]))
+      )
+    };
+  }
+}
 
 /**
  * Handler for result codes report
@@ -421,6 +456,15 @@ const reportHandlers = {
   },
   projects: {
     all: new PassThroughHandler('projects')
+  },
+  protocol: {
+    all: new ESAggregationsHandler('protocol')
+  },
+  loginproviders: {
+    all: new ESAggregationsHandler('loginproviders')
+  },
+  ga4ghrcodes: {
+    all: new ESAggregationsHandler('ga4ghrcodes')
   }
 };
 
@@ -441,4 +485,3 @@ export function fetchRecentData(reportType, reportGroup='all', dateRange=10) {
       }
     );
 }
-

--- a/files/dashboard/usage-reports/src/index.html
+++ b/files/dashboard/usage-reports/src/index.html
@@ -30,8 +30,28 @@
     <main>
       <section id="daterange">
         <h3>Report Window</h3>
-
         <g3r-window-sizer></g3r-window-sizer>
+      </section>
+      <section id="downloadprotocol" class="g3reports-datapanel g3reports-downloadprotocol">
+        <h3>Signed Urls</h3>
+        <p>
+          Number of signed urls generated, split by protocol.
+        </p>
+        <g3r-table></g3r-table>
+      </section>
+      <section id="loginproviders" class="g3reports-datapanel g3reports-loginproviders">
+        <h3>Logins by provider</h3>
+        <p>
+          Number of login events, split by login provider. 
+        </p>
+        <g3r-table></g3r-table>
+      </section>
+      <section id="loginproviders" class="g3reports-datapanel g3reports-drsrcodes">
+        <h3>DRS URI Response Codes</h3>
+        <p>
+          Response codes DRS URI endpoints (/ga4gh/drs/v1/objects) from indexd service.
+        </p>
+        <g3r-table></g3r-table>
       </section>
       <section id="users" class="g3reports-datapanel g3reports-users">
         <h3>Unique Users</h3>

--- a/files/dashboard/usage-reports/src/reportsMain.js
+++ b/files/dashboard/usage-reports/src/reportsMain.js
@@ -21,6 +21,9 @@ export function main() {
       {}
     ),
     users: { 'all': document.body.querySelector('.g3reports-users g3r-table') },
+    protocol: { 'all': document.body.querySelector('.g3reports-downloadprotocol g3r-table') },
+    loginproviders: { 'all': document.body.querySelector('.g3reports-loginproviders g3r-table') },
+    ga4ghrcodes: { 'all': document.body.querySelector('.g3reports-drsrcodes g3r-table') },
   };
 
   statusDOM.innerHTML = `<p>Initializing</p>`;

--- a/files/scripts/reports-cronjob.sh
+++ b/files/scripts/reports-cronjob.sh
@@ -59,6 +59,15 @@ done
 fileName="users-${dateTime}.json"
 gen3 logs history users start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
 
+fileName="protocol-${dateTime}.json"
+gen3 logs history protocol start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
+
+fileName="loginproviders-${dateTime}.json"
+gen3 logs history loginproviders start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
+
+fileName="ga4ghrcodes-${dateTime}.json"
+gen3 logs history ga4gs_rtimes start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
+
 csvToJson="$(cat - <<EOM
 BEGIN {
   prefix="";
@@ -93,6 +102,11 @@ fileName="users-${dateTime}.json"
 gen3 dashboard publish secure "./$fileName" "${destFolder}/$fileName"
 fileName="projects-${dateTime}.json"
 gen3 dashboard publish secure "./$fileName" "${destFolder}/$fileName"
-
+fileName="protocol-${dateTime}.json"
+gen3 dashboard publish secure "./$fileName" "${destFolder}/$fileName"
+fileName="loginproviders-${dateTime}.json"
+gen3 dashboard publish secure "./$fileName" "${destFolder}/$fileName"
+fileName="ga4ghrcodes-${dateTime}.json"
+gen3 dashboard publish secure "./$fileName" "${destFolder}/$fileName"
 cd /tmp
 /bin/rm -rf "${dataFolder}"

--- a/gen3/bin/logs.sh
+++ b/gen3/bin/logs.sh
@@ -53,6 +53,15 @@ if [[ -z "$GEN3_SOURCE_ONLY" ]]; then
         "rtimes")
           gen3_logs_rtime_histogram "$@"
           ;;
+        "loginproviders")
+          gen3_logs_loginprovider_histogram "$@"
+          ;;
+        "protocol")
+          gen3_logs_protocol_histogram "$@"
+          ;;
+        "ga4gs_rtimes")
+          gen3_logs_ga4ghrcodes_histogram "$@"
+          ;;
         "users")
           gen3_logs_user_count "$@"
           ;;


### PR DESCRIPTION
Jira Ticket: [HP-75](https://ctds-planx.atlassian.net/browse/HP-75)


### Improvements

- Add a few additional metrics to the reports-cronjob
- Number of logins per provider
- API invocation rates and response codes for `/ga4gh/drs/v1/objects` endpoint
- Signed URL rates split by provider (s3, gcs etc)