### PR TITLE
PXP-7447 Roll all: deploy audit-service before fence

### DIFF
--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -65,6 +65,12 @@ else
   gen3_log_info "no manifest entry for arborist"
 fi
 
+if g3k_manifest_lookup '.versions["audit-service"]' 2> /dev/null; then
+  gen3 kube-setup-audit-service
+else
+  gen3_log_info "not deploying audit-service - no manifest entry for .versions.audit-service"
+fi
+
 if g3k_manifest_lookup .versions.fence 2> /dev/null; then
   # data ecosystem sub-commons may not deploy fence ...
   gen3 kube-setup-fence
@@ -199,12 +205,6 @@ if g3k_manifest_lookup '.versions["access-backend"]' 2> /dev/null; then
   gen3 kube-setup-access-backend
 else
   gen3_log_info "not deploying access-backend - no manifest entry for .versions.access-backend"
-fi
-
-if g3k_manifest_lookup '.versions["audit-service"]' 2> /dev/null; then
-  gen3 kube-setup-audit-service
-else
-  gen3_log_info "not deploying audit-service - no manifest entry for .versions.audit-service"
 fi
 
 gen3 kube-setup-revproxy


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-7447

related to #1540

Fence waits a bit before crashing when audit logs are enabled but it can't reach audit-service, but deploying audit-service last during roll-all makes Fence wait for too long and the Fence pod ends up restarting until audit-service is up.

### Improvements
- Roll all: deploy audit-service before fence
