### PR TITLE
Fix/daily metrics capture non prod envs

### DIFF
--- a/files/scripts/reports-cronjob.sh
+++ b/files/scripts/reports-cronjob.sh
@@ -5,10 +5,10 @@
 #
 # PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # vpc_name=YOUR-VPC-NAME
-# ns=KUBERNETES_NAMESPACE (optional, defaults to "default")
+# ns_name=K8S_NAMESPACE (optional, defaults to "default")
 # USER=USER
 # KUBECONFIG=path/to/kubeconfig
-# 3   3   *   *   *    (if [ -f $HOME/cloud-automation/files/scripts/reports-cronjob.sh ]; then bash $HOME/cloud-automation/files/scripts/reports-cronjob.sh "vpc=$vpc_name" "ns=$ns"; else echo "no reports-cronjob.sh"; fi) > $HOME/reports-cronjob.log 2>&1
+# 3   3   *   *   *    (if [ -f $HOME/cloud-automation/files/scripts/reports-cronjob.sh ]; then bash $HOME/cloud-automation/files/scripts/reports-cronjob.sh "vpc=$vpc_name" "ns_name=$ns_name"; else echo "no reports-cronjob.sh"; fi) > $HOME/reports-cronjob.log 2>&1
 
 # setup --------------------
 

--- a/files/scripts/reports-cronjob.sh
+++ b/files/scripts/reports-cronjob.sh
@@ -60,8 +60,6 @@ done
 fileName="users-${dateTime}.json"
 gen3 logs history users start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
 
-exit 1
-
 fileName="protocol-${dateTime}.json"
 gen3 logs history protocol start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
 

--- a/files/scripts/reports-cronjob.sh
+++ b/files/scripts/reports-cronjob.sh
@@ -5,6 +5,7 @@
 #
 # PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 # vpc_name=YOUR-VPC-NAME
+# ns=KUBERNETES_NAMESPACE (optional, defaults to "default")
 # USER=USER
 # KUBECONFIG=path/to/kubeconfig
 # 3   3   *   *   *    (if [ -f $HOME/cloud-automation/files/scripts/reports-cronjob.sh ]; then bash $HOME/cloud-automation/files/scripts/reports-cronjob.sh "vpc=$vpc_name"; else echo "no reports-cronjob.sh"; fi) > $HOME/reports-cronjob.log 2>&1
@@ -58,6 +59,8 @@ for service in all fence guppy indexd peregrine sheepdog; do
 done
 fileName="users-${dateTime}.json"
 gen3 logs history users start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"
+
+exit 1
 
 fileName="protocol-${dateTime}.json"
 gen3 logs history protocol start='yesterday 00:00' end='today 00:00' "$@" | tee "${fileName}"

--- a/files/scripts/reports-cronjob.sh
+++ b/files/scripts/reports-cronjob.sh
@@ -8,7 +8,7 @@
 # ns=KUBERNETES_NAMESPACE (optional, defaults to "default")
 # USER=USER
 # KUBECONFIG=path/to/kubeconfig
-# 3   3   *   *   *    (if [ -f $HOME/cloud-automation/files/scripts/reports-cronjob.sh ]; then bash $HOME/cloud-automation/files/scripts/reports-cronjob.sh "vpc=$vpc_name"; else echo "no reports-cronjob.sh"; fi) > $HOME/reports-cronjob.log 2>&1
+# 3   3   *   *   *    (if [ -f $HOME/cloud-automation/files/scripts/reports-cronjob.sh ]; then bash $HOME/cloud-automation/files/scripts/reports-cronjob.sh "vpc=$vpc_name" "ns=$ns"; else echo "no reports-cronjob.sh"; fi) > $HOME/reports-cronjob.log 2>&1
 
 # setup --------------------
 
@@ -27,7 +27,7 @@ source "${GEN3_HOME}/gen3/gen3setup.sh"
 
 help() {
   cat - <<EOM
-Use: bash ./reports-cronjob.sh vpc=YOUR_VPC_NAME
+Use: bash ./reports-cronjob.sh vpc=YOUR_VPC_NAME [ns=K8S_NAMESPACE]
 EOM
 }
 

--- a/files/scripts/reports-cronjob.sh
+++ b/files/scripts/reports-cronjob.sh
@@ -27,7 +27,7 @@ source "${GEN3_HOME}/gen3/gen3setup.sh"
 
 help() {
   cat - <<EOM
-Use: bash ./reports-cronjob.sh vpc=YOUR_VPC_NAME [ns=K8S_NAMESPACE]
+Use: bash ./reports-cronjob.sh vpc=YOUR_VPC_NAME [ns_name=K8S_NAMESPACE]
 EOM
 }
 

