### PR TITLE
chore(ci): Introduce special label to run PR check on separate jenkins-ci-worker pod

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,24 @@ library 'cdis-jenkins-lib@master'
 
 import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 
-node {
+// check if PR contains a label to define where the PR check must run
+// giving a chance for auto-label gh actions to catch up
+sleep(30)
+def prLabels = githubHelper.fetchLabels()
+def pipeConfig = pipelineHelper.setupConfig([:])
+
+def runOnGen3CIWorker = false;
+if (prLabels.any{label -> label.name == "run-on-jenkins-ci-worker"}) {
+  println('Found [run-on-jenkins-ci-worker] label, running CI on ci worker pod...')
+  runOnGen3CIWorker = true
+}
+// if this is a Manifests repo, run on separate jenkins worker pod
+// this is overridable by the 'run-on-jenkins-ci-worker' PR label
+if (pipeConfig.MANIFEST == "True") {
+  runOnGen3CIWorker = true
+}
+
+node(runOnGen3CIWorker? 'gen3-ci-worker' : 'master') {
   List<String> namespaces = []
   List<String> listOfSelectedTests = []
   skipUnitTests = false
@@ -14,10 +31,9 @@ node {
   kubectlNamespace = null
   kubeLocks = []
   testedEnv = "" // for manifest pipeline
-  pipeConfig = pipelineHelper.setupConfig([:])
-  def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(pipeConfig.MANIFEST)
+
+  def AVAILABLE_NAMESPACES = ciEnvsHelper.fetchCIEnvs(runOnGen3CIWorker)
   pipelineHelper.cancelPreviousRunningBuilds()
-  prLabels = githubHelper.fetchLabels()
 
   try {
     stage('CleanWorkspace') {


### PR DESCRIPTION
If we suspect jenkins-master is overwhelmed, we can send PR check jobs to this jenkins-ci-worker pod.