### PR TITLE
chore(observability): Add datadog py lib to jenkins worker img

### DIFF
--- a/Docker/Jenkins-CI-Worker/Dockerfile
+++ b/Docker/Jenkins-CI-Worker/Dockerfile
@@ -94,7 +94,7 @@ RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release && \
     sed -i 's/python3/python3.8/' /usr/bin/add-apt-repository
 
 # install aws cli, poetry, pytest, etc.
-RUN set -xe && python3.8 -m pip install awscli --upgrade && python3.8 -m pip install pytest --upgrade && python3.8 -m pip install poetry && python3.8 -m pip install PyYAML --upgrade && python3.8 -m pip install lxml --upgrade && python3.8 -m pip install yq --upgrade
+RUN set -xe && python3.8 -m pip install awscli --upgrade && python3.8 -m pip install pytest --upgrade && python3.8 -m pip install poetry && python3.8 -m pip install PyYAML --upgrade && python3.8 -m pip install lxml --upgrade && python3.8 -m pip install yq --upgrade && python3.8 -m pip install datadog --upgrade
 
 RUN curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3.8 -
 


### PR DESCRIPTION
We should push more metrics to DataDog so we can achieve better monitoring for our CI processes related to gen3 CLI operations / PROD infra provisioning / batch jobs / etc.