### PR TITLE
fix(ci): Fix Guppy mutation script again (again)

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -14,7 +14,7 @@ set -xe
 g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_config_alias",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_configs_alias",/' original_guppy_config.yaml
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml
 gen3 roll guppy


### PR DESCRIPTION
Fix this issue:
```
[17:16:07] INFO: [ES.initialize] getting array fields from es config index "jenkins_config_alias"...
(node:6) UnhandledPromiseRejectionWarning: Error: index_not_found_exception
```