### PR TITLE
(PXP-8060): add Python3.7 Alpine Docker image with Nginx

### DIFF
--- a/Docker/python-nginx/README.md
+++ b/Docker/python-nginx/README.md
@@ -1,3 +1,5 @@
 The `python2.7-alpine3.7` image is at https://quay.io/repository/cdis/py27base
 
 The `python3.6-alpine3.7` image is at https://quay.io/repository/cdis/python-nginx
+
+The `python3.7-alpine` image is at https://quay.io/repository/cdis/python3.7-nginx

--- a/Docker/python-nginx/python3.7-alpine/Dockerfile
+++ b/Docker/python-nginx/python3.7-alpine/Dockerfile
@@ -1,0 +1,210 @@
+# Dockerfile written by Sebastian Ramirez <tiangolo@gmail.com> at https://github.com/tiangolo/uwsgi-nginx-docker
+
+FROM quay.io/cdis/python:3.7-alpine
+
+# Standard set up Nginx Alpine
+# https://github.com/nginxinc/docker-nginx/blob/f3fc4d5753f0ebb9107738183b9c5cea1bf3f618/mainline/alpine/Dockerfile
+
+ENV NGINX_VERSION 1.15.3
+
+RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
+	&& CONFIG="\
+		--prefix=/etc/nginx \
+		--sbin-path=/usr/sbin/nginx \
+		--modules-path=/usr/lib/nginx/modules \
+		--conf-path=/etc/nginx/nginx.conf \
+		--error-log-path=/var/log/nginx/error.log \
+		--http-log-path=/var/log/nginx/access.log \
+		--pid-path=/var/run/nginx.pid \
+		--lock-path=/var/run/nginx.lock \
+		--http-client-body-temp-path=/var/cache/nginx/client_temp \
+		--http-proxy-temp-path=/var/cache/nginx/proxy_temp \
+		--http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
+		--http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
+		--http-scgi-temp-path=/var/cache/nginx/scgi_temp \
+		--user=nginx \
+		--group=nginx \
+		--with-http_ssl_module \
+		--with-http_realip_module \
+		--with-http_addition_module \
+		--with-http_sub_module \
+		--with-http_dav_module \
+		--with-http_flv_module \
+		--with-http_mp4_module \
+		--with-http_gunzip_module \
+		--with-http_gzip_static_module \
+		--with-http_random_index_module \
+		--with-http_secure_link_module \
+		--with-http_stub_status_module \
+		--with-http_auth_request_module \
+		--with-http_xslt_module=dynamic \
+		--with-http_image_filter_module=dynamic \
+		--with-http_geoip_module=dynamic \
+		--with-threads \
+		--with-stream \
+		--with-stream_ssl_module \
+		--with-stream_ssl_preread_module \
+		--with-stream_realip_module \
+		--with-stream_geoip_module=dynamic \
+		--with-http_slice_module \
+		--with-mail \
+		--with-mail_ssl_module \
+		--with-compat \
+		--with-file-aio \
+		--with-http_v2_module \
+	" \
+	&& addgroup -S nginx \
+	&& adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx nginx \
+	&& apk add --no-cache --virtual .build-deps \
+		gcc \
+		libc-dev \
+		make \
+		openssl-dev \
+		pcre-dev \
+		zlib-dev \
+		linux-headers \
+		curl \
+		gnupg1 \
+		libxslt-dev \
+		gd-dev \
+		geoip-dev \
+		logrotate \
+	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz -o nginx.tar.gz \
+	&& curl -fSL https://nginx.org/download/nginx-$NGINX_VERSION.tar.gz.asc  -o nginx.tar.gz.asc \
+	# install Rust
+	&& curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.51 \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& found=''; \
+	for server in \
+		ha.pool.sks-keyservers.net \
+		hkp://keyserver.ubuntu.com:80 \
+		hkp://p80.pool.sks-keyservers.net:80 \
+		pgp.mit.edu \
+	; do \
+		echo "Fetching GPG key $GPG_KEYS from $server"; \
+		gpg --keyserver "$server" --keyserver-options timeout=10 --recv-keys "$GPG_KEYS" && found=yes && break; \
+	done; \
+	test -z "$found" && echo >&2 "error: failed to fetch GPG key $GPG_KEYS" && exit 1; \
+	gpg --batch --verify nginx.tar.gz.asc nginx.tar.gz \
+	&& rm -rf "$GNUPGHOME" nginx.tar.gz.asc \
+	&& mkdir -p /usr/src \
+	&& tar -zxC /usr/src -f nginx.tar.gz \
+	&& rm nginx.tar.gz \
+	&& cd /usr/src/nginx-$NGINX_VERSION \
+	&& ./configure $CONFIG --with-debug \
+	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& mv objs/nginx objs/nginx-debug \
+	&& mv objs/ngx_http_xslt_filter_module.so objs/ngx_http_xslt_filter_module-debug.so \
+	&& mv objs/ngx_http_image_filter_module.so objs/ngx_http_image_filter_module-debug.so \
+	&& mv objs/ngx_http_geoip_module.so objs/ngx_http_geoip_module-debug.so \
+	&& mv objs/ngx_stream_geoip_module.so objs/ngx_stream_geoip_module-debug.so \
+	&& ./configure $CONFIG \
+	&& make -j$(getconf _NPROCESSORS_ONLN) \
+	&& make install \
+	&& rm -rf /etc/nginx/html/ \
+	&& mkdir /etc/nginx/conf.d/ \
+	&& mkdir -p /usr/share/nginx/html/ \
+	&& install -m644 html/index.html /usr/share/nginx/html/ \
+	&& install -m644 html/50x.html /usr/share/nginx/html/ \
+	&& install -m755 objs/nginx-debug /usr/sbin/nginx-debug \
+	&& install -m755 objs/ngx_http_xslt_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_xslt_filter_module-debug.so \
+	&& install -m755 objs/ngx_http_image_filter_module-debug.so /usr/lib/nginx/modules/ngx_http_image_filter_module-debug.so \
+	&& install -m755 objs/ngx_http_geoip_module-debug.so /usr/lib/nginx/modules/ngx_http_geoip_module-debug.so \
+	&& install -m755 objs/ngx_stream_geoip_module-debug.so /usr/lib/nginx/modules/ngx_stream_geoip_module-debug.so \
+	&& ln -s ../../usr/lib/nginx/modules /etc/nginx/modules \
+	&& strip /usr/sbin/nginx* \
+	&& strip /usr/lib/nginx/modules/*.so \
+	&& rm -rf /usr/src/nginx-$NGINX_VERSION \
+	\
+	# Bring in gettext so we can get `envsubst`, then throw
+	# the rest away. To do this, we need to install `gettext`
+	# then move `envsubst` out of the way so `gettext` can
+	# be deleted completely, then move `envsubst` back.
+	&& apk add --no-cache --virtual .gettext gettext \
+	&& mv /usr/bin/envsubst /tmp/ \
+	\
+	&& runDeps="$( \
+		scanelf --needed --nobanner --format '%n#p' /usr/sbin/nginx /usr/lib/nginx/modules/*.so /tmp/envsubst \
+			| tr ',' '\n' \
+			| sort -u \
+			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+	)" \
+	&& apk add --no-cache --virtual .nginx-rundeps $runDeps \
+	&& apk del .gettext \
+	&& mv /tmp/envsubst /usr/local/bin/ \
+	\
+	# Bring in tzdata so users could set the timezones through the environment
+	# variables
+	&& apk add --no-cache tzdata \
+	\
+	# forward request and error logs to docker log collector
+	&& ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY uwsgi.conf /etc/nginx/sites-available/
+
+# Standard set up Nginx finished
+
+EXPOSE 80
+
+
+# # Expose 443, in case of LTS / HTTPS
+EXPOSE 443
+
+# Install uWSGI
+RUN apk add pcre pcre-dev \
+	&& python -m pip install --upgrade pip \
+	&& pip install uwsgi --no-cache-dir \
+	&& apk del .build-deps
+
+# Copy the base uWSGI ini file to enable default dynamic uwsgi process number
+COPY uwsgi.ini /etc/uwsgi/
+RUN ln -s /etc/nginx/sites-available/uwsgi.conf /etc/nginx/conf.d/uwsgi.conf
+
+# Install Supervisord
+RUN apk add --no-cache supervisor
+# Custom Supervisord config
+COPY supervisord.ini /etc/supervisor.d/supervisord.ini
+
+# Which uWSGI .ini file should be used, to make it customizable
+ENV UWSGI_INI /app/uwsgi.ini
+
+# By default, disable uwsgi cheaper mode and run 2 processes.
+# If UWSGI_CHEAPER=N and UWSGI_PROCESSES=M, N is the min and M is the max
+# number of processes. UWSGI_CHEAPER must be lower than UWSGI_PROCESSES.
+# We set them here instead of in uwsgi.ini so that they can be overwritten.
+ENV UWSGI_CHEAPER=
+ENV UWSGI_PROCESSES=2
+
+# By default, allow unlimited file sizes, modify it to limit the file sizes
+# To have a maximum of 1 MB (Nginx's default) change the line to:
+ENV NGINX_MAX_UPLOAD 1m
+ENV NGINX_MAX_UPLOAD 0
+
+# By default, Nginx will run a single worker process, setting it to auto
+# will create a worker for each CPU core
+ENV NGINX_WORKER_PROCESSES 1
+
+# By default, Nginx listens on port 80.
+# To modify this, change LISTEN_PORT environment variable.
+# (in a Dockerfile or with an option for `docker run`)
+ENV LISTEN_PORT 80
+
+# Copy the entrypoint that will generate Nginx additional configs
+COPY entrypoint.sh /entrypoint.sh
+COPY logrotate-nginx.conf /etc/logrotate.d/nginx
+RUN chmod +x /entrypoint.sh
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+COPY dockerrun.sh /dockerrun.sh
+RUN mkdir -p /var/www/metrics/ && chmod +x /dockerrun.sh
+
+ENTRYPOINT ["sh", "/entrypoint.sh"]
+
+# Add demo app
+COPY ./app /app
+WORKDIR /app
+
+CMD ["/usr/bin/supervisord"]

--- a/Docker/python-nginx/python3.7-alpine/app/main.py
+++ b/Docker/python-nginx/python3.7-alpine/app/main.py
@@ -1,0 +1,4 @@
+def application(env, start_response):
+    start_response('200 OK', [('Content-Type', 'text/html')])
+    return [b"Hello World from a default Nginx uWSGI Python 3.6 app in a\
+            Docker container (default)"]

--- a/Docker/python-nginx/python3.7-alpine/app/main.py
+++ b/Docker/python-nginx/python3.7-alpine/app/main.py
@@ -1,4 +1,4 @@
 def application(env, start_response):
     start_response('200 OK', [('Content-Type', 'text/html')])
-    return [b"Hello World from a default Nginx uWSGI Python 3.6 app in a\
+    return [b"Hello World from a default Nginx uWSGI Python 3.7 app in a\
             Docker container (default)"]

--- a/Docker/python-nginx/python3.7-alpine/app/uwsgi.ini
+++ b/Docker/python-nginx/python3.7-alpine/app/uwsgi.ini
@@ -1,0 +1,2 @@
+[uwsgi]
+wsgi-file=/app/main.py

--- a/Docker/python-nginx/python3.7-alpine/dockerrun.sh
+++ b/Docker/python-nginx/python3.7-alpine/dockerrun.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+#
+# Note: base alpine Linux image may not include bash shell,
+#    and we probably want to move to that for service images,
+#    so just use bourn shell ...
+
+#
+# Update certificate authority index -
+# environment may have mounted more authorities
+# - ex: /usr/local/share/ca-certificates/cdis-ca.crt into system bundle       
+#
+
+GEN3_DEBUG="${GEN3_DEBUG:-False}"
+GEN3_DRYRUN="${GEN3_DRYRUN:-False}"
+GEN3_UWSGI_TIMEOUT="${GEN3_UWSGI_TIMEOUT:-45s}"
+
+run() {
+  if [ "$GEN3_DRYRUN" = True ]; then
+    echo "DRY RUN - not running: $@"
+  else
+    echo "Running $@"
+    "$@"
+  fi
+}
+
+help() {
+    cat - <<EOM
+Gen3 base (generic) launch script
+Use: 
+  dockkerrun.bash [--help] [--debug=False] [--uwsgiTimeout=45s] [--dryrun=False]
+EOM
+}
+
+
+while [ $# -gt 0 ]; do
+  arg="$1"
+  shift
+  key=""
+  value=""
+  key="$(echo "$arg" | sed -e 's/^-*//' | sed -e 's/=.*$//')"
+  value="$(echo "$arg" | sed -e 's/^.*=//')"
+
+  if [ "$value" = "$arg" ]; then # =value not given, so use default
+    value=""
+  fi
+  case "$key" in
+  debug)
+    GEN3_DEBUG="${value:-True}"
+    ;;
+  uwsgiTimeout)
+    GEN3_UWSGI_TIMEOUT="${value:-45s}"
+    ;;
+  dryrun)
+    GEN3_DRYRUN="${value:-True}"
+    ;;
+  help)
+    help
+    exit 0
+    ;;
+  *)
+    echo "ERROR: unknown argument $arg - bailing out"
+    exit 1
+    ;;
+  esac
+done
+
+cat - <<EOM
+Got configuration:
+GEN3_DEBUG=$GEN3_DEBUG
+GEN3_UWSGI_TIMEOUT=$GEN3_UWSGI_TIMEOUT
+GEN3_DRYRUN=$GEN3_DRYRUN
+EOM
+
+run update-ca-certificates
+run mkdir -p /var/run/gen3
+
+# fill in timeout in the uwsgi.conf template
+if [ -f /etc/nginx/sites-available/uwsgi.conf ]; then
+  sed -i -e "s/GEN3_UWSGI_TIMEOUT/$GEN3_UWSGI_TIMEOUT/g" /etc/nginx/sites-available/uwsgi.conf
+fi
+
+#
+# Enable debug flag based on GEN3_DEBUG environment
+#
+if [ -f ./wsgi.py ] && [ "$GEN3_DEBUG" = "True" ]; then
+  echo -e "\napplication.debug=True\n" >> ./wsgi.py
+fi
+
+if [[ -z $DD_ENABLED ]]; then
+(
+  run uwsgi --ini /etc/uwsgi/uwsgi.ini
+) &
+else
+pip install ddtrace
+echo "import=ddtrace.bootstrap.sitecustomize" >> /etc/uwsgi/uwsgi.ini
+(
+  ddtrace-run uwsgi --enable-threads --ini /etc/uwsgi/uwsgi.ini
+) &
+fi
+
+run nginx -g 'daemon off;'
+wait

