### PR TITLE
fix(squid-certs): Added a little script to remove the deprecated elts…

### DIFF
--- a/Docker/squid/Dockerfile
+++ b/Docker/squid/Dockerfile
@@ -19,6 +19,7 @@ COPY ./certfix.sh /certfix.sh
 
 RUN chmod +x /usr/sbin/entrypoint.sh
 RUN chmod +x /certfix.sh
+RUN bash /certfix.sh
 
 RUN (cd /tmp \
     && wget ${SQUID_DOWNLOAD_URL}${SQUID_VERSION}.tar.xz \
@@ -57,7 +58,5 @@ EXPOSE 3129/tcp
 EXPOSE 3130/tcp
 
 VOLUME ${SQUID_LOG_DIR} ${SQUID_CACHE_DIR} ${SQUID_PID_DIR} ${SQUID_SYSCONFIG_DIR}
-
-RUN bash /certfix.sh
 
 ENTRYPOINT ["/usr/sbin/entrypoint.sh"]

--- a/Docker/squid/Dockerfile
+++ b/Docker/squid/Dockerfile
@@ -15,8 +15,10 @@ RUN apt update \
     && apt install -y build-essential wget libssl1.0-dev
 
 COPY ./entrypoint.sh /usr/sbin/entrypoint.sh
+COPY ./certfix.sh /certfix.sh
 
 RUN chmod +x /usr/sbin/entrypoint.sh
+RUN chmod +x /certfix.sh
 
 RUN (cd /tmp \
     && wget ${SQUID_DOWNLOAD_URL}${SQUID_VERSION}.tar.xz \
@@ -55,5 +57,7 @@ EXPOSE 3129/tcp
 EXPOSE 3130/tcp
 
 VOLUME ${SQUID_LOG_DIR} ${SQUID_CACHE_DIR} ${SQUID_PID_DIR} ${SQUID_SYSCONFIG_DIR}
+
+RUN bash /certfix.sh
 
 ENTRYPOINT ["/usr/sbin/entrypoint.sh"]

--- a/Docker/squid/certfix.sh
+++ b/Docker/squid/certfix.sh
@@ -1,0 +1,7 @@
+#/bin/bash
+
+if [[ -z $(cat /etc/ca-certificates.conf | grep '!mozilla/DST_Root_CA_X3.crt') ]] && [[ ! -z $(cat /etc/ca-certificates.conf | grep 'mozilla/DST_Root_CA_X3.crt') ]]; then
+  echo /etc/ca-certificates.conf | xargs sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g'
+  update-ca-certificates
+  squid -k reconfigure
+fi

--- a/Docker/squid/certfix.sh
+++ b/Docker/squid/certfix.sh
@@ -3,5 +3,4 @@
 if [[ -z $(cat /etc/ca-certificates.conf | grep '!mozilla/DST_Root_CA_X3.crt') ]] && [[ ! -z $(cat /etc/ca-certificates.conf | grep 'mozilla/DST_Root_CA_X3.crt') ]]; then
   echo /etc/ca-certificates.conf | xargs sed -i 's/mozilla\/DST_Root_CA_X3.crt/!mozilla\/DST_Root_CA_X3.crt/g'
   update-ca-certificates
-  squid -k reconfigure
 fi


### PR DESCRIPTION
### New Features
Added little script to remove deprecated letsencrypt cert

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
