### PR TITLE
chore(ci-reliability): Set cluster-autoscaler.kubernetes.io/safe-to-evict correctly

### DIFF
--- a/kube/services/jenkins-ci-worker/jenkins-worker-ci-deployment.yaml
+++ b/kube/services/jenkins-ci-worker/jenkins-worker-ci-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   name: jenkins-ci-worker-deployment
 spec:
   selector:
@@ -15,6 +13,8 @@ spec:
         app: jenkins-ci-worker
         # for network policy
         netnolimit: "yes"
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     spec:
       serviceAccountName: jenkins-service
       securityContext:

--- a/kube/services/jenkins-ci-worker/jenkins-worker-ci-deployment.yaml
+++ b/kube/services/jenkins-ci-worker/jenkins-worker-ci-deployment.yaml
@@ -103,8 +103,8 @@ spec:
                 key: google_app_creds.json
         resources:
           limits:
-            cpu: 0.6
-            memory: 2048Mi
+            cpu: 0.9
+            memory: 4096Mi
         imagePullPolicy: Always
         volumeMounts:
         - name: "cert-volume"

--- a/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
+++ b/kube/services/jenkins-worker/jenkins-worker-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   name: jenkins-worker-deployment
 spec:
   selector:
@@ -15,6 +13,8 @@ spec:
         app: jenkins-worker
         # for network policy
         netnolimit: "yes"
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     spec:
       serviceAccountName: jenkins-service
       securityContext:

--- a/kube/services/jenkins/jenkins-deploy.yaml
+++ b/kube/services/jenkins/jenkins-deploy.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   name: jenkins-deployment
 spec:
   selector:
@@ -23,6 +21,8 @@ spec:
         # for network policy
         netnolimit: "yes"
         GEN3_DATE_LABEL
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     spec:
       serviceAccountName: jenkins-service
       securityContext:

--- a/kube/services/selenium/selenium-hub-deployment.yaml
+++ b/kube/services/selenium/selenium-hub-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   labels:
     app: selenium-hub
   name: selenium-hub
@@ -16,6 +14,8 @@ spec:
     metadata:
       labels:
         app: selenium-hub
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     spec:
       containers:
       - env:

--- a/kube/services/selenium/selenium-node-chrome-deployment.yaml
+++ b/kube/services/selenium/selenium-node-chrome-deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   labels:
     app: selenium-node-chrome
   name: selenium-node-chrome
@@ -21,6 +19,8 @@ spec:
     metadata:
       labels:
         app: selenium-node-chrome
+      annotations:
+        "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
     spec:
       containers:
       - env:


### PR DESCRIPTION
We are still facing problems:
```
3m46s       Normal    ScalingReplicaSet                                                                             deployment/jenkins-deployment                          Scaled down replica set jenkins-deployment-7d4b7f848 to 0
3m41s       Normal    ScalingReplicaSet                                                                             deployment/jenkins-deployment                          Scaled up replica set jenkins-deployment-857c7d6bfb to 1
39m         Normal    UpdatedLoadBalancer
```