### PR TITLE
chore(load-testing): Whitelist bdcat preprod for load testing

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -62,6 +62,7 @@ ftp.usf.edu
 ftp.ussg.iu.edu
 gcr.io
 gen3.org
+gen3.biodatacatalyst.nhlbi.nih.gov
 get.helm.sh
 gist.githubusercontent.com
 git.io


### PR DESCRIPTION
running load tests from our Jenkins targeting bdcat preprod.