### PR TITLE
(PXP-9967): Create RAS cronjobs if Fence >= 6.0.0 || Fence >= 2022.07

### DIFF
--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -77,17 +77,16 @@ gen3_log_info "The fence service has been deployed onto the k8s cluster."
 gen3 kube-setup-google
 
 # add cronjob for removing expired ga4gh info for required fence versions
-# TODO: WILL UNCOMMENT THIS ONCE FEATURE IN FENCE IS RELEASED
-# if isServiceVersionGreaterOrEqual "fence" "6.0.0" "2022.04"; then
-#   # Setup db cleanup cronjob
-#   if ! g3kubectl get cronjob fence-cleanup-expired-ga4gh-info >/dev/null 2>&1; then
-#       echo "fence-cleanup-expired-ga4gh-info being added as a cronjob b/c fence >= 6.0.0 or 2022.04"
-#       gen3 job cron fence-cleanup-expired-ga4gh-info "*/5 * * * *"
-#   fi
-#
-#   # Setup visa update cronjob
-#   if ! g3kubectl get cronjob fence-visa-update >/dev/null 2>&1; then
-#       echo "fence-visa-update being added as a cronjob b/c fence >= 6.0.0 or 2022.04"
-#       gen3 job cron fence-visa-update "30 * * * *"
-#   fi
-# fi
+if isServiceVersionGreaterOrEqual "fence" "6.0.0" "2022.07"; then
+  # Setup db cleanup cronjob
+  if ! g3kubectl get cronjob fence-cleanup-expired-ga4gh-info >/dev/null 2>&1; then
+      echo "fence-cleanup-expired-ga4gh-info being added as a cronjob b/c fence >= 6.0.0 or 2022.07"
+      gen3 job cron fence-cleanup-expired-ga4gh-info "*/5 * * * *"
+  fi
+
+  # Setup visa update cronjob
+  if ! g3kubectl get cronjob fence-visa-update >/dev/null 2>&1; then
+      echo "fence-visa-update being added as a cronjob b/c fence >= 6.0.0 or 2022.07"
+      gen3 job cron fence-visa-update "30 * * * *"
+  fi
+fi

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -77,7 +77,8 @@ gen3_log_info "The fence service has been deployed onto the k8s cluster."
 gen3 kube-setup-google
 
 # add cronjob for removing expired ga4gh info for required fence versions
-if isServiceVersionGreaterOrEqual "fence" "6.0.0" "2022.07"; then
+currentFenceVersion=$( [[ $(g3k_manifest_lookup ".versions.fence") =~ \:(.*) ]] && echo "${BASH_REMATCH[1]}")
+if isRepoCommitGreaterOrEqual "fence" ${currentFenceVersion} "6.0.0" "2022.07"; then
   # Setup db cleanup cronjob
   if ! g3kubectl get cronjob fence-cleanup-expired-ga4gh-info >/dev/null 2>&1; then
       echo "fence-cleanup-expired-ga4gh-info being added as a cronjob b/c fence >= 6.0.0 or 2022.07"

--- a/gen3/bin/kube-setup-fence.sh
+++ b/gen3/bin/kube-setup-fence.sh
@@ -77,8 +77,7 @@ gen3_log_info "The fence service has been deployed onto the k8s cluster."
 gen3 kube-setup-google
 
 # add cronjob for removing expired ga4gh info for required fence versions
-currentFenceVersion=$( [[ $(g3k_manifest_lookup ".versions.fence") =~ \:(.*) ]] && echo "${BASH_REMATCH[1]}")
-if isRepoCommitGreaterOrEqual "fence" ${currentFenceVersion} "6.0.0" "2022.07"; then
+if isServiceVersionGreaterOrEqual "fence" "6.0.0" "2022.07"; then
   # Setup db cleanup cronjob
   if ! g3kubectl get cronjob fence-cleanup-expired-ga4gh-info >/dev/null 2>&1; then
       echo "fence-cleanup-expired-ga4gh-info being added as a cronjob b/c fence >= 6.0.0 or 2022.07"

