### PR TITLE
fix(jenkins-disk-cleanup): Run command in the correct container

### DIFF
--- a/files/scripts/jenkins-cronjob.sh
+++ b/files/scripts/jenkins-cronjob.sh
@@ -54,7 +54,7 @@ else
     aws sns publish --topic-arn arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic --message 'qaplanetv1 jenkins-cronjob complete'
   fi
   if [[ "$command" == "go" && ! -z "$jcipod" ]]; then
-    g3kubectl exec -c jenkins "$jcipod" -- bash -c " sudo find /home/jenkins/agent/workspace/ -name "GitHub_Org_*" -type d -mtime +5 -prune -print -exec /bin/rm -rf '{}' ';'"
+    g3kubectl exec -c jenkins-worker "$jcipod" -- bash -c " sudo find /home/jenkins/agent/workspace/ -name "GitHub_Org_*" -type d -mtime +5 -prune -print -exec /bin/rm -rf '{}' ';'"
     gen3 roll jenkins-ci-worker
     aws sns publish --topic-arn arn:aws:sns:us-east-1:433568766270:planx-csoc-alerts-topic --message 'qaplanetv1 jenkins-ci-cronjob complete'
   fi


### PR DESCRIPTION
fixing this:
```
g3kubectl exec -c jenkins "jenkins-ci-worker-deployment-79ffb9d56-7ddf9" -- bash -c " sudo find /home/jenkins/agent/workspace/ -name "GitHub_Org_*" -type d -mtime +5 -prune -print -exec /bin/rm -rf '{}' ';'"
Error from server (BadRequest): container jenkins is not valid for pod jenkins-ci-worker-deployment-79ffb9d56-7ddf9
```