### PR TITLE
Whitelist .idph.illinois.gov

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -39,6 +39,7 @@
 .googleapis.com
 .googleusercontent.com
 .hashicorp.com
+.idph.illinois.gov
 .jenkins-ci.org
 .jenkins.io
 .k8s.io


### PR DESCRIPTION
Jira Ticket: COV-801

relates to https://github.com/uc-cdis/covid19-tools/pull/190

Whitelist .idph.illinois.gov
