### PR TITLE
fix: throw errors on missing arguments and fix sed -i logic

### DIFF
--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -19,12 +19,12 @@ repoName=$1
 
 if ! shift; then
  gen3_log_err "use: mutate-etl-mapping-config prNumber repoName"
- return 1
+ exit 1
 fi
 
 kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
-sed -i 's/.*name: \(.*\)_subject$/    name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml
-sed -i 's/.*name: \(.*\)_etl$/    name: '"${prNumber}"'.'"${repoName}"'.\1_etl/' etlMapping.yaml
-sed -i 's/.*name: \(.*\)_file$/    name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
+sed -i 's/.*- name: \(.*\)_subject$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml
+sed -i 's/.*- name: \(.*\)_etl$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_etl/' etlMapping.yaml
+sed -i 's/.*- name: \(.*\)_file$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
 kubectl delete configmap etl-mapping
 kubectl create configmap etl-mapping --from-file=etlMapping.yaml=etlMapping.yaml

--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -14,7 +14,13 @@ set -xe
 echo "hello world"
 
 prNumber=$1
-repoName=$2
+shift
+repoName=$1
+
+if ! shift; then
+ gen3_log_err "use: mutate-etl-mapping-config prNumber repoName"
+ return 1
+fi
 
 kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
 sed -i 's/.*name: \(.*\)_subject$/    name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml

--- a/gen3/bin/mutate-guppy-config.sh
+++ b/gen3/bin/mutate-guppy-config.sh
@@ -12,7 +12,13 @@ set -xe
 # gen3 mutate-guppy-config {PR} {repoName}
 
 prNumber=$1
-repoName=$2
+shift
+repoName=$1
+
+if ! shift; then
+ gen3_log_err "use: mutate-guppy-config prNumber repoName"
+ return 1
+fi
 
 kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml

--- a/gen3/bin/mutate-guppy-config.sh
+++ b/gen3/bin/mutate-guppy-config.sh
@@ -17,7 +17,7 @@ repoName=$1
 
 if ! shift; then
  gen3_log_err "use: mutate-guppy-config prNumber repoName"
- return 1
+ exit 1
 fi
 
 kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml


### PR DESCRIPTION
the change will now throw out an error with correct arguments to be passed if the command is missing one of the two arguments when executing the command