### PR TITLE
Adding .slack.com to wildcard-whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -18,7 +18,6 @@ archive.linux.duke.edu
 bay.uchicago.edu
 bionimbus.tabix.oicrsofteng.org
 bits.netbeans.org
-cdis.slack.com
 centos.chicago.waneq.com
 centos.firehosted.com
 centos.mirror.ndchost.com
@@ -72,7 +71,6 @@ go.googlesource.com
 golang.org
 gopkg.in
 grafana.com
-hooks.slack.com
 http.us.debian.org
 ifconfig.io
 internet2.edu

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -77,6 +77,7 @@
 .sa-update.pccc.com
 .sencha.com
 .sks-keyservers.net
+.slack.com
 .slack-msgs.com
 .sourceforge.net
 .southsideweekly.com


### PR DESCRIPTION
Adding `.slack.com` to wildcard whitelist