### PR TITLE
fix(save-logs): Fetch logs from failed pods when K8sReset fails

### DIFF
--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -34,7 +34,8 @@ array_of_svc_startup_errors=($(g3kubectl get pods | grep -E "Failed|CrashLoopBac
 for pod in "${array_of_svc_startup_errors[@]}"; do
   pod_name=$(echo $pod | xargs)
   gen3_log_info "storing kubectl logs output into svc_startup_error_${pod_name}.log..."
-  g3kubectl logs $pod_name > svc_startup_error_${pod_name}.log
+  container_name=$(kc get pod ${pod_name} -o jsonpath='{.spec.containers[*].name}')
+  g3kubectl logs $pod_name -c ${container_name} > svc_startup_error_${pod_name}.log
 done
 
 echo "$(date): Done capturing logs" > save-failed-pod-logs.log

--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -34,7 +34,7 @@ array_of_svc_startup_errors=($(g3kubectl get pods | grep -E "Failed|CrashLoopBac
 for pod in "${array_of_svc_startup_errors[@]}"; do
   pod_name=$(echo $pod | xargs)
   gen3_log_info "storing kubectl logs output into svc_startup_error_${pod_name}.log..."
-  container_name=$(kc get pod ${pod_name} -o jsonpath='{.spec.containers[*].name}')
+  container_name=$(g3kubectl get pod ${pod_name} -o jsonpath='{.spec.containers[*].name}')
   g3kubectl logs $pod_name -c ${container_name} > svc_startup_error_${pod_name}.log
 done
 

--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -34,7 +34,7 @@ array_of_svc_startup_errors=($(g3kubectl get pods | grep -E "Failed|CrashLoopBac
 for pod in "${array_of_svc_startup_errors[@]}"; do
   pod_name=$(echo $pod | xargs)
   gen3_log_info "storing kubectl logs output into svc_startup_error_${pod_name}.log..."
-  container_name=$(g3kubectl get pod ${pod_name} -o jsonpath='{.spec.containers[*].name}')
+  container_name=$(g3kubectl get pod ${pod_name} -o jsonpath='{.spec.containers[0].name}')
   g3kubectl logs $pod_name -c ${container_name} > svc_startup_error_${pod_name}.log
 done
 


### PR DESCRIPTION
Quick fix to run kubectl logs with both `pod_name` and `container_name`.