### PR TITLE
Fix(prod-test): Also scan s3 buckets in access check script 

### DIFF
--- a/gen3/bin/gen3qa-run.sh
+++ b/gen3/bin/gen3qa-run.sh
@@ -86,7 +86,7 @@ case "$test" in
           g3kubectl logs $(gen3 pod gen3qa-check-bucket-access) -c gen3qa-check-bucket-access -f
           echo "press ctrl+C to quit..."
           # TODO: This hack is necessary due to the nature of the Selenium sidecar
-          # CodeceptJS has a hard dependency on a running Selenium so that is the only way to run suites/google/checkAllProjectsGoogleBucketAccessTest.js
+          # CodeceptJS has a hard dependency on a running Selenium so that is the only way to run suites/prod/checkAllProjectsBucketAccessTest.js
           # We should create a selenium-standlone wrapper docker img with a proper kill switch 
 	  trap terminate_pod SIGINT
 	  sleep infinity

--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: gen3qa-check-bucket-access
-        GEN3_GEN3_QA_CONTROLLER_IMAGE|-image: quay.io/cdis/gen3-qa-controller:0.3-|
+        GEN3_GEN3_QA_CONTROLLER_IMAGE|-image: quay.io/cdis/gen3-qa-controller:0.4-|
         workingDir: /var/sdet_home
         imagePullPolicy: Always
         env:

--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -25,8 +25,8 @@ spec:
           - "-c"
           - |
             set +x
-            echo "running checkAllProjectsGoogleBucketAccessTest.js..."
-            INDEXD_FILTER=$INDEXD_QUERY_FILTER GEN3_SKIP_PROJ_SETUP=true npm test -- suites/google/checkAllProjectsGoogleBucketAccessTest.js
+            echo "running checkAllProjectsBucketAccessTest.js..."
+            INDEXD_FILTER=$INDEXD_QUERY_FILTER GEN3_SKIP_PROJ_SETUP=true npm test -- suites/prod/checkAllProjectsBucketAccessTest.js
             RC=$?
             if [[ $RC != 0 ]]; then
               echo "ERROR: non zero exit code: $?"


### PR DESCRIPTION
We should perform the bucket-access-check for both gs and s3 protocols. Not just for Google Buckets.
+ New gen3-qa-controller img version/