### PR TITLE
(PXP-9849): Fix mutate-guppy-config-for-pfb-export-test.sh so that index and type match

### DIFF
--- a/doc/gitops.md
+++ b/doc/gitops.md
@@ -45,6 +45,14 @@ Note: if a key exists both under the `manifests/` folder and in `manifest.json`,
 
 Note: also as a random help updates the `etl-mapping` configmap from `etlMapping.yaml`
 
+### configmaps-from-json
+
+Create a `manifest-` configmap from the given json blob.
+
+```
+gen3 gitops configmaps-from-json manifest-guppy "$guppyConfig"
+```
+
 ### enforce
 
 Force the local `cdis-manifest/` and `cloud-automation/` folders to sync with github.

--- a/gen3/bin/gitops.sh
+++ b/gen3/bin/gitops.sh
@@ -1053,6 +1053,9 @@ if [[ -z "$GEN3_SOURCE_ONLY" ]]; then
     "configmaps")
       gen3_gitops_configmaps "$@"
       ;;
+    "configmaps-from-json")
+      gen3_gitops_json_to_configmap "$@"
+      ;;
     "configmaps-list")
       gen3_gitops_configmaps_list "$@"
       ;;

--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -21,6 +21,13 @@ if ! shift; then
 fi
 
 g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
-yq -yi '.mappings[].name |= "'"${prNumber}.${repoName}."'" + .' etlMapping.yaml
+
+prefix="${prNumber}.${repoName}."
+if ! grep "$prefix" etlMapping.yaml; then
+ gen3_log_info "ETL Mapping has already been mutated by a previous run of this script"
+ exit 0
+fi
+
+yq -yi '.mappings[].name |= "'"${prefix}"'" + .' etlMapping.yaml
 g3kubectl delete configmap etl-mapping
 g3kubectl create configmap etl-mapping --from-file=etlMapping.yaml=etlMapping.yaml

--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -23,7 +23,7 @@ fi
 g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
 
 prefix="${prNumber}.${repoName}."
-if ! grep "$prefix" etlMapping.yaml; then
+if grep "$prefix" etlMapping.yaml; then
  gen3_log_info "ETL Mapping has already been mutated by a previous run of this script"
  exit 0
 fi

--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -21,6 +21,6 @@ if ! shift; then
 fi
 
 g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
-yq -i '.mappings[].name |= "'"${prNumber}.${repoName}."'" + .' etlMapping.yaml
+yq -yi '.mappings[].name |= "'"${prNumber}.${repoName}."'" + .' etlMapping.yaml
 g3kubectl delete configmap etl-mapping
 g3kubectl create configmap etl-mapping --from-file=etlMapping.yaml=etlMapping.yaml

--- a/gen3/bin/mutate-etl-mapping-config.sh
+++ b/gen3/bin/mutate-etl-mapping-config.sh
@@ -11,8 +11,6 @@ set -xe
 # how it is executed?
 # gen3 mutate-etl-mapping-config {PR} {repoName}
 
-echo "hello world"
-
 prNumber=$1
 shift
 repoName=$1
@@ -23,8 +21,6 @@ if ! shift; then
 fi
 
 g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' > etlMapping.yaml
-sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_subject$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_subject/' etlMapping.yaml
-sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_etl$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_etl/' etlMapping.yaml
-sed -i 's/^[[:space:]][[:space:]]- name: \(.*\)_file$/  - name: '"${prNumber}"'.'"${repoName}"'.\1_file/' etlMapping.yaml
+yq -i '.mappings[].name |= "'"${prNumber}.${repoName}."'" + .' etlMapping.yaml
 g3kubectl delete configmap etl-mapping
 g3kubectl create configmap etl-mapping --from-file=etlMapping.yaml=etlMapping.yaml

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -25,5 +25,5 @@ newGuppyConfig="$(jq '.indices[].index |= "'"${prNumber}.${repoName}."'" + .' <<
 newGuppyConfig="$(jq '.config_index |= "'"${prNumber}.${repoName}."'" + .' <<< "$newGuppyConfig")"
 
 g3kubectl delete configmap manifest-guppy
-gen3 configmaps-from-json manifest-guppy "$newGuppyConfig"
+gen3 gitops configmaps-from-json manifest-guppy "$newGuppyConfig"
 gen3 roll guppy

