### PR TITLE
chore(observability): Remove Prometheus metrics aggregation

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/dockerrun.sh
+++ b/Docker/python-nginx/python3.6-alpine3.7/dockerrun.sh
@@ -98,46 +98,5 @@ echo "import=ddtrace.bootstrap.sitecustomize" >> /etc/uwsgi/uwsgi.ini
 ) &
 fi
 
-if [[ $GEN3_DRYRUN == "False" ]]; then
-  (
-    while true; do
-      logrotate --force /etc/logrotate.d/nginx
-      sleep 86400
-    done
-  ) &
-fi
-
-if [[ $GEN3_DRYRUN == "False" ]]; then
-  (
-    ENABLE_SVC_METRICS_SCRAPING="false"
-
-    attempt=0
-    maxAttempts=10
-
-    while true; do
-
-      curl -s http://127.0.0.1:9117/metrics > /var/www/metrics/metrics.txt
-      curl -s http://127.0.0.1:9113/metrics >> /var/www/metrics/metrics.txt
-      curl -s http://127.0.0.1:4040/metrics >> /var/www/metrics/metrics.txt
-
-      if [ $attempt -lt $maxAttempts ]; then
-        if [ "$ENABLE_SVC_METRICS_SCRAPING" == "false" ]; then      
-          service_metrics_endpoint=$(curl -L -s -o /dev/null -w "%{http_code}" -X GET http://localhost/metrics)
-
-          if [ "$service_metrics_endpoint" == 200 ]; then
-            ENABLE_SVC_METRICS_SCRAPING="true"
-          else
-            attempt=$(( $attempt + 1 ));
-          fi
-        else
-          curl -s http://127.0.0.1/metrics >> /var/www/metrics/metrics.txt
-        fi
-      fi
-
-      sleep 10
-    done
-  ) &
-fi
-
 run nginx -g 'daemon off;'
 wait


### PR DESCRIPTION
This is a 2-step process.
First we need to remove these instructions that gather all the metrics in the aggregated_metrics file
and then we disable the pod's side car containers on another PR.
Then we will successfully disable the Prometheus metrics scraping.

This PR needs to be merged first and the new base image has to be adopted by fence and indexd before we can move on to the next step.