### PR TITLE
Adopt the awshelper image from AWS ECR

### DIFF
--- a/kube/services/ambtest/ambtest-deploy.yaml
+++ b/kube/services/ambtest/ambtest-deploy.yaml
@@ -59,7 +59,7 @@ spec:
             cpu: 0.3
             memory: 512Mi
       - name: awshelper
-        GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+        GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
         imagePullPolicy: Always
         command: ["/bin/bash" ]
         args:

--- a/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
+++ b/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           echo "done"
         command:
         - /bin/bash
-        image: quay.io/cdis/awshelper:master
+        image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master
         imagePullPolicy: Always
         name: awshelper
         resources: {}

--- a/kube/services/jobs/bucket-replicate-job.yaml
+++ b/kube/services/jobs/bucket-replicate-job.yaml
@@ -30,7 +30,7 @@ spec:
             defaultMode: 0544
       containers:
       - name: replicate
-        GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+        GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
         imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/kube/services/jobs/bucket-size-report-job.yaml
+++ b/kube/services/jobs/bucket-size-report-job.yaml
@@ -17,7 +17,7 @@ spec:
           secretName: "bucket-size-report-g3auto"
       containers:
       - name: awshelper
-        image: quay.io/cdis/awshelper:master
+        image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master
         imagePullPolicy: Always
         volumeMounts:
         - name: "creds"

--- a/kube/services/jobs/config-fence-job.yaml
+++ b/kube/services/jobs/config-fence-job.yaml
@@ -103,7 +103,7 @@ spec:
             cp new-fence-config.yaml /mnt/shared/new-fence-config.yaml
 
       - name: awshelper
-        GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+        GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
         imagePullPolicy: Always
         volumeMounts:
           - name: shared-data

--- a/kube/services/jobs/envtest-job.yaml
+++ b/kube/services/jobs/envtest-job.yaml
@@ -14,7 +14,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: fence
-        GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+        GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
         imagePullPolicy: Always
         env:
           - name: REUBEN

--- a/kube/services/jobs/es-garbage-job.yaml
+++ b/kube/services/jobs/es-garbage-job.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: awshelper
           # often do not want pinned awshelper in gitops-sync
-          GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+          GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
           imagePullPolicy: Always
           env:
             - name: AWS_STS_REGIONAL_ENDPOINTS

--- a/kube/services/jobs/fence-db-migrate-job.yaml
+++ b/kube/services/jobs/fence-db-migrate-job.yaml
@@ -27,7 +27,7 @@ spec:
           emptyDir: {}
       initContainers:
         - name: usersync-disable
-          GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+          GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
           imagePullPolicy: Always
           env:
             - name: gen3Env
@@ -95,7 +95,7 @@ spec:
             fi
             touch /tmp/pod/completed
       - name: usersync-enable
-        GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+        GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
         imagePullPolicy: Always
         env:
           - name: gen3Env

--- a/kube/services/jobs/fluentd-restart-job.yaml
+++ b/kube/services/jobs/fluentd-restart-job.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
         - name: awshelper
           # often do not want pinned awshelper in gitops-sync
-          GEN3_AUTOMATION_IMAGE|-image: quay.io/cdis/awshelper:master-|
+          GEN3_AUTOMATION_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
           imagePullPolicy: Always
           command: ["/bin/bash" ]
           args:

--- a/kube/services/jobs/gitops-sync-job.yaml
+++ b/kube/services/jobs/gitops-sync-job.yaml
@@ -16,7 +16,7 @@ spec:
       containers:
         - name: awshelper
           # often do not want pinned awshelper in gitops-sync
-          GEN3_AUTOMATION_IMAGE|-image: quay.io/cdis/awshelper:master-|
+          GEN3_AUTOMATION_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
           imagePullPolicy: Always
           env:
             - name: gen3Env

--- a/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
@@ -129,7 +129,7 @@ spec:
                     configMapKeyRef:
                       name: manifest-global
                       key: hostname
-            GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+            GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
             volumeMounts:
               - name: shared-data
                 mountPath: /mnt/shared

--- a/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
@@ -135,7 +135,7 @@ spec:
                     configMapKeyRef:
                       name: manifest-global
                       key: hostname       
-            GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+            GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
             volumeMounts:
               - name: shared-data
                 mountPath: /mnt/shared

--- a/kube/services/jobs/google-manage-account-access-cronjob.yaml
+++ b/kube/services/jobs/google-manage-account-access-cronjob.yaml
@@ -129,7 +129,7 @@ spec:
                     configMapKeyRef:
                       name: manifest-global
                       key: hostname
-            GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+            GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
             volumeMounts:
               - name: shared-data
                 mountPath: /mnt/shared

--- a/kube/services/jobs/google-manage-keys-cronjob.yaml
+++ b/kube/services/jobs/google-manage-keys-cronjob.yaml
@@ -129,7 +129,7 @@ spec:
                     configMapKeyRef:
                       name: manifest-global
                       key: hostname
-            GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+            GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
             volumeMounts:
               - name: shared-data
                 mountPath: /mnt/shared

--- a/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
@@ -129,7 +129,7 @@ spec:
                     configMapKeyRef:
                       name: manifest-global
                       key: hostname
-            GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+            GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
             volumeMounts:
               - name: shared-data
                 mountPath: /mnt/shared

--- a/kube/services/jobs/hatchery-metrics-job.yaml
+++ b/kube/services/jobs/hatchery-metrics-job.yaml
@@ -15,7 +15,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: awshelper
-          GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+          GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
           imagePullPolicy: Always
           env:
             - name: KUBECTL_NAMESPACE

--- a/kube/services/jobs/hatchery-reaper-job.yaml
+++ b/kube/services/jobs/hatchery-reaper-job.yaml
@@ -15,7 +15,7 @@ spec:
         fsGroup: 1000
       containers:
         - name: awshelper
-          GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+          GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
           imagePullPolicy: Always
           env:
             - name: KUBECTL_NAMESPACE

--- a/kube/services/jobs/healthcheck-cronjob.yaml
+++ b/kube/services/jobs/healthcheck-cronjob.yaml
@@ -19,7 +19,7 @@ spec:
           serviceAccountName: jenkins-service
           containers:
             - name: awshelper
-              GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+              GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
               imagePullPolicy: Always
               env:
                 - name: slackWebHook

--- a/kube/services/jobs/s3sync-cronjob.yaml
+++ b/kube/services/jobs/s3sync-cronjob.yaml
@@ -27,7 +27,7 @@ spec:
                 secretName: "aws-sync-creds-secret"
           containers:
             - name: awshelper
-              GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+              GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
               imagePullPolicy: Always
               env:
                 - name: slackWebHook

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -225,7 +225,7 @@ spec:
             echo "Exit code: $exitcode"
             exit "$exitcode"
       - name: awshelper
-        GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
+        GEN3_AWSHELPER_IMAGE|-image: 707767160287.dkr.ecr.us-east-1.amazonaws.com/gen3/awshelper:master-|
         imagePullPolicy: Always
         volumeMounts:
           - name: shared-data


### PR DESCRIPTION
This should improve the reliability on PROD environments if any pod that utilizes this sidecar bounces.