--- a/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
+++ b/gen3/bin/mutate-guppy-config-for-pfb-export-test.sh
@@ -20,33 +20,10 @@ if ! shift; then
  exit 1
 fi
 
-# capture the names from the ETL mapping
-echo "debugging"
-etl_mapping_subject=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[0].name)
-echo "### ## etl_mapping_subject: ${etl_mapping_subject}"
-etl_mapping_file=$(g3kubectl get cm etl-mapping -o jsonpath='{.data.etlMapping\.yaml}' | yq .mappings[1].name)
-echo "echo "### ## etl_mapping_file: ${etl_mapping_file}"
-etl_config=$(echo $etl_mapping_subject | tr -d '"' | sed 's/\(.*\)_\(.*\)$/\1_array-config/')
-echo "### ## etl_config: ${etl_config}"
-
-g3kubectl get configmap manifest-guppy -o yaml > original_guppy_config.yaml
-# mutating permanent jenkins config
-sed -i 's/\(.*\)"index": "\(.*\)_subject",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_etl",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
-# exclusive for bloodpac-like envs
-sed -i 's/\(.*\)"index": "\(.*\)_study",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
-# the pre-defined Canine index works with subject ONLY (never case)
-sed -i 's/\(.*\)"type": "case"$/\1"type": "subject"/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file",$/\1"index": '"${etl_mapping_file}"',/' original_guppy_config.yaml
-# note: including double-quotes around etl_config here
-sed -i 's/\(.*\)"config_index": "\(.*\)_array-config",$/\1"config_index": "'"${etl_config}"'",/' original_guppy_config.yaml
-
-# mutating after guppy test (pre-defined canine config) and some qa-* env guppy configs
-sed -i 's/\(.*\)"index": "\(.*\)_subject_alias",$/\1"index": '"${etl_mapping_subject}"',/' original_guppy_config.yaml
-sed -i 's/\(.*\)"index": "\(.*\)_file_alias",$/\1"index": '"${etl_mapping_file}"',/' original_guppy_config.yaml
-# note: including double-quotes around etl_config here
-sed -i 's/\(.*\)"config_index": "\(.*\)_configs_alias",$/\1"config_index": "'"${etl_config}"'",/' original_guppy_config.yaml
+oldGuppyConfig="$(g3kubectl get configmap manifest-guppy -o jsonpath='{.data.json}')"
+newGuppyConfig="$(jq '.indices[].index |= "'"${prNumber}.${repoName}."'" + .' <<< "$oldGuppyConfig")"
+newGuppyConfig="$(jq '.config_index |= "'"${prNumber}.${repoName}."'" + .' <<< "$newGuppyConfig")"
 
 g3kubectl delete configmap manifest-guppy
-g3kubectl apply -f original_guppy_config.yaml
+gen3 configmaps-from-json manifest-guppy "$newGuppyConfig"
 gen3 roll guppy


### PR DESCRIPTION
Jira Ticket: [PXP-9849](https://ctds-planx.atlassian.net/browse/PXP-9849)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.

-->
Previously, `gen3/bin/mutate-guppy-config-for-pfb-export-test.sh` assumed that the first and second entires in the `etlMapping.yaml` are `subject` and `file` types, respectively. However, `subject` [appears as the second entry in PRC's etlMapping.yaml](https://github.com/uc-cdis/cdis-manifest/blob/620ff071135db7064d3a625b3b9a87e6db19c258/chicagoland.pandemicresponsecommons.org/etlMapping.yaml#L166), resulting in a guppy config with mismatched types (e.g. an index `4509.cdis-manifest.covid19_subject` having type `file` (see Guppy logs in ticket)).

[Guppy pod has been failing to start](https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-4509/3/tests) during PFB Export tests using PRC as env.

Using this branch and PRC as env, [Guppy pod successfully started](https://jenkins.planx-pla.net/blue/organizations/jenkins/CDIS_GitHub_Org%2Fcdis-manifest/detail/PR-4541/1/tests) during PFB Export tests.

### Bug Fixes
- Fix `mutate-guppy-config-for-pfb-export-test` so that indices have correct types

### Improvements
- In `mutate-etl-mapping-config`, mutate all `etlMapping.yaml` names so that all aliases created have consistent prefix
