### PR TITLE
Availability zones outside of us-east-1

### DIFF
--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -15,6 +15,7 @@ provider "aws" {}
 
 module "cdis_vpc" {
   ami_account_id                 = "${var.ami_account_id}"
+  availability_zones             = "${var.availability_zones}"
   squid_image_search_criteria    = "${var.squid_image_search_criteria}"
   source                         = "../modules/vpc"
   vpc_cidr_block                 = "${var.vpc_cidr_block}"

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -57,6 +57,11 @@ variable "indexd_prefix" {
   default = "dg.XXXX/"
 }
 
+variable "availability_zones" {
+  type = "list"
+  default = ["us-east-1a","us-east-1b","us-east-1c"]
+}
+
 variable "db_password_peregrine" {}
 
 variable "db_password_sheepdog" {}


### PR DESCRIPTION
This hands down the availability zones configured in config.tf to the VPC module.

Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
Hand down availability zones configured in config.tf to the VPC module, allowing deployment outside of us-east-1

- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
