### PR TITLE
dicom-server client_max_body_size 0

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/dicom-server-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/dicom-server-service.conf
@@ -7,4 +7,7 @@ location /dicom-server/ {
     set $upstream http://dicom-server-service.$namespace.svc.cluster.local;
     rewrite ^/dicom-server/(.*) /$1 break;
     proxy_pass $upstream;
+
+    # no limit to payload size so we can upload large DICOM files
+    client_max_body_size 0;
 }


### PR DESCRIPTION


### Improvements
- DICOM server: no limit to payload size so we can upload large DICOM files
