### PR TITLE
Stop access-backend from giving random users workspace access

### DIFF
--- a/gen3/bin/kube-setup-access-backend.sh
+++ b/gen3/bin/kube-setup-access-backend.sh
@@ -144,7 +144,6 @@ authz:
   all_users_policies:
   - open_data_reader
   - sower
-  - workspace
   anonymous_policies:
   - open_data_reader
 


### PR DESCRIPTION
Removes 'workspace' policy from 'all_users_policies' in the default useryaml used by access-backend. This will prevent access-backend PRs from automatically adding in the 'workspace' policy to all users, which we want to avoid.

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