--- a/gen3/lib/logs/daily.sh
+++ b/gen3/lib/logs/daily.sh
@@ -7,10 +7,6 @@ GEN3_NAMESPACE="$(gen3_logs_get_arg ns "default" "$@")"
 # Get the number of unique users
 #
 gen3_logs_user_count() {
-    echo "************"
-    echo $@
-    echo "************"
-    exit 1
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {

--- a/gen3/lib/logs/daily.sh
+++ b/gen3/lib/logs/daily.sh
@@ -6,7 +6,7 @@ GEN3_AGGS_DAILY="gen3-aggs-daily"
 # Get the number of unique users
 #
 gen3_logs_user_count() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -35,7 +35,7 @@ EOM
 # HTTP response code histogram
 #
 gen3_logs_code_histogram() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs=$(cat - <<EOM
   {
@@ -61,7 +61,7 @@ EOM
 }
 
 gen3_logs_user_histogram() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -90,7 +90,7 @@ EOM
 # /ga4gh response codes
 #
 gen3_logs_ga4ghrcodes_histogram() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes | jq -r '. | del(.query.bool.must[0])')"
     local aggs="$(cat - <<EOM
   {
@@ -139,7 +139,7 @@ EOM
 # Download protocol buckets
 #
 gen3_logs_protocol_histogram() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -185,7 +185,7 @@ EOM
 # Login provider buckets
 #
 gen3_logs_loginprovider_histogram() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -255,7 +255,7 @@ oidc_aggs_output() {
 }
 
 gen3_logs_oidc_logins() {
-  local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+  local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
   local queryStr="$(gen3 logs rawq "$@" | jq -r '. | del(.query.bool.must[0])')"
   local namespace="$(cat - <<EOM
 {"term": {
@@ -309,7 +309,7 @@ EOM
 # Response time histogram
 #
 gen3_logs_rtime_histogram() {
-    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
+    local gen3_namespace="$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs=$(cat - <<EOM
   {

--- a/gen3/lib/logs/daily.sh
+++ b/gen3/lib/logs/daily.sh
@@ -1,12 +1,12 @@
 # support for: gen3 logs history daily, gen3 logs save daily
 
 GEN3_AGGS_DAILY="gen3-aggs-daily"
-GEN3_NAMESPACE="$(gen3_logs_get_arg ns "default" "$@")"
 
 #
 # Get the number of unique users
 #
 gen3_logs_user_count() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -21,7 +21,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
     )";
@@ -35,6 +35,7 @@ EOM
 # HTTP response code histogram
 #
 gen3_logs_code_histogram() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs=$(cat - <<EOM
   {
@@ -50,7 +51,7 @@ EOM
     )
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
     )";
@@ -60,6 +61,7 @@ EOM
 }
 
 gen3_logs_user_histogram() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -74,7 +76,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
     )";
@@ -88,6 +90,7 @@ EOM
 # /ga4gh response codes
 #
 gen3_logs_ga4ghrcodes_histogram() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes | jq -r '. | del(.query.bool.must[0])')"
     local aggs="$(cat - <<EOM
   {
@@ -121,7 +124,7 @@ EOM
     local namespace="$(cat - <<EOM
   {
     "term": {
-      "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+      "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
     }
   }
 EOM
@@ -136,6 +139,7 @@ EOM
 # Download protocol buckets
 #
 gen3_logs_protocol_histogram() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -151,7 +155,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
     )";
@@ -181,6 +185,7 @@ EOM
 # Login provider buckets
 #
 gen3_logs_loginprovider_histogram() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -196,7 +201,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
     )";
@@ -250,10 +255,11 @@ oidc_aggs_output() {
 }
 
 gen3_logs_oidc_logins() {
+  local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
   local queryStr="$(gen3 logs rawq "$@" | jq -r '. | del(.query.bool.must[0])')"
   local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
 )" 
@@ -303,6 +309,7 @@ EOM
 # Response time histogram
 #
 gen3_logs_rtime_histogram() {
+    local gen3_namespace = "$(gen3_logs_get_arg ns_name "default" "$@")"
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs=$(cat - <<EOM
   {
@@ -318,7 +325,7 @@ EOM
     )
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
+  "message.kubernetes.namespace_name.keyword": "$gen3_namespace"
 }}
 EOM
     )";

--- a/gen3/lib/logs/daily.sh
+++ b/gen3/lib/logs/daily.sh
@@ -1,12 +1,16 @@
 # support for: gen3 logs history daily, gen3 logs save daily
 
 GEN3_AGGS_DAILY="gen3-aggs-daily"
-
+GEN3_NAMESPACE="$(gen3_logs_get_arg ns "default" "$@")"
 
 #
 # Get the number of unique users
 #
 gen3_logs_user_count() {
+    echo "************"
+    echo $@
+    echo "************"
+    exit 1
     local queryStr="$(gen3 logs rawq "$@" aggs=yes)"
     local aggs="$(cat - <<EOM
   {
@@ -21,7 +25,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
     )";
@@ -50,7 +54,7 @@ EOM
     )
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
     )";
@@ -74,7 +78,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
     )";
@@ -121,7 +125,7 @@ EOM
     local namespace="$(cat - <<EOM
   {
     "term": {
-      "message.kubernetes.namespace_name.keyword": "default"
+      "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
     }
   }
 EOM
@@ -151,7 +155,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
     )";
@@ -196,7 +200,7 @@ EOM
     )"
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
     )";
@@ -253,7 +257,7 @@ gen3_logs_oidc_logins() {
   local queryStr="$(gen3 logs rawq "$@" | jq -r '. | del(.query.bool.must[0])')"
   local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
 )" 
@@ -318,7 +322,7 @@ EOM
     )
     local namespace="$(cat - <<EOM
 {"term": {
-  "message.kubernetes.namespace_name.keyword": "default"
+  "message.kubernetes.namespace_name.keyword": "$GEN3_NAMESPACE"
 }}
 EOM
     )";


### PR DESCRIPTION
Introduced an optional parameter "ns" to reports-cronjob to enable getting logs mapped to specific namespace. The default value is "default", which does not help capture metrics from vpc's with multiple k8s namespaces like the qa env's. 