### PR TITLE
Adding statsd port to the datadog node agent yaml

### DIFF
--- a/kube/services/datadog/datadog-node-agent.yaml
+++ b/kube/services/datadog/datadog-node-agent.yaml
@@ -411,11 +411,15 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app: datadog-agent-cluster-agent
+    app: datadog-agent
   ports:
   - port: 5005
     name: agentport
     protocol: TCP
+  - name: agentstatsdport
+    port: 8125
+    protocol: UDP
+    targetPort: 8125
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
Addition of statsd port to the agent yaml so that we could configure our own customizable metric inside datadog UI