### PR TITLE
chore(ci-automation): Introduce new Gen3 CLI cmds to mutate k8s configmaps

### DIFF
--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source "${GEN3_HOME}/gen3/lib/utils.sh"
+gen3_load "gen3/gen3setup"
+
+set -xe
+
+# TODO: Add comment here to explain what's going on
+
+echo "hello world"
+
+prNumber=$1
+repoName=$2
+
+kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
+sed -i 's/.*name: \(.*\)_subject$/    name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml
+sed -i 's/.*name: \(.*\)_etl$/    name: '"${prNumber}"'.'"${repoName}"'.\1_etl/' etlMapping.yaml
+sed -i 's/.*name: \(.*\)_file$/    name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
+kubectl delete configmap etl-mapping
+kubectl create configmap etl-mapping --from-file=etlMapping.yaml=etlMapping.yaml

--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -5,7 +5,11 @@ gen3_load "gen3/gen3setup"
 
 set -xe
 
-# TODO: Add comment here to explain what's going on
+# script for mutating the ETLMapping.yaml on jenkins env
+# the incoming PR environment's ETLMapping.yaml is mutated to Jenkins environment
+
+# how it is executed?
+# gen3 mutate-etl-mapping-config {PR} {repoName}
 
 echo "hello world"
 

--- a/gen3/bin/mutate-guppy-config.sh
+++ b/gen3/bin/mutate-guppy-config.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source "${GEN3_HOME}/gen3/lib/utils.sh"
+gen3_load "gen3/gen3setup"
+
+set -xe
+
+# TODO: Add comment here to explain what's going on
+
+prNumber=$1
+repoName=$2
+
+kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_etl",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+kubectl delete configmap manifest-guppy
+kubectl apply -f original_guppy_config.yaml
+gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config.sh
+++ b/gen3/bin/mutate-guppy-config.sh
@@ -5,7 +5,11 @@ gen3_load "gen3/gen3setup"
 
 set -xe
 
-# TODO: Add comment here to explain what's going on
+# script for mutating the guppy configuration on jenkins env
+# the incoming PR's guppy configuration is mutated to Jenkins environment
+
+# how it is executed?
+# gen3 mutate-guppy-config {PR} {repoName}
 
 prNumber=$1
 repoName=$2


### PR DESCRIPTION
In order to facilitate some automated testing involving the Explorer page through the creation of new Elastic Search indices and point Guppy to a new ephemeral ETL'ed data, we are introducing some automation to the Gen3 CLI so we can call these commands from the integration testing script.