### PR TITLE
chore(autoscaling): Trying to fix autoscaler in qaplanetv2

### DIFF
--- a/kube/services/autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/kube/services/autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -155,6 +155,7 @@ spec:
             - --skip-nodes-with-local-storage=false
             - --expander=least-waste
             - --scale-down-delay-after-add=7m
+            - --aws-use-static-instance-list=true
             - --node-group-auto-discovery=asg:tag=k8s.io/cluster-autoscaler/enabled,k8s.io/cluster-type/eks,kubernetes.io/cluster/VPC_NAME
           volumeMounts:
             - name: ssl-certs


### PR DESCRIPTION
We are experiencing some memory leak for autoscaler while running it in qaplanetv2:
```
kc get pods --all-namespaces | grep "cluster-autoscaler"
kube-system        cluster-autoscaler-655b7ff57b-gjrrj                         0/1     CrashLoopBackOff   4          4m29s
```