### PR TITLE
DO NOT MERGE (just an idea) = chore(ingress-versioning): Pull nginx revproxy sub-config files from the docker-nginx repo

### DIFF
--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -68,12 +68,15 @@ if g3k_manifest_lookup .versions.indexd 2> /dev/null; then
   setup_indexd_gateway
 fi
 
+# pick up docker-nginx (revproxy) version from the manifest.json / versions block.
 manifestPath=$(g3k_manifest_path)
 deployVersion="$(jq -r ".[\"revproxy\"]" < "$manifestPath")"
 
-git clone --branch --branch <branchname>  https://github.com/uc-cdis/docker-nginx.git
+# pull ingress config from the docker-nginx (revproxy) repo
+git clone --branch $deployVersion  https://github.com/uc-cdis/docker-nginx.git
 
-cp docker-nginx/ingress-conf/* ${GEN3_HOME}/kube/services/revproxy
+# copy files into the kube revproxy folder
+cp docker-nginx/ingress-config/* ${GEN3_HOME}/kube/services/revproxy/gen3.nginx.conf
 
 scriptDir="${GEN3_HOME}/kube/services/revproxy"
 declare -a confFileList=()

--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -68,6 +68,13 @@ if g3k_manifest_lookup .versions.indexd 2> /dev/null; then
   setup_indexd_gateway
 fi
 
+manifestPath=$(g3k_manifest_path)
+deployVersion="$(jq -r ".[\"revproxy\"]" < "$manifestPath")"
+
+git clone --branch --branch <branchname>  https://github.com/uc-cdis/docker-nginx.git
+
+cp docker-nginx/ingress-conf/* ${GEN3_HOME}/kube/services/revproxy
+
 scriptDir="${GEN3_HOME}/kube/services/revproxy"
 declare -a confFileList=()
 confFileList+=("--from-file" "$scriptDir/gen3.nginx.conf/README.md")


### PR DESCRIPTION
This PR depends on https://github.com/uc-cdis/docker-nginx/pull/8/files

Our nginx config is currently in cloud-automation and our microservices code changes sit in their respective repos.
As we don't have monorepo, the code changes that reflect in new behaviors for our RESTful API endpoints are not in sync / not backwards compatible with our Nginx / Reverse Proxy configuration changes that perform the URL Rewrites that will control the ingress of our Gen3 Ecosystem and redirect the inbound requests to the correct services.

With this approach, we will be able to have specific microservices versions coupled with specific docker-nginx (revproxy) versions and avoid awkward conditions to apply different revproxy configs for specific microservices versions.