### PR TITLE
change HOSTNAME to GEN3_ENDPOINT

### DIFF
--- a/kube/services/hatchery/hatchery-deploy.yaml
+++ b/kube/services/hatchery/hatchery-deploy.yaml
@@ -62,7 +62,7 @@ spec:
         ports:
         - containerPort: 8000
         env:
-          - name: HOSTNAME
+          - name: GEN3_ENDPOINT
             valueFrom:
               configMapKeyRef:
                 name: manifest-global


### PR DESCRIPTION



### Improvements
- Hatchery deployment: change `HOSTNAME` to `GEN3_ENDPOINT`
