### PR TITLE
chore(observability): Track all Fence feature flags in DataDog

### DIFF
--- a/apis_configs/datadog_submit_metrics.py
+++ b/apis_configs/datadog_submit_metrics.py
@@ -23,4 +23,4 @@ def send_metric(metric, tags=None):
 
 if __name__ == '__main__':
   # quick test
-  send_metric("feature_flags", 1, ["MOCK_GOOGLE_AUTH:true"])
+  send_metric("feature_flags", ["MOCK_GOOGLE_AUTH:true"])

--- a/apis_configs/datadog_submit_metrics.py
+++ b/apis_configs/datadog_submit_metrics.py
@@ -1,0 +1,26 @@
+import os
+from datadog import initialize, statsd
+
+options = {
+    'statsd_host':'datadog-agent-cluster-agent.datadog',
+    'statsd_port':8125
+}
+
+initialize(**options)
+
+def send_metric(metric, tags=None):
+    if tags is None:
+        tags = []
+    try:
+        statsd.increment(
+            "planx.config_mgmt.{0}".format(metric),
+            tags=tags,
+        )
+    except Exception as e:
+        # We don't want Fence to fail on an API error
+        print('Couldn\'t send metric "{0}" to Datadog'.format(metric))
+        print(e)
+
+if __name__ == '__main__':
+  # quick test
+  send_metric("feature_flags", 1, ["MOCK_GOOGLE_AUTH:true"])

--- a/apis_configs/yaml_merge.py
+++ b/apis_configs/yaml_merge.py
@@ -18,11 +18,21 @@ import sys
 import json
 from yaml import safe_load as yaml_load
 
+from datadog_submit_metrics import send_metric
+
 config1 = yaml_load(open(sys.argv[1]))
 config2 = yaml_load(open(sys.argv[2]))
 
 if config1 != None:
   for key in config1.keys():
     config2[key] = config1[key]
+
+feature_flags = []
+
+for k,v in config2.items():
+  if type(v) is bool:
+    feature_flags.append(f"{k}:{v}")
+
+send_metric("feature_flags", feature_flags)
 
 print(json.dumps(config2, indent=2))

--- a/apis_configs/yaml_merge.py
+++ b/apis_configs/yaml_merge.py
@@ -27,12 +27,15 @@ if config1 != None:
   for key in config1.keys():
     config2[key] = config1[key]
 
-feature_flags = []
+# only execute the next instructions if DataDog metrics are enabled
+if DD_ENV in os.environ:
+  feature_flags = []
 
-for k,v in config2.items():
-  if type(v) is bool:
-    feature_flags.append(f"{k}:{v}")
+  for k,v in config2.items():
+    if type(v) is bool:
+      feature_flags.append(f"{k}:{v}")
 
-send_metric("feature_flags", feature_flags)
+  send_metric("feature_flags", feature_flags)
+
 
 print(json.dumps(config2, indent=2))

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -25,6 +25,7 @@ setup_audit_sqs() {
 }
 
 gen3 update_config fence-yaml-merge "${GEN3_HOME}/apis_configs/yaml_merge.py"
+gen3 update_config fence-dd-submit-metrics "${GEN3_HOME}/apis_configs/datadog_submit_metrics.py"
 [[ -z "$GEN3_ROLL_ALL" ]] && gen3 kube-setup-secrets
 
 if [[ -f "$(gen3_secrets_folder)/creds.json" && -z "$JENKINS_HOME" ]]; then # create database

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -96,6 +96,9 @@ spec:
         - name: yaml-merge
           configMap:
             name: "fence-yaml-merge"
+        - name: fence-dd-submit-metrics
+          configMap:
+            name: "fence-dd-submit-metrics"
       securityContext:
         # nginx group in current images
         fsGroup: 101
@@ -205,6 +208,10 @@ spec:
             readOnly: true
             mountPath: "/var/www/fence/yaml_merge.py"
             subPath: yaml_merge.py
+          - name: "fence-dd-submit-metrics"
+            readOnly: true
+            mountPath: "/var/www/fence/datadog_submit_metrics.py"
+            subPath: datadog_submit_metrics.py
           - name: "fence-google-app-creds-secret-volume"
             readOnly: true
             mountPath: "/var/www/fence/fence_google_app_creds_secret.json"

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -96,6 +96,9 @@ spec:
         - name: yaml-merge
           configMap:
             name: "fence-yaml-merge"
+        - name: fence-dd-submit-metrics
+          configMap:
+            name: "fence-dd-submit-metrics"
       securityContext:
         # nginx group in current images
         fsGroup: 101
@@ -205,6 +208,10 @@ spec:
             readOnly: true
             mountPath: "/var/www/fence/yaml_merge.py"
             subPath: yaml_merge.py
+          - name: "fence-dd-submit-metrics"
+            readOnly: true
+            mountPath: "/var/www/fence/datadog_submit_metrics.py"
+            subPath: datadog_submit_metrics.py
           - name: "fence-google-app-creds-secret-volume"
             readOnly: true
             mountPath: "/var/www/fence/fence_google_app_creds_secret.json"


### PR DESCRIPTION
We should be able to track / filter all feature flags across all environments by submitting the microservice configurations as metric tags, e.g.,
https://app.datadoghq.com/dashboard/r8v-5v7-t6q?from_ts=1632151862728&to_ts=1632155462728&live=true

This should help us "dark launch" features without exposing the config in the `cdis-manifest` repo.
Once this is in dataDog, all those booleans can easily queryable / filterable in a dashboard.
We can obtain insights, such as:
“WE have 40+ websites.. in which ones is audit-service enabled?”
or
“We are trying some A/B testing in several staging environments for a new GA4GH feature.. where is it enabled across a list of 20 environments? What is the latency / error/ saturation / traffic on the envs where feature_flag X Y Z is enabled?”