--- a/Docker/python-nginx/python3.7-alpine/entrypoint.sh
+++ b/Docker/python-nginx/python3.7-alpine/entrypoint.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+set -e
+
+rate_limit=""
+if [ ! -z $NGINX_RATE_LIMIT ]; then
+  echo "Found NGINX_RATE_LIMIT environment variable..."
+  if [ ! -z $OVERRIDE_NGINX_RATE_LIMIT ]; then
+    rate_limit=$OVERRIDE_NGINX_RATE_LIMIT
+    echo "Overriding Nginx rate limit with new value ${rate_limit}..."
+  else
+    rate_limit=$NGINX_RATE_LIMIT
+    echo "Applying Nginx rate limit from k8s deployment descriptor..."
+  fi
+
+  # Add rate_limit config
+  rate_limit_conf="\ \ \ \ limit_req_zone \$binary_remote_addr zone=one:10m rate=${rate_limit}r/s;"
+  sed -i "/http\ {/a ${rate_limit_conf}" /etc/nginx/nginx.conf
+  if [ -f /etc/nginx/sites-available/uwsgi.conf ]; then
+    limit_req_config="\ \ \ \ \ \ \ \ limit_req zone=one;"
+    sed -i "/location\ \/\ {/a ${limit_req_config}" /etc/nginx/sites-available/uwsgi.conf
+  fi
+fi
+
+# Get the maximum upload file size for Nginx, default to 0: unlimited
+USE_NGINX_MAX_UPLOAD=${NGINX_MAX_UPLOAD:-0}
+# Generate Nginx config for maximum upload file size
+echo "client_max_body_size $USE_NGINX_MAX_UPLOAD;" > /etc/nginx/conf.d/upload.conf
+
+# Explicitly add installed Python packages and uWSGI Python packages to PYTHONPATH
+# Otherwise uWSGI can't import Flask
+export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python3.6/site-packages:/usr/lib/python3.6/site-packages
+
+# Get the number of workers for Nginx, default to 1
+USE_NGINX_WORKER_PROCESSES=${NGINX_WORKER_PROCESSES:-1}
+# Modify the number of worker processes in Nginx config
+sed -i "/worker_processes\s/c\worker_processes ${USE_NGINX_WORKER_PROCESSES};" /etc/nginx/nginx.conf
+
+# Set the max number of connections per worker for Nginx, if requested
+# Cannot exceed worker_rlimit_nofile, see NGINX_WORKER_OPEN_FILES below
+if [ -n "$NGINX_WORKER_CONNECTIONS" ] ; then
+    sed -i "/worker_connections\s/c\    worker_connections ${NGINX_WORKER_CONNECTIONS};" /etc/nginx/nginx.conf
+fi
+
+# Set the max number of open file descriptors for Nginx workers, if requested
+if [ -n "$NGINX_WORKER_OPEN_FILES" ] ; then
+    echo "worker_rlimit_nofile ${NGINX_WORKER_OPEN_FILES};" >> /etc/nginx/nginx.conf
+fi
+
+# Get the listen port for Nginx, default to 80
+USE_LISTEN_PORT=${LISTEN_PORT:-80}
+# Modify Nignx config for listen port
+if ! grep -q "listen ${USE_LISTEN_PORT};" /etc/nginx/nginx.conf ; then
+    sed -i -e "/server {/a\    listen ${USE_LISTEN_PORT};" /etc/nginx/nginx.conf
+fi
+exec "$@"

