### PR TITLE
feat(metadata): use manifest to drive config

### DIFF
--- a/gen3/bin/kube-setup-metadata.sh
+++ b/gen3/bin/kube-setup-metadata.sh
@@ -65,7 +65,13 @@ if [ -f "${aggregateConfigFile}" ]; then
   g3kubectl create secret generic metadata-config --from-file="${aggregateConfigFile}"
 fi
 
-if g3kubectl get configmap manifest-metadata -o json | jq '.data.USE_AGG_MDS == "true"' > /dev/null 2>&1; then
+# Create the metadata manifest configmap if it doesn't exist
+if ! kubectl get configmap manifest-metadata > /dev/null 2>&1; then
+  gen3 gitops configmaps
+fi
+
+# Check the metadata manifest configmap to see if the agg mds is enabled
+if g3kubectl get configmap manifest-metadata -o json | jq -r '.data.json' | jq '.USE_AGG_MDS == true' > /dev/null 2>&1; then
   gen3_log_info "kube-setup-metadata setting up aws-es-proxy dependency"
   gen3 kube-setup-aws-es-proxy || true
   wait_for_esproxy

--- a/gen3/bin/kube-setup-metadata.sh
+++ b/gen3/bin/kube-setup-metadata.sh
@@ -65,7 +65,7 @@ if [ -f "${aggregateConfigFile}" ]; then
   g3kubectl create secret generic metadata-config --from-file="${aggregateConfigFile}"
 fi
 
-if grep "USE_AGG_MDS=true" "$(gen3_secrets_folder)/g3auto/metadata/metadata.env" > /dev/null 2>&1; then
+if g3kubectl get configmap manifest-metadata -o json | jq '.data.USE_AGG_MDS == "true"' > /dev/null 2>&1; then
   gen3_log_info "kube-setup-metadata setting up aws-es-proxy dependency"
   gen3 kube-setup-aws-es-proxy || true
   wait_for_esproxy

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -43,12 +43,18 @@ spec:
         - name: config-volume-g3auto
           secret:
             secretName: metadata-g3auto
+        # This volume may or may not be needed or available. See kube-setup-metadata.sh and note that this
+        # is only available if a <manifest dir>/metadata directory exists.
         - name: config-volume
           secret:
             secretName: metadata-config
+            optional: true
+        # This volume may or may not be needed or available. See kube-setup-metadata.sh and note that this
+        # may not exist if the commons does not have any metadata manifest configuration.
         - name: config-manifest
           configMap:
             name: manifest-metadata
+            optional: true
       containers:
       - name: metadata
         GEN3_METADATA_IMAGE

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -112,10 +112,6 @@ spec:
               readOnly: true
               mountPath: /src/.env
               subPath: metadata.env
-            - name: config-volume
-              readOnly: true
-              mountPath: /aggregate_config.json
-              subPath: aggregate_config.json
           resources:
             limits:
               cpu: 0.8
@@ -125,4 +121,49 @@ spec:
             - "-c"
             - |
               /env/bin/alembic upgrade head
-              [ "${USE_AGG_MDS}" = "true" ] && [ -f /aggregate_config.json ] && python /src/src/mds/populate.py --config /aggregate_config.json --hostname esproxy-service --port 9200
+        - name: metadata-aggregate-mds-pull
+          GEN3_METADATA_IMAGE
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: config-volume-g3auto
+              readOnly: true
+              mountPath: /src/.env
+              subPath: metadata.env
+            - name: config-volume
+              readOnly: true
+              mountPath: /aggregate_config.json
+              subPath: aggregate_config.json
+          env:
+            - name: GEN3_DEBUG
+              GEN3_DEBUG_FLAG|-value: "False"-|
+            - name: GEN3_ES_ENDPOINT
+              value: http://esproxy-service:9200
+            - name: USE_AGG_MDS
+              valueFrom:
+                configMapKeyRef:
+                  name: manifest-metadata
+                  key: USE_AGG_MDS
+                  optional: true
+            - name: AGG_MDS_NAMESPACE
+              valueFrom:
+                configMapKeyRef:
+                  name: manifest-metadata
+                  key: AGG_MDS_NAMESPACE
+                  optional: true
+          resources:
+            limits:
+              cpu: 0.8
+              memory: 512Mi
+          command: ["/bin/sh"]
+          args:
+            - "-c"
+            - |
+              if [ "${USE_AGG_MDS}" != "true" ]; then
+                echo "agg mds not enabled"
+                exit 0
+              fi
+              if [ ! -f /aggregate_config.json ]; then
+                echo "no agg mds config file found"
+                exit 0
+              fi
+              python /src/src/mds/populate.py --config /aggregate_config.json --hostname esproxy-service --port 9200

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -103,6 +103,13 @@ spec:
           limits:
             cpu: 1
             memory: 2048Mi
+        lifecycle:
+          # Run the agg mds import as a post start command. Aggregare MDS may refer back to its _own_ non-aggregate MDS as a data source
+          # and so we must wait for the app to be running locally if needed.
+          postStart:
+            exec:
+              # This command will check environment variables and exit cleanly if this should not actually run.
+              command: ["python", "/src/src/mds/populate.py", "--config", "/aggregate_config.json", "--hostname", "esproxy-service", "--port", "9200"]
       initContainers:
         - name: metadata-db-migrate
           GEN3_METADATA_IMAGE
@@ -121,49 +128,3 @@ spec:
             - "-c"
             - |
               /env/bin/alembic upgrade head
