### PR TITLE
Fix/guppy config mutation

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -15,6 +15,12 @@ g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_configs_alias",/' original_guppy_config.yaml
+
+# mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
+sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml
 gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -16,7 +16,7 @@ sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' or
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_configs_alias",/' original_guppy_config.yaml
 
-# mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
+# mutating back to expected canine config in case this runs after pfb export test
 sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml

--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -16,11 +16,6 @@ sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' or
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_configs_alias",/' original_guppy_config.yaml
 
-# mutating back to expected canine config in case this runs after pfb export test
-sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
-
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml
 gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -20,17 +20,22 @@ if ! shift; then
  exit 1
 fi
 
+# capture the names from the ETL mapping
+etl_mapping_subject=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[0].name)
+etl_mapping_file=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[1].name)
+etl_config=$(echo $etl_mapping_subject | sed 's/\(.*\)_etl/\1_array-config/')
+
 g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
 # mutating permanent jenkins config
-sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_etl",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${etl_mapping_subject}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "'"${etl_mapping_subject}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${etl_mapping_file}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${etl_config}"'",/' original_guppy_config.yaml
 
 # mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
-sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.'"${NAMESPACE}"'_subject",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.'"${NAMESPACE}"'_file",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.'"${NAMESPACE}"'_array-config",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${etl_mapping_subject}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${etl_mapping_file}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${etl_config}"'",/' original_guppy_config.yaml
 
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -21,10 +21,17 @@ if ! shift; then
 fi
 
 g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
+# mutating permanent jenkins config
 sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_etl",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+
+# mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
+sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml
 gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -28,9 +28,9 @@ sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${prNumber}"'.'"${repoNam
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
 
 # mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
-sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_subject",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.\2_file",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.\2_array-config",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.'"${NAMESPACE}"'_subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${prNumber}"'.'"${repoName}"'.'"${NAMESPACE}"'_file",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${prNumber}"'.'"${repoName}"'.'"${NAMESPACE}"'_array-config",/' original_guppy_config.yaml
 
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml


### PR DESCRIPTION
When jenkins environments are mutated based on artifacts from other environments, the guppy config in the manifest might still have the pre-defined canine indices, hence we should mutate them as well.