--- a/Docker/python-nginx/python3.7-alpine/logrotate-nginx.conf
+++ b/Docker/python-nginx/python3.7-alpine/logrotate-nginx.conf
@@ -1,0 +1,9 @@
+# nginx log rotation
+/var/log/nginx {
+    weekly
+    size 10M
+    postrotate
+        [ ! -f /var/run/nginx.pid ] || kill -USR1 `cat /var/run/nginx.pid`
+    endscript
+    rotate 5
+}

--- a/Docker/python-nginx/python3.7-alpine/nginx.conf
+++ b/Docker/python-nginx/python3.7-alpine/nginx.conf
@@ -1,0 +1,53 @@
+user  nginx;
+worker_processes  1;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+  	##
+	  # Logging Settings
+	  ##
+    log_format json '{"gen3log": "nginx", '
+          '"date_access": "$time_iso8601", '
+          '"user_id": "$http_x_userid", '
+          '"request_id": "$http_x_reqid", '
+          '"session_id": "$http_x_sessionid", '
+          '"visitor_id": "$http_x_visitorid", '
+          '"network_client_ip": "$http_x_forwarded_for", '
+          '"network_bytes_write": $body_bytes_sent, '
+          '"response_secs": $request_time, '
+          '"http_status_code": $status, '
+          '"http_request": "$request_uri", '
+          '"http_verb": "$request_method", '
+          '"http_referer": "$http_referer", '
+          '"http_useragent": "$http_user_agent", '
+          '"message": "$request"}';
+
+    access_log  /dev/stdout  json;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access_not_json.log main;
+    access_log  /var/log/nginx/access.log  json;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/Docker/python-nginx/python3.7-alpine/supervisord.ini
+++ b/Docker/python-nginx/python3.7-alpine/supervisord.ini
@@ -1,0 +1,18 @@
+[supervisord]
+nodaemon=true
+
+[program:uwsgi]
+command=uwsgi --ini /etc/uwsgi/uwsgi.ini --die-on-term --need-app
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:nginx]
+command=/usr/sbin/nginx
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+# Graceful stop, see http://nginx.org/en/docs/control.html
+stopsignal=QUIT

