### PR TITLE
Increase data-portal livenessProbe failureThreshold to 10

### DIFF
--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -68,7 +68,7 @@ spec:
           timeoutSeconds: 30
           # portal sometimes takes a long time to come up ... -
           # has to fetch the dictionary, relay compile, etc
-          failureThreshold: 6
+          failureThreshold: 10
         resources:
           requests:
             cpu: 0.6


### PR DESCRIPTION
Increase data-portal livenessProbe failureThreshold to 10 because the PRC portal fails to come up