### PR TITLE
PXP-8080 fix: disable npm notifier

### DIFF
--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -86,6 +86,10 @@ spec:
         env:
           - name: HOSTNAME
             value: revproxy-service
+          # disable npm 7's brand new update notifier to prevent Portal from stuck at starting up
+          # see https://github.com/npm/cli/issues/3163
+          - name: NPM_CONFIG_UPDATE_NOTIFIER
+            value: "false"
           - name: APP
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
Jira Ticket: [PXP-8080](https://ctds-planx.atlassian.net/browse/PXP-8080)

Disable npm 7 update notifier because it is causing Portal pods to stuck at starting up after 7 days

Doing this change in cloud-automation here so we don't need to cherry-pick for many old portal images

Will also have a PR for Portal for this fix so it can be applied to future images even if they are not being deployed using cloud-automation 

### Bug Fixes
- Disable npm 7 update notifier because it is causing Portal pods to stuck at starting up after 7 days


