### PR TITLE
PXP-8363 Fix/samesite cookie

### DIFF
--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -261,7 +261,7 @@ server {
   if ($cookie_csrftoken) {
     set $csrf_token "$cookie_csrftoken";
   }
-  add_header Set-Cookie "csrftoken=$csrf_token$csrf_cookie_domain;Path=/;SecureSameSite=Lax";
+  add_header Set-Cookie "csrftoken=$csrf_token$csrf_cookie_domain;Path=/;Secure;SameSite=Lax";
 
   # visitor and session tracking for analytics -
   #    https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -237,7 +237,7 @@ server {
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 
   # update service release cookie
-  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure";
+  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
   
   if ($request_method = 'OPTIONS') {
     return 204;
@@ -261,7 +261,7 @@ server {
   if ($cookie_csrftoken) {
     set $csrf_token "$cookie_csrftoken";
   }
-  add_header Set-Cookie "csrftoken=$csrf_token$csrf_cookie_domain;Path=/;Secure";
+  add_header Set-Cookie "csrftoken=$csrf_token$csrf_cookie_domain;Path=/;SecureSameSite=Lax";
 
   # visitor and session tracking for analytics -
   #    https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id
@@ -271,13 +271,13 @@ server {
   if ($cookie_session) {
     set $session_id "$cookie_session";
   }
-  add_header Set-Cookie "session=$session_id;Path=/;Max-Age=1200;HttpOnly;Secure";
+  add_header Set-Cookie "session=$session_id;Path=/;Max-Age=1200;HttpOnly;Secure;SameSite=Lax";
   # Simple visitor tracking - immortal
   set $visitor_id "$request_id";
   if ($cookie_visitor) {
     set $visitor_id "$cookie_visitor";
   }
-  add_header Set-Cookie "visitor=$visitor_id;Path=/;Max-Age=36000000;HttpOnly;Secure";
+  add_header Set-Cookie "visitor=$visitor_id;Path=/;Max-Age=36000000;HttpOnly;Secure;SameSite=Lax";
 
   if ($cookie_access_token) {
       set $access_token "bearer $cookie_access_token";


### PR DESCRIPTION
Jira Ticket: [PXP-8363](https://ctds-planx.atlassian.net/browse/PXP-8363)

Add `samesite="Lax"` to cookies of `session`, `visitor`, `csrftoken` and `service_releases`

This shouldn't breaks anything since some browsers (Chrome/Edge) has already been using `Lax`
 as default value of `samesite` if not declared

To fix vulnerability documented in Veracode scan report (link in Jira ticket)



### Improvements
- Add `samesite="Lax"` to cookies of `session`, `visitor`, `csrftoken` and `service_releases`
