### PR TITLE
fix: update guppy timeout

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
@@ -1,4 +1,9 @@
           location /guppy/ {
+              proxy_connect_timeout 600s;
+              proxy_send_timeout 600s;
+              proxy_read_timeout 600s;
+              send_timeout 600s;
+
               set $proxy_service  "guppy";
               # upstream is written to logs
               set $upstream http://guppy-service.$namespace.svc.cluster.local;


### PR DESCRIPTION


### Improvements
- Update timeouts to `/guppy` to 10 mins
