### PR TITLE
fix(ci): Reset fence-config secret on every k8sReset operation

### DIFF
--- a/gen3/bin/reset.sh
+++ b/gen3/bin/reset.sh
@@ -141,6 +141,9 @@ g3kubectl delete configmap fence
 g3kubectl create configmap fence "--from-file=user.yaml=$useryaml"
 /bin/rm "$useryaml"
 
+# Recreate fence-config k8s secret on every CI run
+gen3 kube-setup-secrets
+
 #
 # various weird race conditions
 # where these setup jobs setup part of a service


### PR DESCRIPTION
If a PR is interrupted abruptly, this is never called:
```
AfterSuite(async ({ auditService }) => {
  await auditService.do.configureFenceAuditLogging(false); // disable
```
source: https://github.com/uc-cdis/gen3-qa/blob/e9177b0f48fe229f3df4f9c6c698ca2c8736c448/suites/apis/auditServiceTest.js#L52

Therefore we must make sure the `fence-config` k8s secret is refreshed based on its local vm files at the very beginning of each CI run.