### PR TITLE
fix(ci): Mutate manifest-guppy cm properly

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -21,21 +21,25 @@ if ! shift; then
 fi
 
 # capture the names from the ETL mapping
+echo "debugging"
 etl_mapping_subject=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[0].name)
+echo "### ## etl_mapping_subject: ${etl_mapping_subject}"
 etl_mapping_file=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[1].name)
+echo "echo "### ## etl_mapping_file: ${etl_mapping_file}"
 etl_config=$(echo $etl_mapping_subject | sed 's/\(.*\)_etl/\1_array-config/')
+echo "### ## etl_config: ${etl_config}"
 
 g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
 # mutating permanent jenkins config
-sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": "'"${etl_mapping_subject}"'",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "'"${etl_mapping_subject}"'",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "'"${etl_mapping_file}"'",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${etl_config}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": '"${etl_mapping_file}"',/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": '"${etl_config}"',/' original_guppy_config.yaml
 
 # mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
-sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": "'"${etl_mapping_subject}"'",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": "'"${etl_mapping_file}"'",/' original_guppy_config.yaml
-sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${etl_config}"'",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
+sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": '"${etl_mapping_file}"',/' original_guppy_config.yaml
+sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": '"${etl_config}"',/' original_guppy_config.yaml
 
 g3kubectl delete configmap manifest-guppy
 g3kubectl apply -f original_guppy_config.yaml


### PR DESCRIPTION
The configuration is ending up with more double-quotation marks than we actually need.
e.g.,
```
    {
      "indices": [
        {
          "index": ""1520.gitops-qa.qa-dcp_subject"",
          "type": "subject"
        },
        {
          "index": ""1520.gitops-qa.qa-dcp_file"",
          "type": "file"
        }
      ],
      "config_index": ""1520.gitops-qa.qa-dcp_file-array-config"",
      "auth_filter_field": "auth_resource_path"
    }
```