### PR TITLE
Chore(ci): Dynamic ci envs pool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ library 'cdis-jenkins-lib@master'
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 node {
-  def AVAILABLE_NAMESPACES = ['jenkins-blood', 'jenkins-brain', 'jenkins-niaid', 'jenkins-dcp', 'jenkins-genomel']
+  def AVAILABLE_NAMESPACES = ciEnsPoolHelper.fetchCIEnvs()
   List<String> namespaces = []
   List<String> listOfSelectedTests = []
   skipUnitTests = false


### PR DESCRIPTION
DEPENDS ON https://github.com/uc-cdis/cdis-jenkins-lib/pull/157


Making our list of CI environments dynamic:
https://cdistest-public-test-bucket.s3.amazonaws.com/jenkins-envs.txt

With this change we will be able to mutate the pool of CI environments on the fly.
This is a very powerful mechanism as it will allow us to:
- Lock envs for experiments (taking them out of rotation).
- Cordon environments to protect crime scenes in case we need to conduct some critical investigation.
- This is also a stepping stone for our ephemeral CI envs initiative.

## New Features
- Instead of hardcoding the list of jenkins environments, we will utilize an easily mutable text file hosted in an S3 bucket.