### PR TITLE
(PXP-9536): fix `gen3 logs snapshot` when there are "Pending" pods

### DIFF
--- a/gen3/lib/logs/snapshot.sh
+++ b/gen3/lib/logs/snapshot.sh
@@ -37,7 +37,7 @@ gen3_logs_snapshot_container() {
 #
 gen3_logs_snapshot_all() {
   g3kubectl get pods -o json | \
-    jq -r '.items | map( {pod: .metadata.name, containers: .spec.containers | map(.name) } ) | map( .pod as $pod | .containers | map( { pod: $pod, cont: .})[]) | map(select(.cont != "pause" and .cont != "jupyterhub"))[] | .pod + "  " + .cont' | \
+    jq -r '.items | map(select(.status.phase != "Pending" and .status.phase != "Unknown")) | map( {pod: .metadata.name, containers: .spec.containers | map(.name) } ) | map( .pod as $pod | .containers | map( { pod: $pod, cont: .})[]) | map(select(.cont != "pause" and .cont != "jupyterhub"))[] | .pod + "  " + .cont' | \
     while read -r line; do
       gen3_logs_snapshot_container $line
     done


### PR DESCRIPTION
Jira Ticket: [PXP-9536](https://ctds-planx.atlassian.net/browse/PXP-9536)

`gen3 logs snapshot` fails to snapshot all pods' logs when it encounters a pod in the "Pending" phase. For an example, please search for "snapshot" on the [RunTests stage of a recent Nightly Builds Jenkins run](https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-4202/1/pipeline/354) and also see [the incomplete list of snapshotted logs](https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-4202/1/artifacts/).

### Bug Fixes
- Fix `gen3 logs snapshot` so that it no longer fails when a pod is in the "Pending" phase.
