### PR TITLE
update the Dockerfile for jenkins-worker

### DIFF
--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -122,3 +122,4 @@ RUN DISTRO="$(lsb_release -c -s)"  \
       && rm -rf /var/lib/apt/lists/*
 
 USER jenkins
+

--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -39,8 +39,8 @@ RUN apt-get update \
 RUN sudo apt-get install -y ruby-full
 
 # install k6 to run load tests
-RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61 \
-  && echo "deb https://dl.bintray.com/loadimpact/deb stable main" | sudo tee -a /etc/apt/sources.list \
+RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69 \
+  && echo "deb https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list \
   && sudo apt-get update \
   && sudo apt-get install k6
 


### PR DESCRIPTION
Updating the installation for k6 when building the Quay Image

```
Failed to fetch https://dl.bintray.com/loadimpact/deb/dists/stable/InRelease 403 Forbidden [IP: 50.112.35.45 443]
5/22/2021, 1:06:04 AMThe repository 'https://dl.bintray.com/loadimpact/deb stable InRelease' is not signed.
```

The Root cause

<img width="720" alt="Screen Shot 2021-05-24 at 10 02 37 AM" src="https://user-images.githubusercontent.com/41084525/119367574-15a67b80-bc80-11eb-809c-36eb4eec714a.png">
