### PR TITLE
fix(ci): Guppy test config mutation needs to switch from case to subject

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -15,6 +15,8 @@ g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' original_guppy_config.yaml
 # for bloodpac-like envs
 sed -i 's/\(.*\)"index": "\(.*\)_case",$/\1"index": "jenkins_subject_alias",/' original_guppy_config.yaml
+# the pre-defined Canine index works with subject ONLY (never case)
+sed -i 's/\(.*\)"type": "case"$/\1"type": "subject",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_configs_alias",/' original_guppy_config.yaml
 


### PR DESCRIPTION
Fix this error:
```
ERROR: Tue Jul 27 2021 22:08:31 GMT+0000 (Coordinated Universal Time): The new guppy pod never came up with the expected indices.
```

Our jenkins-brain config is using `case` instead of `subject`:
https://github.com/uc-cdis/gitops-qa/blob/master/jenkins-brain.planx-pla.net/manifest.json#L292

And the pre-defined Canine-based index we use for Guppy tests MUST use index type = `subject`:
https://github.com/uc-cdis/gen3-qa/tree/master/suites/guppy/jenkinsSetup

Hence, we need to accommodate this mutation scenario as well.