### PR TITLE
fix(ci): new runIntegrationTests function signature

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,6 +300,7 @@ node {
             pipeConfig.serviceTesting.name,
             testedEnv,
             "true",
+            "false",
             listOfSelectedTests
         )
       } else {


### PR DESCRIPTION
The new signature for the runIntegrationTests function is:
```
def runIntegrationTests(String namespace, String service, String testedEnv, String isGen3Release, String isNightlyBuild = "false",  List<String> selectedTests = ['all']) {
```

This `Jenkinsfile` is missing the value for `isNightlyBuild`.