### PR TITLE
fix(save-failed-pods-logs): Capture logs before namespace is wiped out

### DIFF
--- a/gen3/bin/kube-wait4-pods.sh
+++ b/gen3/bin/kube-wait4-pods.sh
@@ -18,25 +18,18 @@ EOM
 }
 
 
-MAX_RETRIES=180
-IS_K8S_RESET="false"
+MAX_RETRIES=${1:-180}
+IS_K8S_RESET="${2:-false}"
 
-if [[ $# -gt 0 ]]; then
-  if [[ "$1" =~ ^[0-9]+$ ]]; then
-    MAX_RETRIES="$1"
-    shift
-  else
-    gen3_log_err "ignoring invalid retry count: $1"
-  fi
+if [[ ! "$MAX_RETRIES" =~ ^[0-9]+$ ]];
+then
+  gen3_log_err "ignoring invalid retry count: $1"
+fi
 
-  if [[ -z $1 ]]; then
-    if [[ "$1" =~ "true|false" ]]; then
-      IS_K8S_RESET=$1
-    else
-      gen3_log_err "invalid MY_OTHER_VAR (needs to be true or false): $1"
-      exit 1
-    fi
-  fi
+if [[ ! "$IS_K8S_RESET" =~ ^(true$|false$) ]];
+then
+  gen3_log_err "invalid IS_K8S_RESET (needs to be true or false): $IS_K8S_RESET"
+  exit 1
 fi
 
 (

--- a/gen3/bin/kube-wait4-pods.sh
+++ b/gen3/bin/kube-wait4-pods.sh
@@ -19,6 +19,7 @@ EOM
 
 
 MAX_RETRIES=180
+IS_K8S_RESET="false"
 
 if [[ $# -gt 0 ]]; then
   if [[ "$1" =~ ^[0-9]+$ ]]; then
@@ -26,6 +27,15 @@ if [[ $# -gt 0 ]]; then
     shift
   else
     gen3_log_err "ignoring invalid retry count: $1"
+  fi
+
+  if [[ -z $1 ]]; then
+    if [[ "$1" =~ "true|false" ]]; then
+      IS_K8S_RESET=$1
+    else
+      gen3_log_err "invalid MY_OTHER_VAR (needs to be true or false): $1"
+      exit 1
+    fi
   fi
 fi
 
@@ -48,6 +58,9 @@ fi
         let COUNT+=1
         if [[ COUNT -gt "$MAX_RETRIES" ]]; then
           gen3_log_err "pods still not ready after $((MAX_RETRIES * 10)) seconds - bailing out"
+          if [ "$IS_K8S_RESET" == "true" ]; then
+            gen3 save-failed-pod-logs
+          fi
           exit 1
         fi
         sleep 10

--- a/gen3/bin/reset.sh
+++ b/gen3/bin/reset.sh
@@ -38,7 +38,7 @@ run_setup_jobs() {
   done
   gen3_log_info "Waiting for jobs to finish, and late starting services to come up"
   sleep 5
-  gen3 kube-wait4-pods
+  gen3 kube-wait4-pods default true
   for jobName in gdcdb-create indexd-userdb fence-db-migrate; do
     gen3_log_info "--------------------"
     gen3_log_info "Logs for $jobName"

--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -17,6 +17,8 @@ EOM
   return 0
 }
 
+gen3_log_info "capturing and archiving logs from failed pods (if any)..."
+
 # image pull errors
 array_of_img_pull_errors=($(g3kubectl get pods | grep -E "ErrImagePull|ImagePullBackOff" | xargs -I {} echo {} | awk '{ print $1 }' | tr "\n" " "))
   

--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -33,4 +33,5 @@ for pod in "${array_of_svc_startup_errors[@]}"; do
   pod_name=$(echo $pod | xargs)
   gen3_log_info "storing kubectl logs output into svc_startup_error_${pod_name}.log..."
   g3kubectl logs $pod_name > svc_startup_error_${pod_name}.log
+  echo "$(date): Done capturing logs" > save-failed-pod-logs.log
 done

--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -33,5 +33,6 @@ for pod in "${array_of_svc_startup_errors[@]}"; do
   pod_name=$(echo $pod | xargs)
   gen3_log_info "storing kubectl logs output into svc_startup_error_${pod_name}.log..."
   g3kubectl logs $pod_name > svc_startup_error_${pod_name}.log
-  echo "$(date): Done capturing logs" > save-failed-pod-logs.log
 done
+
+echo "$(date): Done capturing logs" > save-failed-pod-logs.log


### PR DESCRIPTION
Capture logs from failed pods when K8sReset fails.

### Bug Fixes
- Capture logs from failed pods when K8sReset fails (before the k8s namespace is teared down).
