### PR TITLE
Added a variable to allow configuration of the logs bucket

### DIFF
--- a/tf_files/aws/csoc_management-logs/root.tf
+++ b/tf_files/aws/csoc_management-logs/root.tf
@@ -10,4 +10,5 @@ module "logging" {
   source               = "../modules/management-logs"
   accounts_id          = "${var.accounts_id}"
   elasticsearch_domain = "${var.elasticsearch_domain}"
+  log_bucket_name      = "${var.log_bucket_name}"
 }

--- a/tf_files/aws/csoc_management-logs/variables.tf
+++ b/tf_files/aws/csoc_management-logs/variables.tf
@@ -7,3 +7,7 @@ variable "accounts_id" {
 variable "elasticsearch_domain" {
   default = "commons-logs"
 }
+
+variable "log_bucket_name" {
+  default = "management-logs-remote-accounts"
+}

--- a/tf_files/aws/modules/management-logs/logging.tf
+++ b/tf_files/aws/modules/management-logs/logging.tf
@@ -2,7 +2,7 @@
 # Kinesis stream logs
 
 resource "aws_s3_bucket" "management-logs_bucket" {
-  bucket = "management-logs-remote-accounts"
+  bucket = "${var.log_bucket_name}"
   acl    = "private"
 
   tags = {

--- a/tf_files/aws/modules/management-logs/variables.tf
+++ b/tf_files/aws/modules/management-logs/variables.tf
@@ -7,3 +7,7 @@ variable "accounts_id" {
 variable "elasticsearch_domain" {
   default = "commons-logs"
 }
+
+variable "log_bucket_name" {
+  default = "management-logs-remote-accounts"
+}


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.
Added a variable to the management-logs module to allow configuring the destination bucket for logs. This variable will default to the cdis-default: management-logs-remote-accounts .

- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.
Added a variable to the management-logs module to allow configuring the destination bucket for logs. This variable will default to the cdis-default: management-logs-remote-accounts .


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
