### PR TITLE
set nginx proxy_read_timeout to 300s

### DIFF
--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -320,7 +320,8 @@ server {
   proxy_buffers              8 16k;
   proxy_busy_buffers_size    32k;
   client_body_buffer_size    16k;
-  
+  proxy_read_timeout         300;
+ 
   #
   # also incoming from client:
   # * https://fullvalence.com/2016/07/05/cookie-size-in-nginx/


### PR DESCRIPTION

### Improvements
Increasing the nginx proxy_read_timeout to 300 seconds

