### PR TITLE
derive postgres parameter group version

### DIFF
--- a/tf_files/aws/commons/kube.tf
+++ b/tf_files/aws/commons/kube.tf
@@ -117,10 +117,13 @@ resource "aws_db_instance" "db_indexd" {
 # See https://www.postgresql.org/docs/9.6/static/runtime-config-logging.html
 # and https://www.postgresql.org/docs/9.6/static/runtime-config-query.html#RUNTIME-CONFIG-QUERY-ENABLE
 # for detail parameter descriptions
+locals {
+  pg_family_version = "${replace( var.indexd_engine_version ,"/\\.[0-9]/", "" )}"
+}
 
 resource "aws_db_parameter_group" "rds-cdis-pg" {
   name   = "${var.vpc_name}-rds-cdis-pg"
-  family = "postgres9.6"
+  family = "postgres${local.pg_family_version}"
 
   # make index searches cheaper per row
   parameter {


### PR DESCRIPTION
This fixes an issue in cloud-automation where if a Postgres newer than 9.6 is deployed terraform will fail. The reason is that the parameter group version is not in sync with the engine version. 

This patch will derive the parameter group version. This will not work with posture < 10 

### New Features


### Breaking Changes
does not work with Postgres < 10 (which is out of support @ AWS anyways)

### Bug Fixes

### Improvements

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
