### PR TITLE
fix: increase internal nginx timeout to 600 seconds for peregrine and…

### DIFF
--- a/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedSheepdogResult.yaml
@@ -78,6 +78,8 @@ spec:
           - containerPort: 80
           - containerPort: 443
           env:
+          - name: GEN3_UWSGI_TIMEOUT
+            value: "600"
           - name: DD_ENABLED
             valueFrom:
               configMapKeyRef:

--- a/kube/services/peregrine/peregrine-deploy.yaml
+++ b/kube/services/peregrine/peregrine-deploy.yaml
@@ -68,6 +68,8 @@ spec:
           - containerPort: 80
           - containerPort: 443
           env:
+          - name: GEN3_UWSGI_TIMEOUT
+            value: "600"
           - name: DD_ENABLED
             valueFrom:
               configMapKeyRef:

--- a/kube/services/sheepdog/sheepdog-deploy.yaml
+++ b/kube/services/sheepdog/sheepdog-deploy.yaml
@@ -78,6 +78,8 @@ spec:
           - containerPort: 80
           - containerPort: 443
           env:
+          - name: GEN3_UWSGI_TIMEOUT
+            value: "600"
           - name: DD_ENABLED
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
… sheepdog

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
* increase the internal nginx (the one running inside the peregrine/sheepdog Docker container) timeout for peregrine and sheepdog to 600 seconds

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
