### PR TITLE
chore(gen3-qa-worker): Add pandas to help with gen3 release date calculations

### DIFF
--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip less vim gettext-base
 RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade && python -m pip install lxml --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
-RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade
+RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade && python3 -m pip install pandas --upgrade
 
 RUN apt-get update \
   && apt-get install -y lsb-release \


### PR DESCRIPTION
Testing (determining 2nd Friday of the month):
```jenkins@jenkins-deployment-595d6846c8-8ts9g:/$ pip install pandas
Defaulting to user installation because normal site-packages is not writeable
Collecting pandas
  Downloading pandas-1.2.4-cp38-cp38-manylinux1_x86_64.whl (9.7 MB)
...
jenkins@jenkins-deployment-595d6846c8-8ts9g:/$ python3
Python 3.8.0 (default, Feb 24 2021, 16:32:42)
[GCC 6.3.0 20170516] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas as pd
>>> pd.date_range('2021-05-01','2021-05-31',freq='WOM-2FRI')
DatetimeIndex(['2021-05-14'], dtype='datetime64[ns]', freq='WOM-2FRI')
```