### PR TITLE
flag added to bypass verification of plugins at terraform init

### DIFF
--- a/gen3/bin/refresh.sh
+++ b/gen3/bin/refresh.sh
@@ -66,6 +66,6 @@ fi
 
 echo "Running terraform init ..."
 cd "$GEN3_WORKDIR"
-gen3_terraform init --backend-config ./backend.tfvars "$GEN3_TFSCRIPT_FOLDER/"
+gen3_terraform init -verify-plugins=false --backend-config ./backend.tfvars "$GEN3_TFSCRIPT_FOLDER/"
 
 exit 0

--- a/gen3/bin/workon.sh
+++ b/gen3/bin/workon.sh
@@ -157,4 +157,4 @@ EOM
 fi
 
 gen3_log_info "Running: terraform init --backend-config ./backend.tfvars $GEN3_TFSCRIPT_FOLDER/ in $(pwd)"
-gen3_terraform init --backend-config ./backend.tfvars "$GEN3_TFSCRIPT_FOLDER/"
+gen3_terraform init -verify-plugins=false --backend-config ./backend.tfvars "$GEN3_TFSCRIPT_FOLDER/"

--- a/tf_files/README.md
+++ b/tf_files/README.md
@@ -8,7 +8,7 @@ We typically run terraform from a "state folder" where a local state for a parti
 
 ```
 $ cd state/folder
-$ terraform init --backend-config ./vars1.tfvars --backend-config ./vars2.tfvars ~/Code/cloud-automation/tf_files/SUBFOLDER
+$ terraform init -verify-plugins=false --backend-config ./vars1.tfvars --backend-config ./vars2.tfvars ~/Code/cloud-automation/tf_files/SUBFOLDER
 ```
 
 * tf_files/aws - rules for resources in an AWS commons VPC


### PR DESCRIPTION
Jira Ticket: [OCC-24](https://ctds-planx.atlassian.net/browse/OCC-24)

### Issue
While using `Gen3 workon` command in new linux environment. The following errors terminated the remote s3 connection for terraform. The version of providers used in the script seemed to be the cause for it.

```
Error installing provider "archive": openpgp: signature made by unknown entity.

Error installing provider "aws": openpgp: signature made by unknown entity.

```

### Bug Fixes

to fix this bug, the flag `-verify-plugins=false` is added with terraform init in following places
- gen3/bin/workon.sh
- gen3/bin/refresh.sh

