### PR TITLE
chore(gen3qa-check-bucket-access): Running gen3-qa tests + embedded selenium-standlone

### DIFF
--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -10,20 +10,32 @@ spec:
     spec:
       containers:
       - name: gen3qa-check-bucket-access
-        GEN3_GEN3_QA_CONTROLLER_IMAGE|-image: quay.io/cdis/gen3-qa-controller:0.4-|
+        GEN3_GEN3_QA_CONTROLLER_IMAGE|-image: quay.io/cdis/gen3-qa-controller:0.5-|
         workingDir: /var/sdet_home
         imagePullPolicy: Always
         env:
           - name: INDEXD_QUERY_FILTER
             GEN3_INDEXD_QUERY_FILTER|-value: "all"-|
-          - name: ACCESS_TOKEN
-            GEN3_ACCESS_TOKEN|-value: ""-|
+          - name: SELENIUM_TIMEOUT
+            GEN3_SELENIUM_TIMEOUT|-value: "300"-|
           - name: RUNNING_IN_PROD_TIER
             value: "true"
-        command: ["/bin/sh"]
+        command: ["/bin/bash"]
         args:
           - "-c"
           - |
+            # wait for the access token to be created in the sidecar "fence" container
+            let count=0
+            while [[ ! -f /mnt/shared/access_token.txt && $count -lt 50 ]]; do
+              echo "waiting for /mnt/shared/access_token.txt";
+              sleep 2
+              let count=$count+1
+            done
+
+            export ACCESS_TOKEN="$(cat /mnt/shared/access_token.txt)"
+
+            npx selenium-standalone install --version=4.0.0-alpha-7
+            timeout $SELENIUM_TIMEOUT npx selenium-standalone start --version=4.0.0-alpha-7 &
             set +x
             echo "running checkAllProjectsBucketAccessTest.js..."
             INDEXD_FILTER=$INDEXD_QUERY_FILTER GEN3_SKIP_PROJ_SETUP=true npm test -- suites/prod/checkAllProjectsBucketAccessTest.js
@@ -31,10 +43,6 @@ spec:
             if [[ $RC != 0 ]]; then
               echo "ERROR: non zero exit code: $?"
             fi
-      - name: selenium
-        image: selenium/standalone-chrome:4
-        ports:
-        - containerPort: 4444
         readinessProbe:
           httpGet:
             path: /wd/hub
@@ -42,4 +50,127 @@ spec:
           successThreshold: 2
           initialDelaySeconds: 5
           periodSeconds: 5
+        volumeMounts:
+          - name: shared-data
+            mountPath: /mnt/shared
+      - name: fence
+        GEN3_FENCE_IMAGE
+        imagePullPolicy: Always
+        env:
+          - name: PYTHONPATH
+            value: /var/www/fence
+          - name: TEST_OPERATOR
+            GEN3_TEST_OPERATOR|-value: "marceloc@uchicago.edu"-|
+          - name: TOKEN_EXPIRATION
+            GEN3_TOKEN_EXPIRATION|-value: "3600"-|
+          - name: FENCE_PUBLIC_CONFIG
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-fence
+                key: fence-config-public.yaml
+                optional: true
+        volumeMounts:
+          - name: "old-config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/local_settings.py"
+            subPath: local_settings.py
+          - name: "creds-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/creds.json"
+            subPath: creds.json
+          - name: "config-helper"
+            readOnly: true
+            mountPath: "/var/www/fence/config_helper.py"
+            subPath: config_helper.py
+          - name: "json-secret-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence_credentials.json"
+            subPath: fence_credentials.json
+# -----------------------------------------------------------------------------
+          - name: "config-volume"
+            readOnly: true
+            mountPath: "/var/www/fence/fence-config-secret.yaml"
+            subPath: fence-config.yaml
+          - name: "yaml-merge"
+            readOnly: true
+            mountPath: "/var/www/fence/yaml_merge.py"
+            subPath: yaml_merge.py
+          - name: "fence-jwt-keys"
+            readOnly: true
+            mountPath: "/fence/jwt-keys.tar"
+            subPath: "jwt-keys.tar"
+          - name: shared-data
+            mountPath: /mnt/shared
+        command: ["/bin/bash" ]
+        args:
+            - "-c"
+            - |
+              echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
+              python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+              if [ -f /fence/jwt-keys.tar ]; then
+                cd /fence
+                tar xvf jwt-keys.tar
+                if [ -d jwt-keys ]; then
+                  mkdir -p keys
+                  mv jwt-keys/* keys/
+                fi
+              fi
+              echo "generate access token"
+              echo "fence-create --path fence token-create --type access_token --username $TEST_OPERATOR --scopes openid,user,test-client --exp $TOKEN_EXPIRATION"
+              tempFile="$(mktemp -p /tmp token.txt_XXXXXX)"
+              success=false
+              count=0
+              sleepTime=10
+              # retry loop
+              while [[ $count -lt 3 && $success == false ]]; do
+                if fence-create --path fence token-create --type access_token --username $TEST_OPERATOR --scopes openid,user,test-client --exp $TOKEN_EXPIRATION > "$tempFile"; then
+                  echo "fence-create success!"
+                  tail -1 "$tempFile" > /mnt/shared/access_token.txt
+                  # base64 --decode complains about invalid characters - don't know why
+                  awk -F . '{ print $2 }' /mnt/shared/access_token.txt | base64 --decode 2> /dev/null
+                  success=true
+                else
+                  echo "fence-create failed!"
+                  cat "$tempFile"
+                  echo "sleep for $sleepTime, then retry"
+                  sleep "$sleepTime"
+                  let sleepTime=$sleepTime+$sleepTime
+                fi
+                let count=$count+1
+              done
+              if [[ $success != true ]]; then
+                echo "Giving up on fence-create after $count retries - failed to create valid access token"
+              fi
+              echo ""
+              echo "All Done - always succeed to avoid k8s retries"
       restartPolicy: Never
+      serviceAccountName: useryaml-job
+      volumes:
+        - name: yaml-merge
+          configMap:
+            name: "fence-yaml-merge"
+        - name: shared-data
+          emptyDir: {}
+# -----------------------------------------------------------------------------
+# DEPRECATED! Remove when all commons are no longer using local_settings.py
+#             for fence.
+# -----------------------------------------------------------------------------
+        - name: old-config-volume
+          secret:
+            secretName: "fence-secret"
+        - name: creds-volume
+          secret:
+            secretName: "fence-creds"
+        - name: config-helper
+          configMap:
+            name: config-helper
+        - name: json-secret-volume
+          secret:
+            secretName: "fence-json-secret"
+# -----------------------------------------------------------------------------
+        - name: config-volume
+          secret:
+            secretName: "fence-config"
+        - name: fence-jwt-keys
+          secret:
+            secretName: "fence-jwt-keys"


### PR DESCRIPTION
This will eliminate the need to invoke this test through the `gen3/bin/gen3qa-run.sh` script.

The new gen3-qa-controller image has the ability to run tests with an embedded `selenium-standalone` binary and a google chrome all within the same container (https://github.com/uc-cdis/gen3-qa/pull/668).