### PR TITLE
chore(k8sReset-debugging): Capture logs from pods in CreateContainerConfigError state

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -356,12 +356,12 @@ node {
     stage('Post') {
       kubeHelper.teardown(kubeLocks)
       testHelper.teardown(doNotRunTests)
+      pipelineHelper.teardown(currentBuild.result)
       if(!skipUnitTests) {
         // tear down network policies deployed by the tests
         kubeHelper.kube(kubectlNamespace, {
           sh(script: 'kubectl --namespace="' + kubectlNamespace + '" delete networkpolicies --all', returnStatus: true);
         });
-        pipelineHelper.teardown(currentBuild.result)
       }
     }
   }

--- a/gen3/bin/save-failed-pod-logs.sh
+++ b/gen3/bin/save-failed-pod-logs.sh
@@ -20,9 +20,9 @@ EOM
 gen3_log_info "capturing and archiving logs from failed pods (if any)..."
 
 # image pull errors
-array_of_img_pull_errors=($(g3kubectl get pods | grep -E "ErrImagePull|ImagePullBackOff" | xargs -I {} echo {} | awk '{ print $1 }' | tr "\n" " "))
+array_of_img_pull_errors=($(g3kubectl get pods | grep -E "ErrImagePull|ImagePullBackOff|CreateContainerConfigError" | xargs -I {} echo {} | awk '{ print $1 }' | tr "\n" " "))
 
-gen3_log_info "looking for pods with ErrImagePull or ImagePullBackOff..."
+gen3_log_info "looking for pods with ErrImagePull, ImagePullBackOff or CreateContainerConfigError..."
 
 for pod in "${array_of_img_pull_errors[@]}"; do
   pod_name=$(echo $pod | xargs)


### PR DESCRIPTION
We are facing issues with:
```
mariner-deployment-75897674bc-shc4x              0/1     CreateContainerConfigError   0          2m23s
```
Hence, we should add this pod status to the log-capturing logic so we can debug it before the crime scene is wiped out by subsequent PR checks.