### PR TITLE
chore(update-ruby-version): Ruby 2.5 will be EOL 7/30, updating to la…

### DIFF
--- a/tf_files/aws/modules/alarms-lambda/lambda.tf
+++ b/tf_files/aws/modules/alarms-lambda/lambda.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_function" "lambda" {
   function_name    = "cloudwatch-lambda-${var.vpc_name}"
   role             = "${aws_iam_role.lambda_role.arn}"
   handler          = "lambda_function.processMessage"
-  runtime          = "ruby2.5"
+  runtime          = "ruby2.7"
   source_code_hash = "${data.archive_file.cloudwatch_lambda.output_base64sha256}"
   environment {
     variables = {


### PR DESCRIPTION
…test tested ruby version to prevent deprecation

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates
Ruby 2.5 will be EOL 7/30, updating to latest tested ruby version to prevent deprecation

### Deployment changes
