### PR TITLE
Add HEAL to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -39,6 +39,7 @@
 .googleapis.com
 .googleusercontent.com
 .hashicorp.com
+.healdata.org
 .idph.illinois.gov
 .jenkins-ci.org
 .jenkins.io


### PR DESCRIPTION
Add HEAL to squid whitelist to fix issue with workspace token service in HEAL preprod.

Slack thread: https://cdis.slack.com/archives/C01EEN7LW1E/p1617217431064100