### PR TITLE
chore(reliability): Bump up nginx rate limit for presigned-url-fence

### DIFF
--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -100,7 +100,7 @@ spec:
         GEN3_FENCE_IMAGE
         env:
         - name: NGINX_RATE_LIMIT
-          value: "6"
+          value: "18"
         - name: PYTHONPATH
           value: /var/www/fence
         - name: AWS_STS_REGIONAL_ENDPOINTS


### PR DESCRIPTION
Due to the improvements delivered in https://github.com/uc-cdis/fence/pull/774
We can now accommodate more Pre Signed URL requests in our fence pod.