### PR TITLE
Whitelist download.pytorch.org

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -50,6 +50,7 @@ docker.elastic.co
 docs.google.com
 download.java.net
 download.oracle.com
+download.pytorch.org
 dream.annailabs.com
 ecsft.cern.ch
 edelivery.oracle.com


### PR DESCRIPTION
Add download.pytorch.org to squid whitelist for @yilinxu's PRC notebook to download a googlenet model at https://download.pytorch.org/models/googlenet-1378be20.pth