### PR TITLE
Remove unnecessary revproxy timeouts for fence and presigned-url-fence

### DIFF
--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -97,9 +97,6 @@ spec:
       - name: fence
         GEN3_FENCE_IMAGE
         env:
-        # TODO remove GEN3_UWSGI_TIMEOUT after performance improvements to GA4GH DRS endpoint
-        - name: GEN3_UWSGI_TIMEOUT
-          value: "60"
         - name: DD_ENABLED
           valueFrom:
             configMapKeyRef:

--- a/kube/services/revproxy/gen3.nginx.conf/fence-service-ga4gh.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/fence-service-ga4gh.conf
@@ -3,12 +3,6 @@ location ~ \/ga4gh\/drs\/v1\/objects\/(.*)\/access {
       return 403 "failed csrf check";
     }
 
-    # TODO remove these timeouts after performance improvements to GA4GH DRS endpoint
-    proxy_connect_timeout 60;
-    proxy_send_timeout 60;
-    proxy_read_timeout 60;
-    send_timeout 60;
-
     set $proxy_service  "${presigned_url_fence_release_name}";
     set $upstream http://${presigned_url_fence_release_name}-service$des_domain;
     rewrite ^/user/(.*) /$1 break;

--- a/kube/services/revproxy/gen3.nginx.conf/fence-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/fence-service.conf
@@ -25,13 +25,6 @@ location /user/ {
       return 403 "failed csrf check";
     }
 
-    # TODO remove these timeouts after performance improvements to Fence's
-    # sync after RAS login
-    proxy_connect_timeout 60;
-    proxy_send_timeout 60;
-    proxy_read_timeout 60;
-    send_timeout 60;
-
     set $proxy_service  "${fence_release_name}";
     set $upstream http://${fence_release_name}-service$des_domain;
     rewrite ^/user/(.*) /$1 break;


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Test manually.

-->

Remove unnecessary `revproxy` timeouts for `fence` and `presigned-url-fence` services. A revert of #1804, which is no longer necessary after performance improvements to Fence sync code.
