### PR TITLE
Fix/install libgit2 to unblock py3.8 automation

### DIFF
--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -5,7 +5,7 @@ USER root
 ENV DEBIAN_FRONTEND=noninteractive
 
 # install python and pip and aws cli
-RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential zip unzip less vim gettext-base
+RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils python python-setuptools python-dev python-pip python3 python3-pip build-essential libgit2-dev zip unzip less vim gettext-base
 RUN set -xe && python -m pip install awscli --upgrade && python -m pip install pytest --upgrade && python -m pip install PyYAML --upgrade && python -m pip install lxml --upgrade
 RUN set -xe && python3 -m pip install pytest --upgrade && python3 -m pip install PyYAML --upgrade
 RUN set -xe && python -m pip install yq --upgrade && python3 -m pip install yq --upgrade && python3 -m pip install pandas --upgrade
@@ -23,7 +23,6 @@ RUN apt-get update \
      libreadline-dev \
      libsqlite3-dev \
      libgdbm-dev \
-     libgit2 \
      libdb5.3-dev \
      libbz2-dev \
      libexpat1-dev \

--- a/Docker/Jenkins-Worker/Dockerfile
+++ b/Docker/Jenkins-Worker/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update \
      libreadline-dev \
      libsqlite3-dev \
      libgdbm-dev \
+     libgit2 \
      libdb5.3-dev \
      libbz2-dev \
      libexpat1-dev \


### PR DESCRIPTION
Release automation task is failing due to:
```
Requirement already satisfied: pycparser in /usr/local/lib/python3.8/site-packages (from cffi>=1.4.0->pygit2) (2.20)
Building wheels for collected packages: pygit2
  Building wheel for pygit2 (PEP 517): started
  Building wheel for pygit2 (PEP 517): finished with status 'error'
  ERROR: Command errored out with exit status 1:
...
  running build_ext
  generating cffi module 'build/temp.linux-x86_64-3.8/pygit2._libgit2.c'
  creating build/temp.linux-x86_64-3.8
  building 'pygit2._pygit2' extension
  creating build/temp.linux-x86_64-3.8/src
  gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -I/usr/local/include -I/usr/local/include/python3.8 -c src/blob.c -o build/temp.linux-x86_64-3.8/src/blob.o
  In file included from src/blob.c:30:
  src/blob.h:33:10: fatal error: git2.h: No such file or directory
```