### PR TITLE
fix(zdt): Introduce readinessProbe to indexd

### DIFF
--- a/kube/services/indexd/indexd-deploy.yaml
+++ b/kube/services/indexd/indexd-deploy.yaml
@@ -122,6 +122,10 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
           timeoutSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /_status
+            port: 80
         ports:
         - containerPort: 80
         - containerPort: 443


### PR DESCRIPTION
Without a readinessProbe k8s won’t know when new pods are healthy enough to be placed in the rotation of the load balancers, which will result in ZDT during a `gen3 roll indexd` operation.