### PR TITLE
fix(gen3qa-check-bucket-access): Pin chromedriver version to fix the gen3qa-check-bucket-access job

### DIFF
--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -34,8 +34,8 @@ spec:
 
             export ACCESS_TOKEN="$(cat /mnt/shared/access_token.txt)"
 
-            npx selenium-standalone install --version=4.0.0-alpha-7
-            timeout $SELENIUM_TIMEOUT npx selenium-standalone start --version=4.0.0-alpha-7 &
+            npx selenium-standalone install --version=4.0.0-alpha-7 --drivers.chrome.version=92.0.4515.107 --drivers.chrome.baseURL=https://chromedriver.storage.googleapis.com
+            timeout $SELENIUM_TIMEOUT npx selenium-standalone start --version=4.0.0-alpha-7 --drivers.chrome.version=92.0.4515.107 &
             set +x
             echo "running checkAllProjectsBucketAccessTest.js..."
             INDEXD_FILTER=$INDEXD_QUERY_FILTER GEN3_SKIP_PROJ_SETUP=true npm test -- suites/prod/checkAllProjectsBucketAccessTest.js


### PR DESCRIPTION
The job is currently failing in bdcat prod -- I think it's due to the lack of immutability around our dependencies.
We have faced the same issue in our CI Pipeline recently and we fixed it with this solution:
https://github.com/uc-cdis/gen3-qa/pull/696/files