--- a/Docker/python-nginx/python3.7-alpine/uwsgi.conf
+++ b/Docker/python-nginx/python3.7-alpine/uwsgi.conf
@@ -1,0 +1,66 @@
+server {
+    listen       6567;
+
+    root /var/www/metrics;
+
+    location /aggregated_metrics {
+        types {}
+        default_type text/plain;
+        try_files $uri $uri/ /metrics.txt;
+        autoindex on;
+        access_log off;
+    }
+}
+
+server {
+    listen 80;
+
+    location / {
+        uwsgi_param REMOTE_ADDR $http_x_forwarded_for if_not_empty;
+        uwsgi_param REMOTE_USER $http_x_userid if_not_empty;
+        uwsgi_param REMOTE_REQID $http_x_reqid if_not_empty;
+        uwsgi_param REMOTE_SESSIONID $http_x_sessionid if_not_empty;
+        uwsgi_param REMOTE_VISITORID $http_x_visitorid if_not_empty;
+        uwsgi_param GEN3_REQUEST_TIMESTAMP $msec;
+        uwsgi_param GEN3_TIMEOUT_SECONDS GEN3_UWSGI_TIMEOUT;
+
+        include uwsgi_params;
+        uwsgi_pass unix:/var/run/gen3/uwsgi.sock;
+        uwsgi_read_timeout GEN3_UWSGI_TIMEOUT;
+        uwsgi_send_timeout GEN3_UWSGI_TIMEOUT;
+    }
+
+    location /_status {
+        include uwsgi_params;
+        uwsgi_pass unix:/var/run/gen3/uwsgi.sock;
+        uwsgi_param GEN3_REQUEST_TIMESTAMP $msec;
+        uwsgi_param GEN3_TIMEOUT_SECONDS GEN3_UWSGI_TIMEOUT;
+        uwsgi_read_timeout GEN3_UWSGI_TIMEOUT;
+        uwsgi_ignore_client_abort on;
+        access_log off;
+    }
+
+    location /nginx_status {
+        stub_status;
+        allow 127.0.0.1;
+        deny all;
+        access_log off;
+    }
+
+    location /uwsgi_status {
+        proxy_pass "http://127.0.0.1:9191";
+        allow 127.0.0.1;
+        deny all;
+        access_log off;
+    }
+
+    error_page 502 /502.html;
+    location /502.html {
+        return 504 '{"error": "Request Timeout or Service Unavailable"}';
+    }
+
+    error_page 504 /504.html;
+    location /504.html {
+        return 504 '{"error": "Request Timeout"}';
+    }
+}

