### PR TITLE
Enable squid running on AL2

### DIFF
--- a/flavors/squid_auto/squid_running_on_docker.sh
+++ b/flavors/squid_auto/squid_running_on_docker.sh
@@ -4,7 +4,11 @@
 ###############################################################
 # variables
 ###############################################################
+DISTRO=$(awk -F '[="]*' '/^NAME/ { print $2 }' < /etc/os-release)
 WORK_USER="ubuntu"
+if [[ $DISTRO == "Amazon Linux" ]]; then
+  WORK_USER="ec2-user"
+fi
 HOME_FOLDER="/home/${WORK_USER}"
 SUB_FOLDER="${HOME_FOLDER}/cloud-automation"
 MAGIC_URL="http://169.254.169.254/latest/meta-data/"
@@ -54,8 +58,9 @@ fi
 
 
 function install_basics(){
-  apt -y install atop
-  apt -y install jq
+  if [[ $DISTRO == "Ubuntu" ]]; then
+    apt -y install atop
+  fi
 }
 
 function install_docker(){
@@ -193,8 +198,12 @@ function install_awslogs {
   ###############################################################
   # download and install awslogs
   ###############################################################
-  wget ${AWSLOGS_DOWNLOAD_URL} -O amazon-cloudwatch-agent.deb
-  dpkg -i -E ./amazon-cloudwatch-agent.deb
+  if [[ $DISTRO == "Ubuntu" ]]; then
+    wget ${AWSLOGS_DOWNLOAD_URL} -O amazon-cloudwatch-agent.deb
+    dpkg -i -E ./amazon-cloudwatch-agent.deb
+  else
+    sudo yum install amazon-cloudwatch-agent -y
+  fi
   
   # Configure the AWS logs
   

--- a/flavors/squid_auto/squid_running_on_docker.sh
+++ b/flavors/squid_auto/squid_running_on_docker.sh
@@ -202,7 +202,7 @@ function install_awslogs {
     wget ${AWSLOGS_DOWNLOAD_URL} -O amazon-cloudwatch-agent.deb
     dpkg -i -E ./amazon-cloudwatch-agent.deb
   else
-    sudo yum install amazon-cloudwatch-agent -y
+    sudo yum install amazon-cloudwatch-agent nc -y
   fi
   
   # Configure the AWS logs

--- a/flavors/squid_auto/squid_running_on_docker.sh
+++ b/flavors/squid_auto/squid_running_on_docker.sh
@@ -176,11 +176,11 @@ EOF
   # Copy the updatewhitelist.sh script to the home directory 
   cp  ${SUB_FOLDER}/flavors/squid_auto/updatewhitelist-docker.sh ${HOME_FOLDER}/updatewhitelist.sh
   chmod +x ${HOME_FOLDER}/updatewhitelist.sh
-  cp  ${SUB_FOLDER}/flavors/squid_auto/healthcheck.sh /home/ubuntu
-  chmod +x /home/ubuntu/healthcheck.sh  
+  cp  ${SUB_FOLDER}/flavors/squid_auto/healthcheck.sh ${HOME_FOLDER}/healtcheck.sh
+  chmod +x ${HOME_FOLDER}/healthcheck.sh  
 
   crontab -l > crontab_file; echo "*/15 * * * * ${HOME_FOLDER}/updatewhitelist.sh >/dev/null 2>&1" >> crontab_file
-  echo '*/1 * * * * /home/ubuntu/healthcheck.sh >/dev/null 2>&1' >> crontab_file
+  echo "*/1 * * * * ${HOME_FOLDER}/healthcheck.sh >/dev/null 2>&1" >> crontab_file
   #chown -R ${WORK_USER}. ${HOME_FOLDER}
   crontab crontab_file
 

--- a/flavors/squid_auto/updatewhitelist-docker.sh
+++ b/flavors/squid_auto/updatewhitelist-docker.sh
@@ -3,7 +3,12 @@
 ###############################################################
 # variables
 ###############################################################
-MAIN_HOME="/home/ubuntu"
+DISTRO=$(awk -F '[="]*' '/^NAME/ { print $2 }' < /etc/os-release)
+USER="ubuntu"
+if [[ $DISTRO == "Amazon Linux" ]]; then
+  USER="ec2-user"
+fi
+MAIN_HOME="/home/$USER"
 SFTP_HOME="/home/sftpuser"
 declare -a WHITELIST_FILES
 WHITELIST_FILES=( "web_whitelist" "web_wildcard_whitelist" "ftp_whitelist")

--- a/flavors/squid_auto/updatewhitelist.sh
+++ b/flavors/squid_auto/updatewhitelist.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
+DISTRO=$(awk -F '[="]*' '/^NAME/ { print $2 }' < /etc/os-release)
+USER="ubuntu"
+if [[ $DISTRO == "Amazon Linux" ]]; then
+  USER="ec2-user"
+fi
 
-(cd /home/ubuntu/cloud-automation && git pull)
+(cd /home/$USER/cloud-automation && git pull)
 (cd /home/sftpuser/cloud-automation && git pull)
 
 echo "Checking if list of authorized keys have changed for admin"
-diff "/home/ubuntu/cloud-automation/files/authorized_keys/squid_authorized_keys_admin" "/home/ubuntu/.ssh/authorized_keys"
+diff "/home/$USER/cloud-automation/files/authorized_keys/squid_authorized_keys_admin" "/home/$USER/.ssh/authorized_keys"
 DIFF_AUTH1=$?
 if [ "$DIFF_AUTH1" -ne 0  ] ; then
 echo "There is a change in authorized_keys for admin"
-rsync -a /home/ubuntu/cloud-automation/files/authorized_keys/squid_authorized_keys_admin /home/ubuntu/.ssh/authorized_keys
+rsync -a /home/$USER/cloud-automation/files/authorized_keys/squid_authorized_keys_admin /home/$USER/.ssh/authorized_keys
 fi
 
 
@@ -22,27 +27,27 @@ fi
 
 
 echo "Checking if web_whitelist has changed"
-diff "/home/ubuntu/cloud-automation/files/squid_whitelist/web_whitelist" "/etc/squid/web_whitelist"
+diff "/home/$USER/cloud-automation/files/squid_whitelist/web_whitelist" "/etc/squid/web_whitelist"
 DIFF_SQUID1=$?
 if [ "$DIFF_SQUID1" -ne 0  ] ; then
 echo "There is a change in web_whitelist"
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/web_whitelist /etc/squid/web_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/web_whitelist /etc/squid/web_whitelist
 fi
 
 echo "Checking if web_wildcard_whitelist has changed"
-diff "/home/ubuntu/cloud-automation/files/squid_whitelist/web_wildcard_whitelist" "/etc/squid/web_wildcard_whitelist"
+diff "/home/$USER/cloud-automation/files/squid_whitelist/web_wildcard_whitelist" "/etc/squid/web_wildcard_whitelist"
 DIFF_SQUID2=$?
 if [ "$DIFF_SQUID2" -ne 0  ] ; then
 echo "There is a change in web_wildcard_whitelist"
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/web_wildcard_whitelist /etc/squid/web_wildcard_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/web_wildcard_whitelist /etc/squid/web_wildcard_whitelist
 fi
 
 echo "Checking if ftp whitelist has changed"
-diff "/home/ubuntu/cloud-automation/files/squid_whitelist/ftp_whitelist" "/etc/squid/ftp_whitelist"
+diff "/home/$USER/cloud-automation/files/squid_whitelist/ftp_whitelist" "/etc/squid/ftp_whitelist"
 DIFF_SQUID3=$?
 if [ "$DIFF_SQUID3" -ne 0  ] ; then
 echo "There is a change in ftp_whitelist"
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/ftp_whitelist /etc/squid/ftp_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/ftp_whitelist /etc/squid/ftp_whitelist
 fi
 
 

--- a/flavors/squid_nlb/updatewhitelist.sh
+++ b/flavors/squid_nlb/updatewhitelist.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
+DISTRO=$(awk -F '[="]*' '/^NAME/ { print $2 }' < /etc/os-release)
+USER="ubuntu"
+if [[ $DISTRO == "Amazon Linux" ]]; then
+  USER="ec2-user"
+fi
 
-(cd /home/ubuntu/cloud-automation && git pull)
+
+(cd /home/$USER/cloud-automation && git pull)
 (cd /home/sftpuser/cloud-automation && git pull)
 
-DIFF_AUTH1=$(diff "/home/ubuntu/cloud-automation/files/authorized_keys/squid_authorized_keys_admin" "/home/ubuntu/.ssh/authorized_keys")
+DIFF_AUTH1=$(diff "/home/$USER/cloud-automation/files/authorized_keys/squid_authorized_keys_admin" "/home/$USER/.ssh/authorized_keys")
 DIFF_AUTH2=$(diff "/home/sftpuser/cloud-automation/files/authorized_keys/squid_authorized_keys_user" "/home/sftpuser/.ssh/authorized_keys")
 
-DIFF_SQUID1=$(diff "/home/ubuntu/cloud-automation/files/squid_whitelist/web_whitelist" "/etc/squid/web_whitelist")
-DIFF_SQUID2=$(diff "/home/ubuntu/cloud-automation/files/squid_whitelist/web_wildcard_whitelist" "/etc/squid/web_wildcard_whitelist")
-DIFF_SQUID3=$(diff "/home/ubuntu/cloud-automation/files/squid_whitelist/ftp_whitelist" "/etc/squid/ftp_whitelist")
+DIFF_SQUID1=$(diff "/home/$USER/cloud-automation/files/squid_whitelist/web_whitelist" "/etc/squid/web_whitelist")
+DIFF_SQUID2=$(diff "/home/$USER/cloud-automation/files/squid_whitelist/web_wildcard_whitelist" "/etc/squid/web_wildcard_whitelist")
+DIFF_SQUID3=$(diff "/home/$USER/cloud-automation/files/squid_whitelist/ftp_whitelist" "/etc/squid/ftp_whitelist")
 
 if [ "$DIFF_AUTH1" != ""  ] ; then
-rsync -a /home/ubuntu/cloud-automation/files/authorized_keys/squid_authorized_keys_admin /home/ubuntu/.ssh/authorized_keys
+rsync -a /home/$USER/cloud-automation/files/authorized_keys/squid_authorized_keys_admin /home/$USER/.ssh/authorized_keys
 fi
 
 if [ "$DIFF_AUTH2" != ""  ] ; then
@@ -20,15 +26,15 @@ fi
 
 
 if [ "$DIFF_SQUID1" != ""  ] ; then
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/web_whitelist /etc/squid/web_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/web_whitelist /etc/squid/web_whitelist
 fi
 
 if [ "$DIFF_SQUID2" != ""  ] ; then
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/web_wildcard_whitelist /etc/squid/web_wildcard_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/web_wildcard_whitelist /etc/squid/web_wildcard_whitelist
 fi
 
 if [ "$DIFF_SQUID3" != ""  ] ; then
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/ftp_whitelist /etc/squid/ftp_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/ftp_whitelist /etc/squid/ftp_whitelist
 fi
 
 if ([ "$DIFF_SQUID1" != "" ]  ||  [ "$DIFF_SQUID2" != "" ] || [ "$DIFF_SQUID3" != "" ]) ; then

--- a/flavors/squid_nlb_central/updatewhitelist.sh
+++ b/flavors/squid_nlb_central/updatewhitelist.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-(cd /home/ubuntu/cloud-automation && git pull)
+DISTRO=$(awk -F '[="]*' '/^NAME/ { print $2 }' < /etc/os-release)
+USER="ubuntu"
+if [[ $DISTRO == "Amazon Linux" ]]; then
+  USER="ec2-user"
+fi
+
+
+(cd /home/$USER/cloud-automation && git pull)
 (cd /home/sftpuser/cloud-automation && git pull)
 
 echo "Checking if list of authorized keys have changed for admin"
-diff "/home/ubuntu/cloud-automation/files/authorized_keys/squid_authorized_keys_admin" "/home/ubuntu/.ssh/authorized_keys"
+diff "/home/$USER/cloud-automation/files/authorized_keys/squid_authorized_keys_admin" "/home/$USER/.ssh/authorized_keys"
 DIFF_AUTH1=$?
 if [ "$DIFF_AUTH1" -ne 0  ] ; then
 echo "There is a change in authorized_keys for admin"
-rsync -a /home/ubuntu/cloud-automation/files/authorized_keys/squid_authorized_keys_admin /home/ubuntu/.ssh/authorized_keys
+rsync -a /home/$USER/cloud-automation/files/authorized_keys/squid_authorized_keys_admin /home/$USER/.ssh/authorized_keys
 fi
 
 
@@ -22,27 +29,27 @@ fi
 
 
 echo "Checking if web_whitelist has changed"
-diff "/home/ubuntu/cloud-automation/files/squid_whitelist/web_whitelist" "/etc/squid/web_whitelist"
+diff "/home/$USER/cloud-automation/files/squid_whitelist/web_whitelist" "/etc/squid/web_whitelist"
 DIFF_SQUID1=$?
 if [ "$DIFF_SQUID1" -ne 0  ] ; then
 echo "There is a change in web_whitelist"
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/web_whitelist /etc/squid/web_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/web_whitelist /etc/squid/web_whitelist
 fi
 
 echo "Checking if web_wildcard_whitelist has changed"
-diff "/home/ubuntu/cloud-automation/files/squid_whitelist/web_wildcard_whitelist" "/etc/squid/web_wildcard_whitelist"
+diff "/home/$USER/cloud-automation/files/squid_whitelist/web_wildcard_whitelist" "/etc/squid/web_wildcard_whitelist"
 DIFF_SQUID2=$?
 if [ "$DIFF_SQUID2" -ne 0  ] ; then
 echo "There is a change in web_wildcard_whitelist"
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/web_wildcard_whitelist /etc/squid/web_wildcard_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/web_wildcard_whitelist /etc/squid/web_wildcard_whitelist
 fi
 
 echo "Checking if ftp whitelist has changed"
-diff "/home/ubuntu/cloud-automation/files/squid_whitelist/ftp_whitelist" "/etc/squid/ftp_whitelist"
+diff "/home/$USER/cloud-automation/files/squid_whitelist/ftp_whitelist" "/etc/squid/ftp_whitelist"
 DIFF_SQUID3=$?
 if [ "$DIFF_SQUID3" -ne 0  ] ; then
 echo "There is a change in ftp_whitelist"
-rsync -a /home/ubuntu/cloud-automation/files/squid_whitelist/ftp_whitelist /etc/squid/ftp_whitelist
+rsync -a /home/$USER/cloud-automation/files/squid_whitelist/ftp_whitelist /etc/squid/ftp_whitelist
 fi
 
 

--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -15,6 +15,7 @@ provider "aws" {}
 
 module "cdis_vpc" {
   ami_account_id                 = "${var.ami_account_id}"
+  squid_image_search_criteria    = "${var.squid_image_search_criteria}"
   source                         = "../modules/vpc"
   vpc_cidr_block                 = "${var.vpc_cidr_block}"
   vpc_name                       = "${var.vpc_name}"

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -135,7 +135,7 @@ variable "gdcapi_oauth2_client_secret" {
 
 # id of AWS account that owns the public AMI's
 variable "ami_account_id" {
-  default = "707767160287"
+  default = "099720109477"
 }
 
 variable "squid_image_search_criteria" {

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -138,6 +138,11 @@ variable "ami_account_id" {
   default = "707767160287"
 }
 
+variable "squid_image_search_criteria" {
+  description = "Search criteria for squid AMI look up"
+  default     = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*"
+}
+
 variable "peering_vpc_id" {
   default = "vpc-e2b51d99"
 }

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -50,6 +50,11 @@ resource "aws_iam_role_policy" "squid_policy" {
   role   = "${aws_iam_role.squid-auto_role.id}"
 }
 
+# Amazon SSM Policy 
+resource "aws_iam_role_policy_attachment" "eks-policy-AmazonSSMManagedInstanceCore" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role   = "${aws_iam_role.squid-auto_role.id}"
+}
 
 resource "aws_iam_instance_profile" "squid-auto_role_profile" {
   count = "${var.deploy_ha_squid ? 1 : 0}"

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -132,9 +132,12 @@ USER_HOME="/home/$USER"
 CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
 (
   cd $USER_HOME
+  if [[ ! -z "${var.slack_webhook}" ]]; then
+    echo "${var.slack_webhook}" > /slackWebhook
+  fi
   if [[ $DISTRO == "Amazon Linux" ]]; then
     sudo yum update -y
-    sudo yum install git -y
+    sudo yum install git lsof -y
   fi
   git clone https://github.com/uc-cdis/cloud-automation.git
   cd $CLOUD_AUTOMATION
@@ -168,7 +171,7 @@ CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
   # https://success.qualys.com/discussions/s/question/0D52L00004TnwvgSAB/installing-qualys-cloud-agent-on-amazon-linux-2-instances
   if [[ $DISTRO == "Ubuntu" ]]; then
     if [[ ! -z "${var.activation_id}" ]] || [[ ! -z "${var.customer_id}" ]]; then
-      apt install awscli -y
+      apt install awscli jq -y
       aws s3 cp s3://qualys-agentpackage/QualysCloudAgent.deb ./qualys-cloud-agent.x86_64.deb
       dpkg -i ./qualys-cloud-agent.x86_64.deb
       # Clean up deb package after install

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -117,12 +117,19 @@ resource "aws_launch_configuration" "squid_auto" {
 
 user_data = <<EOF
 #!/bin/bash
-
+DISTRO=$(awk -F '[="]*' '/^NAME/ { print $2 }' < /etc/os-release)
 USER="ubuntu"
+if [[ $DISTRO == "Amazon Linux" ]]; then
+  USER="ec2-user"
+fi
 USER_HOME="/home/$USER"
 CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
 (
   cd $USER_HOME
+  if [[ $DISTRO == "Amazon Linux" ]]; then
+    sudo yum update -y
+    sudo yum install git -y
+  fi
   git clone https://github.com/uc-cdis/cloud-automation.git
   cd $CLOUD_AUTOMATION
   git pull
@@ -133,36 +140,35 @@ CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
     git checkout "${var.branch}"
     git pull
   fi
-  chown -R ubuntu. $CLOUD_AUTOMATION
+  chown -R $USER. $CLOUD_AUTOMATION
 
   echo "127.0.1.1 ${var.env_squid_name}" | tee --append /etc/hosts
   hostnamectl set-hostname ${var.env_squid_name}
+  if [[ $DISTRO == "Ubuntu" ]]; then
+    apt -y update
+    DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' upgrade 
 
-  apt -y update
-  DEBIAN_FRONTEND='noninteractive' apt-get -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' upgrade 
-
-  apt autoremove -y
-  apt clean
-  apt autoclean
-
-  cd $USER_HOME
-  
-  # Create a file with the slack webhook, so that the healtcheck script can access it
-  if [[ ! -z "${var.slack_webhook}" ]]; then
-    echo "${var.slack_webhook}" > /slackWebhook
+    apt autoremove -y
+    apt clean
+    apt autoclean
   fi
-  
+  cd $USER_HOME
+
   bash "${var.bootstrap_path}${var.bootstrap_script}" "cwl_group=${var.env_log_group};${join(";",var.extra_vars)}" 2>&1
   cd $CLOUD_AUTOMATION
   git checkout master
   # Install qualys agent if the activtion and customer id provided
-  if [[ ! -z "${var.activation_id}" ]] || [[ ! -z "${var.customer_id}" ]]; then
-    apt install awscli -y
-    aws s3 cp s3://qualys-agentpackage/QualysCloudAgent.deb ./qualys-cloud-agent.x86_64.deb
-    dpkg -i ./qualys-cloud-agent.x86_64.deb
-    # Clean up deb package after install
-    rm qualys-cloud-agent.x86_64.deb
-    sudo /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent.sh ActivationId=${var.activation_id} CustomerId=${var.customer_id}
+  # Amazon Linux does not support qualys agent (?)
+  # https://success.qualys.com/discussions/s/question/0D52L00004TnwvgSAB/installing-qualys-cloud-agent-on-amazon-linux-2-instances
+  if [[ $DISTRO == "Ubuntu" ]]; then
+    if [[ ! -z "${var.activation_id}" ]] || [[ ! -z "${var.customer_id}" ]]; then
+      apt install awscli -y
+      aws s3 cp s3://qualys-agentpackage/QualysCloudAgent.deb ./qualys-cloud-agent.x86_64.deb
+      dpkg -i ./qualys-cloud-agent.x86_64.deb
+      # Clean up deb package after install
+      rm qualys-cloud-agent.x86_64.deb
+      sudo /usr/local/qualys/cloud-agent/bin/qualys-cloud-agent.sh ActivationId=${var.activation_id} CustomerId=${var.customer_id}
+    fi
   fi
 ) > /var/log/bootstrapping_script.log
 EOF

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -52,6 +52,7 @@ resource "aws_iam_role_policy" "squid_policy" {
 
 # Amazon SSM Policy 
 resource "aws_iam_role_policy_attachment" "eks-policy-AmazonSSMManagedInstanceCore" {
+  count = "${var.deploy_ha_squid ? 1 : 0}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   role   = "${aws_iam_role.squid-auto_role.id}"
 }

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -28,6 +28,7 @@ module "squid-auto" {
   squid_proxy_subnet             = "${var.network_expansion ? cidrsubnet(var.vpc_cidr_block,5,3) : cidrsubnet(var.vpc_cidr_block,4,1)}"
   organization_name              = "${var.organization_name}"
   ssh_key_name                   = "${var.ssh_key_name}"
+  ami_account_id                 = "${var.ami_account_id}"
   image_name_search_criteria     = "${var.squid_image_search_criteria}"
   squid_instance_drive_size      = "${var.squid_instance_drive_size}"
   squid_availability_zones       = "${var.availability_zones}"

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -1,6 +1,6 @@
 # id of AWS account that owns the public AMI's
 variable "ami_account_id" {
-  default = "707767160287"
+  default = "099720109477"
 }
 
 variable "vpc_name" {}


### PR DESCRIPTION
Enable squid to be ran on amazon linux 2 instances. We can use custom ami's f.ex an AMI with FIPS enabled. 

To override default behaviour (ubuntu instance) we need to supply the following variables 

```
squid_image_search_criteria = "amazon-eks-node-1-21*"
ami_account_id="707767160287"
ha-squid_instance_drive_size=25

branch="feat/squid_al2"
```

Also attaching SSM IAM policy so we can use ssm to manage instances in case ssh isn't working. 