### PR TITLE
python-nginx base image Rust install

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
+++ b/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
@@ -71,8 +71,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		logrotate \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
-        # install Rust
-        && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh \
+	# install Rust
+	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& found=''; \
 	for server in \
@@ -193,6 +193,8 @@ ENV LISTEN_PORT 80
 COPY entrypoint.sh /entrypoint.sh
 COPY logrotate-nginx.conf /etc/logrotate.d/nginx
 RUN chmod +x /entrypoint.sh
+
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 COPY dockerrun.sh /dockerrun.sh
 RUN mkdir -p /var/www/metrics/ && chmod +x /dockerrun.sh

--- a/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
+++ b/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
@@ -72,7 +72,7 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
 	# install Rust
-	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=stable \
+	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.51 \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& found=''; \
 	for server in \

--- a/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
+++ b/Docker/python-nginx/python3.6-alpine3.7/Dockerfile
@@ -71,6 +71,8 @@ RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 		logrotate \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
 	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
+        # install Rust
+        && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& found=''; \
 	for server in \


### PR DESCRIPTION
Notes from @m0nhawk:
"The curl command to install rustup is tricky, it’s not interactive (`-y`) and it only installs rustup, not the rust toolchain itself (hence the part with `stable`/`1.51`).
Having `stable` is not a good idea, it’s better be a specific version for reproducibility => using `1.51` instead.
And it doesn’t work as expected because of `PATH` — it’s Alpine and it won’t read `.profile` by default (I have no idea why), that’s why I edited it manually."

### Improvements
- Install Rust and Rust toolchain in `python-nginx` image to fix issues installing cyrptography