--- a/Docker/python-nginx/python3.7-alpine/uwsgi.ini
+++ b/Docker/python-nginx/python3.7-alpine/uwsgi.ini
@@ -1,0 +1,6 @@
+[uwsgi]
+socket = /tmp/uwsgi.sock
+chown-socket = nginx:nginx
+chmod-socket = 664
+# Graceful shutdown on SIGTERM, see https://github.com/unbit/uwsgi/issues/849#issuecomment-118869386
+hook-master-start = unix_signal:15 gracefully_kill_them_all

--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -31,7 +31,7 @@ location = /gen3-authz {
 # authorization endpoint
 # https://hostname/authz?resource=programs/blah&method=acb&service=xyz
 #
-location ~ /authz/? {
+location = /authz/? {
     if ($csrf_check !~ ^ok-\S.+$) {
         return 403 "failed csrf check";
     }

--- a/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/arborist-service.conf
@@ -31,7 +31,7 @@ location = /gen3-authz {
 # authorization endpoint
 # https://hostname/authz?resource=programs/blah&method=acb&service=xyz
 #
-location = /authz/? {
+location ~ /authz/? {
     if ($csrf_check !~ ^ok-\S.+$) {
         return 403 "failed csrf check";
     }


### PR DESCRIPTION
Jira Ticket: [PXP-8060](https://ctds-planx.atlassian.net/browse/PXP-8060)

The `/aggregate/{endpoint}` [endpoint in the Workspace Token Service](https://github.com/uc-cdis/workspace-token-service/pull/36) requires Python 3.7. To support this change, this PR adds a Python 3.7 Docker image.

### New Features
- add Python 3.7 Alphine Docker image with Nginx
