### PR TITLE
feat add argo to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -13,6 +13,7 @@ dataguids.org
 api.immport.org
 api.login.yahoo.com
 api.snapcraft.io
+argoproj.github.io
 archive.cloudera.com
 archive.linux.duke.edu
 bay.uchicago.edu


### PR DESCRIPTION
### New Features
adding argoproj.github.io to squid whitelist to install argo in vhdc prod