### PR TITLE
Fix OOM for cluster-autoscaler on startup

### DIFF
--- a/kube/services/autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/kube/services/autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -143,7 +143,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 300Mi
+              memory: 600Mi
             requests:
               cpu: 100m
               memory: 300Mi


### PR DESCRIPTION
Saw OOM for cluster-autoscaler a few times in qaplanetv1

https://github.com/kubernetes/autoscaler/issues/3506 

Upped the memory limit to 600mb 