### PR TITLE
fix(ci): Improve regex to mutate etl-mapping

### DIFF
--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -23,8 +23,8 @@ if ! shift; then
 fi
 
 g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
-sed -i 's/.*- name: \(.*\)_subject$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml
-sed -i 's/.*- name: \(.*\)_etl$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_etl/' etlMapping.yaml
-sed -i 's/.*- name: \(.*\)_file$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
+sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_subject$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml
+sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_etl$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_etl/' etlMapping.yaml
+sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_file$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
 g3kubectl delete configmap etl-mapping
 g3kubectl create configmap etl-mapping --from-file=etlMapping.yaml=etlMapping.yaml

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -26,7 +26,7 @@ etl_mapping_subject=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMappin
 echo "### ## etl_mapping_subject: ${etl_mapping_subject}"
 etl_mapping_file=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[1].name)
 echo "echo "### ## etl_mapping_file: ${etl_mapping_file}"
-etl_config=$(echo $etl_mapping_subject | sed 's/\(.*\)_etl/\1_array-config/')
+etl_config=$(echo $etl_mapping_subject | sed 's/\(.*\)_\(.*\)$/\1_array-config/')
 echo "### ## etl_config: ${etl_config}"
 
 g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
@@ -35,6 +35,8 @@ sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": '"${etl_mapping_subject}"
 sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
 # exclusive for bloodpac-like envs
 sed -i 's/\(.*\)"index": "\(.*\)_study",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
+# the pre-defined Canine index works with subject ONLY (never case)
+sed -i 's/\(.*\)"type": "case"$/\1"type": "subject"/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": '"${etl_mapping_file}"',/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": '"${etl_config}"',/' original_guppy_config.yaml
 


### PR DESCRIPTION
The current regex that is used to mutate the etl-mapping config map
```
sed -i 's/.*- name: \(.*\)_file$/ - name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
```
 is accidentally changing this line here from `gen3.theanvil.io/etlMapping.yaml`:
```
      - name: capture_region_bed_file
```

To avoid the malformed yaml that breaks the ETL job, we must utilize a better `sed` instruction:
```
sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_file$/ - name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
```