### PR TITLE
chore(ci): Introduce cli commands to mutate guppy config for CI purposes

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+source "${GEN3_HOME}/gen3/lib/utils.sh"
+gen3_load "gen3/gen3setup"
+
+set -xe
+
+# script for mutating the guppy configuration on jenkins env
+# This will configure the pre-defined Canine ETL'ed data against Guppy
+
+# how to run:
+# gen3 mutate-guppy-config-for-guppy-test
+
+kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "jenkins_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_array-config",/' original_guppy_config.yaml
+kubectl delete configmap manifest-guppy
+kubectl apply -f original_guppy_config.yaml
+gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -12,9 +12,9 @@ set -xe
 # gen3 mutate-guppy-config-for-guppy-test
 
 kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "jenkins_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_array-config",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_config_alias",/' original_guppy_config.yaml
 kubectl delete configmap manifest-guppy
 kubectl apply -f original_guppy_config.yaml
 gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+source "${GEN3_HOME}/gen3/lib/utils.sh"
+gen3_load "gen3/gen3setup"
+
+set -xe
+
+# script for mutating the guppy configuration on jenkins env
+# the incoming PR's guppy configuration is mutated to Jenkins environment
+
+# how to run:
+# gen3 mutate-guppy-config-for-pfb-export-test {PR} {repoName}
+
+prNumber=$1
+shift
+repoName=$1
+
+if ! shift; then
+ gen3_log_err "use: mutate-guppy-config prNumber repoName"
+ exit 1
+fi
+
+kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_etl",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+kubectl delete configmap manifest-guppy
+kubectl apply -f original_guppy_config.yaml
+gen3 roll guppy


### PR DESCRIPTION
We need to be able to mutate the guppy config in our CI environments for 2 test flows:
 - DYNAMIC data to test the end-to-end flow of the Export to PFB and Export to Workspace features.
 - PREDEFINED data to test Guppy queries based on Queries and Expected Responses (based on Canine DD -- ES index pre-hydrated).

These two utility scripts will be instrumented by gen3-qa tests to help us mutate the k8s configmap to achieve both scenarios. 