### PR TITLE
Add data.cityofchicago.org to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -10,6 +10,7 @@ biodata-integration-tests.net
 biorender.com
 clinicaltrials.gov
 ctds-planx.atlassian.net
+data.cityofchicago.org
 dataguids.org
 api.login.yahoo.com
 api.snapcraft.io


### PR DESCRIPTION
Add data.cityofchicago.org to squid whitelist
For PRC ETL https://github.com/uc-cdis/covid19-tools/pull/265