### PR TITLE
chore(logs): fix duplicate entries in the nginx access log 

### DIFF
--- a/Docker/python-nginx/python3.6-alpine3.7/nginx.conf
+++ b/Docker/python-nginx/python3.6-alpine3.7/nginx.conf
@@ -33,7 +33,6 @@ http {
           '"http_useragent": "$http_user_agent", '
           '"message": "$request"}';
 
-    access_log  /dev/stdout  json;
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                       '$status $body_bytes_sent "$http_referer" '


### PR DESCRIPTION
Jira Ticket: [GPE-145](https://ctds-planx.atlassian.net/browse/GPE-145)

Removed one among the two instances where Nginx access logs were redirected to stdout.

### Bug Fixes

fix duplicate entries in the nginx access log 

