### PR TITLE
HP-623 Fix/aws es timeout

### DIFF
--- a/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
@@ -49,7 +49,7 @@ spec:
             if [ -f /aws-es-proxy ];
             then
               # 1.3 needs this PR: https://github.com/uc-cdis/aws-es-proxy/pull/2
-              BINARY=/aws-es-proxy -timeout 30
+              BINARY=/aws-es-proxy -timeout 180
             elif [ -f /usr/local/bin/aws-es-proxy ];
             then
               # 0.9

--- a/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
@@ -49,7 +49,7 @@ spec:
             if [ -f /aws-es-proxy ];
             then
               # 1.3 needs this PR: https://github.com/uc-cdis/aws-es-proxy/pull/2
-              BINARY=/aws-es-proxy
+              BINARY=/aws-es-proxy -timeout 30
             elif [ -f /usr/local/bin/aws-es-proxy ];
             then
               # 0.9

--- a/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
+++ b/kube/services/aws-es-proxy/aws-es-proxy-deploy.yaml
@@ -49,7 +49,9 @@ spec:
             if [ -f /aws-es-proxy ];
             then
               # 1.3 needs this PR: https://github.com/uc-cdis/aws-es-proxy/pull/2
-              BINARY=/aws-es-proxy -timeout 180
+              # aws-es-proxy 1.0+ is prone to throw ES timeout error from client
+              # customize timeout value to compensate this, note the -timeout option only works for 1.2+
+              BINARY="/aws-es-proxy -timeout 180"
             elif [ -f /usr/local/bin/aws-es-proxy ];
             then
               # 0.9


### PR DESCRIPTION
Jira Ticket: [HP-623](https://ctds-planx.atlassian.net/browse/HP-623)

Fixing intermittent issue of  `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` from aggMDS sync job

`aws-es-proxy` was changed to use a customized HTTP client from verison 1.0+, and this new client is the cause of throwing these timeout issues

Pass an option `-timeout` to increase its timeout from 15s (default) to 180s, note this option is oly supported from version `1.2+`



### Improvements
- Increase timeout for `aws-es-proxy` client


### Deployment changes
- Envs that is using `AggMDS` should consider to use `aws-es-proxy: 1.2+`