-        - name: metadata-aggregate-mds-pull
-          GEN3_METADATA_IMAGE
-          imagePullPolicy: Always
-          volumeMounts:
-            - name: config-volume-g3auto
-              readOnly: true
-              mountPath: /src/.env
-              subPath: metadata.env
-            - name: config-volume
-              readOnly: true
-              mountPath: /aggregate_config.json
-              subPath: aggregate_config.json
-          env:
-            - name: GEN3_DEBUG
-              GEN3_DEBUG_FLAG|-value: "False"-|
-            - name: GEN3_ES_ENDPOINT
-              value: http://esproxy-service:9200
-            - name: USE_AGG_MDS
-              valueFrom:
-                configMapKeyRef:
-                  name: manifest-metadata
-                  key: USE_AGG_MDS
-                  optional: true
-            - name: AGG_MDS_NAMESPACE
-              valueFrom:
-                configMapKeyRef:
-                  name: manifest-metadata
-                  key: AGG_MDS_NAMESPACE
-                  optional: true
-          resources:
-            limits:
-              cpu: 0.8
-              memory: 512Mi
-          command: ["/bin/sh"]
-          args:
-            - "-c"
-            - |
-              if [ "${USE_AGG_MDS}" != "true" ]; then
-                echo "agg mds not enabled"
-                exit 0
-              fi
-              if [ ! -f /aggregate_config.json ]; then
-                echo "no agg mds config file found"
-                exit 0
-              fi
-              python /src/src/mds/populate.py --config /aggregate_config.json --hostname esproxy-service --port 9200

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -108,10 +108,14 @@ spec:
           GEN3_METADATA_IMAGE
           imagePullPolicy: Always
           volumeMounts:
-            - name: "config-volume-g3auto"
+            - name: config-volume-g3auto
               readOnly: true
-              mountPath: "/src/.env"
-              subPath: "metadata.env"
+              mountPath: /src/.env
+              subPath: metadata.env
+            - name: config-volume
+              readOnly: true
+              mountPath: /aggregate_config.json
+              subPath: aggregate_config.json
           resources:
             limits:
               cpu: 0.8
@@ -121,3 +125,4 @@ spec:
             - "-c"
             - |
               /env/bin/alembic upgrade head
+              [ "${USE_AGG_MDS}" = "true" ] && [ -f /aggregate_config.json ] && python /src/src/mds/populate.py --config /aggregate_config.json --hostname esproxy-service --port 9200

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -103,13 +103,6 @@ spec:
           limits:
             cpu: 1
             memory: 2048Mi
-        lifecycle:
-          # Run the agg mds import as a post start command. Aggregare MDS may refer back to its _own_ non-aggregate MDS as a data source
-          # and so we must wait for the app to be running locally if needed.
-          postStart:
-            exec:
-              # This command will check environment variables and exit cleanly if this should not actually run.
-              command: ["python", "/src/src/mds/populate.py", "--config", "/aggregate_config.json", "--hostname", "esproxy-service", "--port", "9200"]
       initContainers:
         - name: metadata-db-migrate
           GEN3_METADATA_IMAGE

--- a/kube/services/metadata/metadata-deploy.yaml
+++ b/kube/services/metadata/metadata-deploy.yaml
@@ -40,9 +40,15 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       automountServiceAccountToken: false
       volumes:
+        - name: config-volume-g3auto
+          secret:
+            secretName: metadata-g3auto
         - name: config-volume
           secret:
-            secretName: "metadata-g3auto"
+            secretName: metadata-config
+        - name: config-manifest
+          configMap:
+            name: manifest-metadata
       containers:
       - name: metadata
         GEN3_METADATA_IMAGE
@@ -51,6 +57,18 @@ spec:
             GEN3_DEBUG_FLAG|-value: "False"-|
           - name: GEN3_ES_ENDPOINT
             value: http://esproxy-service:9200
+          - name: USE_AGG_MDS
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-metadata
+                key: USE_AGG_MDS
+                optional: true
+          - name: AGG_MDS_NAMESPACE
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-metadata
+                key: AGG_MDS_NAMESPACE
+                optional: true
         imagePullPolicy: Always
         livenessProbe:
           httpGet:
@@ -66,10 +84,18 @@ spec:
         ports:
         - containerPort: 80
         volumeMounts:
-          - name: "config-volume"
+          - name: config-volume-g3auto
             readOnly: true
-            mountPath: "/src/.env"
-            subPath: "metadata.env"
+            mountPath: /src/.env
+            subPath: metadata.env
+          - name: config-volume
+            readOnly: true
+            mountPath: /aggregate_config.json
+            subPath: aggregate_config.json
+          - name: config-manifest
+            readOnly: true
+            mountPath: /metadata.json
+            subPath: json
         resources:
           requests:
             cpu: 0.4
@@ -82,7 +108,7 @@ spec:
           GEN3_METADATA_IMAGE
           imagePullPolicy: Always
           volumeMounts:
-            - name: "config-volume"
+            - name: "config-volume-g3auto"
               readOnly: true
               mountPath: "/src/.env"
               subPath: "metadata.env"


### PR DESCRIPTION
Jira Ticket: [HP-291](https://ctds-planx.atlassian.net/browse/HP-291), [HP-320](https://ctds-planx.atlassian.net/browse/HP-320)

### New Features

* Create configuration scripts for metadata-service

### Improvements

* Move aggregate MDS configuration to our standard manifest config process

### Deployment changes

* Remove `USE_AGG_MDS` and `AGG_MDS_NAMESPACE` from `Gen3Secrets/g3auto/metadata/metadata.env` and set those variables in a `manifest: {}` block in `manifest.json`
* Migrate the appropriate agg MDS config to the relevant manifest repo under a `metadata/aggregate_config.json` path
* Run `gen3 kube-setup-metdata` and roll the metadata service in Kubernetes
