### PR TITLE
fix(ci): Fix guppy test configmap mutation logic

### DIFF
--- a/gen3/bin/mutate-guppy-config-for-guppy-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-guppy-test.sh
@@ -16,7 +16,7 @@ sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": "jenkins_subject_alias",/' or
 # for bloodpac-like envs
 sed -i 's/\(.*\)"index": "\(.*\)_case",$/\1"index": "jenkins_subject_alias",/' original_guppy_config.yaml
 # the pre-defined Canine index works with subject ONLY (never case)
-sed -i 's/\(.*\)"type": "case"$/\1"type": "subject",/' original_guppy_config.yaml
+sed -i 's/\(.*\)"type": "case"$/\1"type": "subject"/' original_guppy_config.yaml
 sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": "jenkins_file_alias",/' original_guppy_config.yaml
 sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "jenkins_configs_alias",/' original_guppy_config.yaml
 


### PR DESCRIPTION
there’s an extra comma after "subject"
```
$ kc get cm manifest-guppy -o yaml
apiVersion: v1
data:
  auth_filter_field: auth_resource_path
  config_index: jenkins-brain.planx-pla.net_array-config
  indices: |-
    [
      {
        "index": "jenkins_subject_alias",
        "type": "subject",
      },
```