### PR TITLE
chore: Whiteslist apt.kubernetes.io

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -13,6 +13,7 @@ dataguids.org
 api.immport.org
 api.login.yahoo.com
 api.snapcraft.io
+apt.kubernetes.io
 argoproj.github.io
 archive.cloudera.com
 archive.linux.duke.edu


### PR DESCRIPTION
whitelist apt.kubernetes.io - Kubernetes apt repository

### Improvements
whitelist apt.kubernetes.io - Kubernetes apt repository

