### PR TITLE
close external calls to cohort-data/* endpoints

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/cohort-middleware-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/cohort-middleware-service.conf
@@ -6,3 +6,9 @@ location /cohort-middleware/ {
     proxy_pass $upstream;
     client_max_body_size 0;
 }
+
+location /cohort-middleware/cohort-data/ {
+    # Do not expose /cohort-middleware/cohort-data/* . The cohort-data endpoints should
+    # only be used by internal services, and never be exposed to users/browsers:
+    deny all;
+}


### PR DESCRIPTION
Jira Ticket: [PXP-9789](https://ctds-planx.atlassian.net/browse/PXP-9789)

### New Features

* Closing external access to cohort-data/* endpoints. The cohort-data endpoints should  only be used by internal services, and never be exposed to users/browsers.
