### PR TITLE
fix(squid): remove redundant/overlapping rules

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -26,7 +26,6 @@ centos.mirrors.wvstateu.edu
 cernvm.cern.ch
 charts.helm.sh
 cloud.r-project.org
-conda.anaconda.org
 coreos.com
 covidstoplight.org
 cpan.mirrors.tds.net


### PR DESCRIPTION
Related to #1641. That PR introduced a squid bug in that `*.anaconda.org` would overlap with existing rule `cloud.anaconda.org` and resulted in failed tests https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcloud-automation/detail/PR-1641/1/pipeline/.

With the wildcard we should be fine to remove the explicit duplicate from the list.