### PR TITLE
fix(squid): allow anaconda.org

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -3,6 +3,7 @@
 .amazonaws.com
 .amazoncognito.com
 .anaconda.com
+.anaconda.org
 .apache.org
 .qg3.apps.qualys.com
 .archive.canonical.com


### PR DESCRIPTION
### New Features

* Add `anaconda.org` in addition to `anaconda.com` to the squid allow list