### PR TITLE
Add covid19-notebook-etl job

### DIFF
--- a/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
+++ b/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
@@ -4,8 +4,7 @@ kind: CronJob
 metadata:
   name: covid19-notebook-etl
 spec:
-  # Weekly Thursday 6:00PM Chicago time == Friday 12:00AM UTC
-  schedule: "0 0 * * 5"
+  schedule: "0 10 * * *"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 2
   concurrencyPolicy: Forbid

--- a/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
+++ b/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
@@ -1,9 +1,8 @@
-# gen3 job run nb-etl S3_BUCKET <S3_BUCKET>
-# deprecated; replaced by covid19-nb-etl-cronjob.yaml; delete once we're ready
+# gen3 job run covid19-notebook-etl S3_BUCKET <S3_BUCKET>
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
-  name: nb-etl
+  name: covid19-notebook-etl
 spec:
   # Weekly Thursday 6:00PM Chicago time == Friday 12:00AM UTC
   schedule: "0 0 * * 5"
@@ -27,11 +26,11 @@ spec:
               value: "jupyter"
               effect: "NoSchedule"
           containers:
-            - name: nb-etl
+            - name: covid19-notebook-etl
               imagePullPolicy: Always
               ports:
               - containerPort: 80
-              GEN3_NB-ETL_IMAGE
+              GEN3_COVID19-NOTEBOOK-ETL_IMAGE
               env:
               - name: S3_BUCKET
                 GEN3_S3_BUCKET

--- a/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
+++ b/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
@@ -1,4 +1,4 @@
-# gen3 job run covid19-notebook-etl S3_BUCKET <S3_BUCKET>
+# gen3 job run covid19-notebook-etl-cronjob S3_BUCKET <S3_BUCKET>
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -33,8 +33,6 @@ spec:
               env:
               - name: S3_BUCKET
                 GEN3_S3_BUCKET
-              - name: doSlack
-                GEN3_DO_SLACK|-value: "true"-|
               - name: slackWebHook
                 valueFrom:
                   configMapKeyRef:

--- a/kube/services/jobs/covid19-notebook-etl-job.yaml
+++ b/kube/services/jobs/covid19-notebook-etl-job.yaml
@@ -1,9 +1,8 @@
-# gen3 job run nb-etl S3_BUCKET <S3_BUCKET>
-# deprecated; replaced by covid19-nb-etl-job.yaml; delete once we're ready
+# gen3 job run covid19-notebook-etl S3_BUCKET <S3_BUCKET>
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: nb-etl
+  name: covid19-notebook-etl
 spec:
   template:
     metadata:
@@ -20,9 +19,9 @@ spec:
           value: "jupyter"
           effect: "NoSchedule"
       containers:
-      - name: nb-etl
+      - name: covid19-notebook-etl
         imagePullPolicy: Always
-        GEN3_NB-ETL_IMAGE
+        GEN3_COVID19-NOTEBOOK-ETL_IMAGE
         ports:
         - containerPort: 80
         env:

--- a/kube/services/jobs/covid19-notebook-etl-job.yaml
+++ b/kube/services/jobs/covid19-notebook-etl-job.yaml
@@ -25,8 +25,6 @@ spec:
         ports:
         - containerPort: 80
         env:
-        - name: doSlack
-          GEN3_DO_SLACK|-value: "true"-|
         - name: slackWebHook
           valueFrom:
             configMapKeyRef:

--- a/kube/services/jobs/nb-etl-cronjob.yaml
+++ b/kube/services/jobs/nb-etl-cronjob.yaml
@@ -1,4 +1,4 @@
-# gen3 job run nb-etl S3_BUCKET <S3_BUCKET>
+# gen3 job run nb-etl-cronjob S3_BUCKET <S3_BUCKET>
 # deprecated; replaced by covid19-nb-etl-cronjob.yaml; delete once we're ready
 apiVersion: batch/v1beta1
 kind: CronJob


### PR DESCRIPTION
Jira Ticket: [COV-807](https://occ-data.atlassian.net/browse/COV-807)

Goes with https://github.com/uc-cdis/covid19-tools/pull/188

### New Features
- Make copies of the "nb-etl" files; rename them "covid19-notebook-etl". The new "covid19-notebook-etl" job (daily) only runs notebooks. The old files will stay here until we can completely deprecate the "nb-etl" job (weekly), which runs notebooks + the Bayes model. The "nb-etl" job will eventually be replaced by a "covid19-bayes-model" job that only runs the Bayes model.
