### PR TITLE
fix(ci): Fix Guppy mutation script again

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -12,8 +12,8 @@ set -xe
 # gen3 mutate-guppy-config-for-guppy-test
 
 g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_config_alias",/' original_guppy_config.yaml
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml


### PR DESCRIPTION
The correct names for the aliases are:
```
  "guppy": {
    "indices": [
      {
        "index": "jenkins_subject_alias",
        "type": "subject"
      },
      {
        "index": "jenkins_file_alias",
        "type": "file"
      },
```