### PR TITLE
covid19-notebok-etl cronjob: do not overwrite the startup commands

### DIFF
--- a/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
+++ b/kube/services/jobs/covid19-notebook-etl-cronjob.yaml
@@ -40,6 +40,8 @@ spec:
                   configMapKeyRef:
                     name: global
                     key: slack_webhook
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: "/secrets/credentials/default.json"
               - name: gen3Env
                 valueFrom:
                   configMapKeyRef:
@@ -54,9 +56,3 @@ spec:
                 limits:
                   cpu: 0.5
                   memory: 512Mi
-              command: ["/bin/bash" ]
-              args:
-                - "-c"
-                - |
-                  export GOOGLE_APPLICATION_CREDENTIALS=/secrets/credentials/default.json
-                  bash /src/covid19-notebook-etl-run-with-slack.sh


### PR DESCRIPTION
same as #1848, but for the cronjob
