### PR TITLE
chore(ci-reliability): Prevent CI infra from being torn down by autoscaler

### DIFF
--- a/kube/services/jenkins-ci-worker/jenkins-worker-ci-deployment.yaml
+++ b/kube/services/jenkins-ci-worker/jenkins-worker-ci-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: false
   name: jenkins-ci-worker-deployment
 spec:
   selector:

--- a/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
+++ b/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: false
   name: jenkins-worker-deployment
 spec:
   selector:

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: false
   name: jenkins-deployment
 spec:
   selector:

--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: false
   labels:
     app: selenium-hub
   name: selenium-hub

--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -1,6 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    cluster-autoscaler.kubernetes.io/safe-to-evict: false
   labels:
     app: selenium-node-chrome
   name: selenium-node-chrome


### PR DESCRIPTION
This should prevent this:
```
$ kc get events | grep jenkins | grep -i down
11m         Normal    ScaleDown                                                                                      pod/jenkins-deployment-7d4b7f848-7pjl5                 deleting pod for node scale down
qaplanetv1@cdistest_dev_admin:~$
```