--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -75,8 +75,7 @@ confFileList+=("--from-file" "$scriptDir/gen3.nginx.conf/README.md")
 # load priority confs first (who need to fallback on later confs)
 
 # add new nginx conf to route ga4gh access requests to fence instead of indexd
-currentFenceVersion=$( [[ $(g3k_manifest_lookup ".versions.fence") =~ \:(.*) ]] && echo "${BASH_REMATCH[1]}")
-if isRepoCommitGreaterOrEqual "fence" ${currentFenceVersion} "5.5.0" "2021.10"; then
+if isServiceVersionGreaterOrEqual "fence" "5.5.0" "2021.10"; then
   filePath="$scriptDir/gen3.nginx.conf/fence-service-ga4gh.conf"
   if [[ -f "$filePath" ]]; then
     echo "$filePath being added to nginx conf file list b/c fence >= 5.4.0 or 2021.10"

--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -75,7 +75,8 @@ confFileList+=("--from-file" "$scriptDir/gen3.nginx.conf/README.md")
 # load priority confs first (who need to fallback on later confs)
 
 # add new nginx conf to route ga4gh access requests to fence instead of indexd
-if isServiceVersionGreaterOrEqual "fence" "5.5.0" "2021.10"; then
+currentFenceVersion=$( [[ $(g3k_manifest_lookup ".versions.fence") =~ \:(.*) ]] && echo "${BASH_REMATCH[1]}")
+if isRepoCommitGreaterOrEqual "fence" ${currentFenceVersion} "5.5.0" "2021.10"; then
   filePath="$scriptDir/gen3.nginx.conf/fence-service-ga4gh.conf"
   if [[ -f "$filePath" ]]; then
     echo "$filePath being added to nginx conf file list b/c fence >= 5.4.0 or 2021.10"

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -109,11 +109,11 @@ semver_ge() {
 # @param imageTag
 #
 # examples:
-#   - `convertImageTagToGitBranch "feat_passport"` returns "feat/passport"
-#   - `convertImageTagToGitBranch "chore_passport"` returns "chore/passport"
-#   - `convertImageTagToGitBranch "feat_passport_extra_info"` returns "feat/passport_extra_info"
-#   - `convertImageTagToGitBranch "passport"` returns "passport"
-#   - `convertImageTagToGitBranch "passport_extra_info"` returns "passport_extra_info"
+#   - `convertImageTagToGitBranch "feat_passport"` evaluates to "feat/passport"
+#   - `convertImageTagToGitBranch "chore_passport"` evaluates to "chore/passport"
+#   - `convertImageTagToGitBranch "feat_passport_extra_info"` evaluates to "feat/passport_extra_info"
+#   - `convertImageTagToGitBranch "passport"` evaluates to "passport"
+#   - `convertImageTagToGitBranch "passport_extra_info"` evaluates to "passport_extra_info"
 convertImageTagToGitBranch() {
   if [[ -z "$1" ]]; then
     gen3_log_err "convertImageTagToBranch" "requires imageTag as its only argument"
@@ -129,11 +129,12 @@ convertImageTagToGitBranch() {
     branchPrefix=${prefixes[$imagePrefix]}
     if grep "^${imagePrefix}" <<< $imageTag; then
       newBranch=$(sed "s/${imagePrefix}/${branchPrefix}/" <<< $imageTag)
-      return $newBranch
+      echo $newBranch
+      return 0
     fi
   done
 
-  return $imageTag
+  echo $imageTag
 }
 
 #

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -137,7 +137,7 @@ isServiceVersionGreaterOrEqual() {
     possibleAncestorCommits+=( $(convertImageTagToGitBranch "$possibleAncestorTag") )
   done
 
-  isRepoCommitGreaterOrEqual "$repo" "$currentServiceCommit" "${possibleAncestorCommits[@]/#/-}"
+  isRepoCommitGreaterOrEqual "$repo" "$currentRepoCommit" "${possibleAncestorCommits[@]/#/-}"
 }
 
 # Takes 2 required and 1 optional arguments:

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -103,6 +103,12 @@ semver_ge() {
   ) 1>&2
 }
 
+#
+# Given the name of a service as it is listed in the manifest,
+# determine the corresponding uc-cdis repo for the service.
+#
+# @param service
+#
 getRepoFromService(){
   if [[ -z "$1" ]]; then
     gen3_log_err "getRepoFromService" "requires service as its single argument"
@@ -114,9 +120,24 @@ getRepoFromService(){
   echo "${serviceToRepo["$service"]:-"$service"}"
 }
 
+#
+# Return 0 if the current image tag for service is greater than or equal to at
+# least one possible ancestor image tag. Otherwise, return 1.
+
+# Note that as this function utilizes getRepoFromService,
+# isServiceVersionGreaterOrEqual is intended for services having a repository
+# in the uc-cdis Github organization (i.e. for services such as revproxy not
+# having a correpsonding uc-cdis repo, please use
+# legacyIsServiceVersionGreaterOrEqual)
+#
+# @param service
+# @param ... possible ancestor image tags
+#
+# ex: isServiceVersionGreaterOrEqual "fence" "3.0.0"
+# or: isServiceVersionGreaterOrEqual "fence" "3.0.0" "2020.01"
 isServiceVersionGreaterOrEqual() {
   if [[ -z "$1" || -z "$2" ]]; then
-    gen3_log_err "isServiceVersionGreaterOrEqual" "requires service and  as its first two arguments"
+    gen3_log_err "isServiceVersionGreaterOrEqual" "requires service and an image tag as its first two arguments"
     return 1
   fi
 

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -119,6 +119,67 @@ serviceToRepo(){
   declare -A serviceToRepo=(["awshelper"]="feat\/" ["fix_"]="fix\/" ["chore_"]="chore\/" ["doc_"]="doc\/")
 }
 
+# Takes 2 required and 1 optional arguments:
+#   $1 service name
+#   $2 version of service where tests apply >=
+#   $3 version of service where tests apply >=, in monthly release (2020.xx) format
+#
+# ex: isServiceVersionGreaterOrEqual "fence" "3.0.0"
+# or: isServiceVersionGreaterOrEqual "fence" "3.0.0" "2020.01"
+isServiceVersionGreaterOrEqual() {
+  # make sure args provided
+  if [[ -z "$1" || -z "$2" ]]; then
+    return 0
+  fi
+
+  local currentVersion
+  currentVersion=$( [[ $(g3k_manifest_lookup ".versions.${1}") =~ \:(.*) ]] && echo "${BASH_REMATCH[1]}")
+
+  # check if currentVersion is actually a number
+  # NOTE: this assumes that all releases are tagged with actual numbers like:
+  #       2.8.0, 3.0.0, 3.0, 0.2, 0.2.1.5, etc
+  re='[0-9]+([.][0-9])+'
+  if ! [[ $currentVersion =~ $re ]] ; then
+    # force non-version numbers (e.g. branches and master)
+    # to be some arbitrary large number, so that it will
+    # cause next comparison to run the optional test.
+    # NOTE: The assumption here is that branches and master should run all the tests,
+    #       if you've branched off an old version that actually should NOT run the tests..
+    #       this script cannot currently handle that
+    # hopefully our service versions are never "OVER 9000!"
+    versionAsNumber=9000
+  else
+    # version is actually a pinned number, not a branch name or master
+    versionAsNumber=$currentVersion
+  fi
+
+  min=$(printf "2020\n$versionAsNumber\n" | sort -V | head -n1)
+  if [[ "$min" = "2020" && -n "$3" ]]; then
+    # 1. versionAsNumber >=2020, so assume it is a monthly release (or it was a branch
+    #    and is now 9000, in which case it will still pass the check as expected)
+    # 2. monthly release version arg was provided
+    # So, do the version comparison based on monthly release version arg
+    min=$(printf "$3\n$versionAsNumber\n" | sort -V | head -n1)
+    if [ "$min" = "$3" ]; then
+      echo "$1 version ($currentVersion) is greater than $3"
+    else
+      echo "$1 version ($currentVersion) is less than $3"
+      return 1
+    fi
+  else
+    # versionAsNumber is normal semver tag
+    min=$(printf "$2\n$versionAsNumber\n" | sort -V | head -n1)
+    if [ "$min" = "$2" ]; then
+      echo "$1 version ($currentVersion) is greater than $2"
+    else
+      echo "$1 version ($currentVersion) is less than $2"
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
 #
 # Convert Docker image tag name to original Git branch name for common prefixes ("feat_", "chore_", etc.)
 #

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -103,6 +103,22 @@ semver_ge() {
   ) 1>&2
 }
 
+serviceToRepo(){
+  if [[ $(echo ${imageTag} | tr -cd '_' | wc -c) -ge 2 ]]; then
+    gen3_log_warn "convertImageTagToGitBranch" "imageTag ${imageTag} has >=2 underscores, so conversion will be attempted but resulting branch may not be accurate"
+  fi
+  # awshelper
+  # revproxy
+  # metadata
+  # portal
+  # fluentd
+  # spark
+  # ambassador
+  # wts
+  # dashboard
+  declare -A serviceToRepo=(["awshelper"]="feat\/" ["fix_"]="fix\/" ["chore_"]="chore\/" ["doc_"]="doc\/")
+}
+
 #
 # Convert Docker image tag name to original Git branch name for common prefixes ("feat_", "chore_", etc.)
 #
@@ -120,14 +136,11 @@ convertImageTagToGitBranch() {
     return 1
   fi
   local imageTag="$1"
-  if [[ $(echo ${imageTag} | tr -cd '_' | wc -c) -ge 2 ]]; then
-    gen3_log_warn "convertImageTagToGitBranch" "imageTag ${imageTag} has >=2 underscores, so conversion will be attempted but resulting branch may not be accurate"
-  fi
 
   declare -A prefixes=(["feat_"]="feat\/" ["fix_"]="fix\/" ["chore_"]="chore\/" ["doc_"]="doc\/")
   for imagePrefix in ${!prefixes[@]}; do
     branchPrefix=${prefixes[$imagePrefix]}
-    if grep "^${imagePrefix}" <<< $imageTag; then
+    if grep "^${imagePrefix}" -q <<< $imageTag; then
       newBranch=$(sed "s/${imagePrefix}/${branchPrefix}/" <<< $imageTag)
       echo $newBranch
       return 0

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -137,7 +137,7 @@ isServiceVersionGreaterOrEqual() {
     possibleAncestorCommits+=( $(convertImageTagToGitBranch "$possibleAncestorTag") )
   done
 
-  isRepoCommitGreaterOrEqual "$repo" "$currentRepoCommit" "${possibleAncestorCommits[@]/#/-}"
+  isRepoCommitGreaterOrEqual "$repo" "$currentRepoCommit" "${possibleAncestorCommits[@]/#/}"
 }
 
 # Takes 2 required and 1 optional arguments:
@@ -261,6 +261,8 @@ isRepoCommitGreaterOrEqual() {
   # below wouldn't recognize it as a valid object name
   if ! git checkout ${repoCommit}; then
     gen3_log_warn "isRepoCommitGreaterOrEqual" "something went wrong with checking out ${repoCommit}"
+    cd -
+    yes | rm -r ~/temp_${repoName}
     return 1
   fi
 
@@ -270,6 +272,8 @@ isRepoCommitGreaterOrEqual() {
     # below wouldn't recognize it as a valid object name
     if ! git checkout ${possibleAncestorCommit}; then
       gen3_log_warn "isRepoCommitGreaterOrEqual" "something went wrong with checking out ${possibleAncestorCommit}"
+      cd -
+      yes | rm -r ~/temp_${repoName}
       return 1
     fi
     if git merge-base --is-ancestor ${possibleAncestorCommit} ${repoCommit}; then


### PR DESCRIPTION
Jira Ticket: [PXP-9967](https://ctds-planx.atlassian.net/browse/PXP-9967)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

Create RAS cronjobs if Fence >= 6.0.0 || Fence >= 2022.07.

Previously if Fence's manifest image tag was pinned to `branch-name`, `isServiceVersionGreaterOrEqual "fence" "2022.04"` would return `0` even if `branch-name` was "less than" `2022.04`.

### Bug Fixes
- Fix `isServiceVersionGreaterOrEqual` to work with branch tags
