### PR TITLE
removing jenkins-perf from jenkins test pool

### DIFF
--- a/files/scripts/ci-env-pool-reset.sh
+++ b/files/scripts/ci-env-pool-reset.sh
@@ -33,7 +33,6 @@ jenkins-blood
 jenkins-brain
 jenkins-dcp
 jenkins-new
-jenkins-perf
 EOF
 
 cat - > jenkins-envs-releases.txt <<EOF
@@ -43,7 +42,6 @@ jenkins-blood
 jenkins-brain
 jenkins-dcp
 jenkins-new
-jenkins-perf
 EOF
 
 aws s3 cp jenkins-envs-services.txt s3://cdistest-public-test-bucket/jenkins-envs-services.txt


### PR DESCRIPTION
### New Features
Removing `jenkins-perf` from the pool of jenkins test environment so we can do performance tests without the environment being reset.