### PR TITLE
Bump terraform version

### DIFF
--- a/Chef/repo/cookbooks/cdis_admin_vm/attributes/default.rb
+++ b/Chef/repo/cookbooks/cdis_admin_vm/attributes/default.rb
@@ -26,7 +26,7 @@ default["adminvm"]["remotePackages"] = {
     "exName": "helm"
   },
   "terraform12": {
-    "repo": "https://releases.hashicorp.com/terraform/0.12.24/terraform_0.12.24_linux_amd64.zip",
+    "repo": "https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip",
     "fileName": "terraform12.zip"
   },
   "packer": {

--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -100,7 +100,7 @@ RUN set -xe \
     && apt-get install -y google-chrome-stable
 
 # install terraform
-RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip \
+RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip \
    && unzip /tmp/terraform.zip -d /usr/local/bin && /bin/rm /tmp/terraform.zip
 
 # install packer

--- a/Docker/Jenkins/Dockerfile
+++ b/Docker/Jenkins/Dockerfile
@@ -100,10 +100,10 @@ RUN set -xe \
     && apt-get install -y google-chrome-stable
 
 # install terraform
-RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip \
+RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip \
    && unzip /tmp/terraform.zip -d /usr/local/bin && /bin/rm /tmp/terraform.zip
 
-RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip \
+RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip \
    && unzip /tmp/terraform.zip -d /tmp && mv /tmp/terraform /usr/local/bin/terraform12 && /bin/rm /tmp/terraform.zip
 
 # install packer

--- a/flavors/adminvm/ubuntu-18-init.sh
+++ b/flavors/adminvm/ubuntu-18-init.sh
@@ -11,7 +11,7 @@ AVAILABILITY_ZONE=$(curl http://169.254.169.254/latest/meta-data/placement/avail
 REGION=$(echo ${AVAILABILITY_ZONE::-1})
 DOCKER_DOWNLOAD_URL="https://download.docker.com/linux/ubuntu"
 AWSLOGS_DOWNLOAD_URL="https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb"
-TERRAFORM_DOWNLOAD_URL="https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip"
+TERRAFORM_DOWNLOAD_URL="https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip"
 
 HOSTNAME_BIN=$(command -v hostname)
 HOSTNAME=$(${HOSTNAME_BIN})

--- a/flavors/vpn_nlb_central/vpnvm_ubuntu18.sh
+++ b/flavors/vpn_nlb_central/vpnvm_ubuntu18.sh
@@ -13,7 +13,7 @@ PUBLIC_IPV4=$(curl -s ${MAGIC_URL}public-ipv4)
 REGION=$(echo ${AVAILABILITY_ZONE::-1})
 #DOCKER_DOWNLOAD_URL="https://download.docker.com/linux/ubuntu"
 AWSLOGS_DOWNLOAD_URL="https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb"
-#TERRAFORM_DOWNLOAD_URL="https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip"
+#TERRAFORM_DOWNLOAD_URL="https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip"
 OPENVPN_INSTALL_SCRIPT="install_ovpn_ubuntu18.sh"
 
 

--- a/gen3/bin/kube-setup-workvm.sh
+++ b/gen3/bin/kube-setup-workvm.sh
@@ -119,7 +119,7 @@ if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
   
   ( # in a subshell - install terraform
     install_terraform() {
-      curl -o "${XDG_RUNTIME_DIR}/terraform.zip" https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_amd64.zip
+      curl -o "${XDG_RUNTIME_DIR}/terraform.zip" https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip
       sudo /bin/rm -rf /usr/local/bin/terraform > /dev/null 2>&1 || true
       sudo unzip "${XDG_RUNTIME_DIR}/terraform.zip" -d /usr/local/bin;
       /bin/rm "${XDG_RUNTIME_DIR}/terraform.zip"
@@ -127,7 +127,7 @@ if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
 
     install_terraform12() {
       mkdir "${XDG_RUNTIME_DIR}/t12"
-      curl -o "${XDG_RUNTIME_DIR}/t12/terraform12.zip" https://releases.hashicorp.com/terraform/0.12.29/terraform_0.12.29_linux_amd64.zip
+      curl -o "${XDG_RUNTIME_DIR}/t12/terraform12.zip" https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_linux_amd64.zip
       sudo /bin/rm -rf /usr/local/bin/terraform12 > /dev/null 2>&1 || true
       unzip "${XDG_RUNTIME_DIR}/t12/terraform12.zip" -d "${XDG_RUNTIME_DIR}/t12";
       sudo cp "${XDG_RUNTIME_DIR}/t12/terraform" "/usr/local/bin/terraform12"
@@ -138,7 +138,7 @@ if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
       install_terraform  
     else
       TERRAFORM_VERSION=$(terraform --version | head -1 | awk '{ print $2 }' | sed 's/^[^0-9]*//')
-      if ! semver_ge "$TERRAFORM_VERSION" "0.11.14"; then
+      if ! semver_ge "$TERRAFORM_VERSION" "0.11.15"; then
         install_terraform
       fi
     fi
@@ -146,7 +146,7 @@ if sudo -n true > /dev/null 2>&1 && [[ $(uname -s) == "Linux" ]]; then
       install_terraform12  
     else
       T12_VERSION=$(terraform12 --version | head -1 | awk '{ print $2 }' | sed 's/^[^0-9]*//')
-      if ! semver_ge "$T12_VERSION" "0.12.29"; then
+      if ! semver_ge "$T12_VERSION" "0.12.31"; then
         install_terraform12
       fi
     fi


### PR DESCRIPTION
### Dependency updates
Due to a security incident Hashicorp has updated the GPG keys used to sign its releases (including providers and plugins etc) 

That's why we see cloud-automation CI runs fail on Terraform tests. 

We need to bump them to a new version that support the new keys. 

Ref: 
https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570