### PR TITLE
(PXP-7565): Exclude Fence register-user blueprint from CSRF check

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/fence-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/fence-service.conf
@@ -31,6 +31,16 @@ location /user/ {
     proxy_pass $upstream;
 }
 
+location /user/register-user {
+    # Like /user/ but without CSRF check. Registration form submission is
+    # incompatible with revproxy-level cookie-to-header CSRF check.
+    # Fence enforces its own CSRF protection here so this is OK.
+    set $proxy_service  "${fence_release_name}";
+    set $upstream http://${fence_release_name}-service$des_domain;
+    rewrite ^/user/(.*) /$1 break;
+    proxy_pass $upstream;
+}
+
 location /user/data/download {
     if ($csrf_check !~ ^ok-\S.+$) {
       return 403 "failed csrf check";


### PR DESCRIPTION
**TLDR:
The revproxy currently implements CSRF checks using the cookie-to-header method.
Fence's new registration form, like other HTML forms, is not compatible with this method. The usual way to implement CSRF protection with HTML forms is using a hidden form field.
So here we exclude the Fence registration endpoints from the revproxy CSRF check. This is OK because Fence implements its own CSRF checks.**

Here is the relevant Fence PR (implementing registration endpoints) https://github.com/uc-cdis/fence/pull/906

For the record, more background on cloud-auto CSRF history:

Fence [has been operating](https://github.com/uc-cdis/fence/blob/61be960499434b39db8793f9cde37741f0709b26/fence/__init__.py#L398-L427) under the assumption that it manages its own CSRF token. 
But actually the revproxy [rewrites the token](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/nginx.conf#L260-L264) and performs its own CSRF checking. 

At time of PR, the revproxy CSRF check looks like [this](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/nginx.conf#L331-L345).
That code can be traced back to [this](https://github.com/uc-cdis/cloud-automation/commit/75168738adb36d9048e3cc54f06baeffc04311dd) commit and [this](https://github.com/uc-cdis/cloud-automation/commit/bf5f1204c755ec26eeaae6f02370a570632a81f2) commit.

At some point between then and now, [the "return 403 failed csrf check" bit](https://github.com/uc-cdis/cloud-automation/commit/75168738adb36d9048e3cc54f06baeffc04311dd#diff-c30961987621af78cf47846c2ef7c050142786990f0e3901ea214198db1a6410R81-R83) migrated from the main nginx.conf into the [individual](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/gen3.nginx.conf/peregrine-service.conf#L37-L39) [*-service.conf](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf#L35-L37) [files](https://github.com/uc-cdis/cloud-automation/blob/c445e42ad69a8a65eb8846e19cb2d09869f71fd6/kube/services/revproxy/gen3.nginx.conf/fence-service.conf#L24-L26). 


---

Jira Ticket: [PXP-7565](https://ctds-planx.atlassian.net/browse/PXP-7565)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
