### PR TITLE
fix(ci): Use correct class / function to pull CI environments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ library 'cdis-jenkins-lib@master'
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
 node {
-  def AVAILABLE_NAMESPACES = ciEnsPoolHelper.fetchCIEnvs()
+  def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs()
   List<String> namespaces = []
   List<String> listOfSelectedTests = []
   skipUnitTests = false


### PR DESCRIPTION
Replacing:
`ciEnsPoolHelper.fetchCIEnvs()`

With:
`ciEnvsHelper.fetchCIEnvs()`

PLEASE NOTE that to unblock / replay old PRs, you will need to visit their Replay text area and apply this fix because old PRs have already cached the original Groovy instruction.

Just visit an URL similar to:
https://jenkins.planx-pla.net/job/CDIS_GitHub_Org/job/cloud-automation/view/change-requests/job/PR-1599/4/

And click on "Replay".