### PR TITLE
fix(installation of cloud-automation into a subfolder)  (#1774)

### DIFF
--- a/gen3/bin/kube-setup-workvm.sh
+++ b/gen3/bin/kube-setup-workvm.sh
@@ -303,7 +303,7 @@ EOF
 
   if ! grep 'GEN3_HOME=' ${WORKSPACE}/.${RC_FILE} > /dev/null; then
     cat - >>${WORKSPACE}/.${RC_FILE} <<EOF
-export GEN3_HOME=${WORKSPACE}/cloud-automation
+export GEN3_HOME=${GEN3_HOME}
 if [ -f "\${GEN3_HOME}/gen3/gen3setup.sh" ]; then
   source "\${GEN3_HOME}/gen3/gen3setup.sh"
 fi

--- a/gen3/bin/workon.sh
+++ b/gen3/bin/workon.sh
@@ -113,7 +113,7 @@ if [[ ! -f "$bucketCheckFlag" && "$GEN3_FLAVOR" == "AWS" ]]; then
   }
 EOM
 )
-    gen3_aws_run aws s3api create-bucket --acl private --bucket "$GEN3_S3_BUCKET"
+    gen3_aws_run aws s3api create-bucket --acl private --bucket "$GEN3_S3_BUCKET" --create-bucket-configuration LocationConstraint="$(aws configure get $GEN3_PROFILE.region)"
     sleep 5 # Avoid race conditions
     if gen3_aws_run aws s3api put-bucket-encryption --bucket "$GEN3_S3_BUCKET" --server-side-encryption-configuration "$S3_POLICY"; then
       touch "$bucketCheckFlag"


### PR DESCRIPTION
* when cloud-automation is installed into a subfolder, the wrong GEN3_HOME will be defined in .bashrc. This fix sets the correct GEN3_HOME folder.

* fix(outside us-east-1 bucket creation fails)