### PR TITLE
DEVOPS-62 feat: add datadog to portal

### DIFF
--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -170,6 +170,20 @@ spec:
                 name: global
                 key: mapbox_token
                 optional: true
+          - name: DATADOG_APPLICATION_ID
+            # Optional application ID for Datadog
+            valueFrom:
+              secretKeyRef:
+                name: portal-datadog-config
+                key: datadog_application_id
+                optional: true
+          - name: DATADOG_CLIENT_TOKEN
+            # Optional client token for Datadog
+            valueFrom:
+              secretKeyRef:
+                name: portal-datadog-config
+                key: datadog_client_token
+                optional: true
         volumeMounts:
           - name: "cert-volume"
             readOnly: true


### PR DESCRIPTION
Jira Ticket: [DEVOPS-62](https://ctds-planx.atlassian.net/browse/DEVOPS-62)

Pass Datadog RUM application ID and client token into Portal. They come from a k8s secret names `portal-datadog-config`

Example for `portal-datadog-config` secret

```
apiVersion: v1
  kind: Secret
metadata:
  name: portal-datadog-config
type: Opaque
stringData:
  datadog_application_id: <MY_DD_APPLICATION_ID>
  datadog_client_token: <MY_DD_CLIENT_TOKEN>
```


### Improvements
- Pass Datadog RUM application ID and client token into Portal
