### PR TITLE
introduce timeout and set it to 30

### DIFF
--- a/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
@@ -29,7 +29,7 @@ spec:
             secretName: "aws-es-proxy"
       containers:
       - name: esproxy
-        GEN3_AWS-ES-PROXY_IMAGE|-image: quay.io/cdis/aws-es-proxy:0.8-|
+        GEN3_AWS-ES-PROXY_IMAGE|-image: quay.io/cdis/aws-es-proxy:1.1-|
         imagePullPolicy: Always
         ports:
         - containerPort: 9200
@@ -55,7 +55,7 @@ spec:
               # 0.8
               BINARY=/go/src/github.com/abutaha/aws-es-proxy/aws-es-proxy
             fi
-            ${BINARY} -endpoint "https://$ES_ENDPOINT" -verbose -listen ":9200"
+            ${BINARY} -endpoint "https://$ES_ENDPOINT" -verbose -listen ":9200" -timeout 30
         resources:
           limits:
             cpu: 0.3


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
The newer versions (>=1.0) of aws-es-proxy support timeout (default was 15). This PR introduces the parameter and sets it to 30sec

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
