### PR TITLE
Add SSM endpoints to vpc

### DIFF
--- a/tf_files/aws/eks/root.tf
+++ b/tf_files/aws/eks/root.tf
@@ -20,6 +20,7 @@ module "eks" {
   jupyter_instance_type            = "${var.jupyter_instance_type}"
   workers_subnet_size              = "${var.workers_subnet_size}"
   bootstrap_script                 = "${var.bootstrap_script}"
+  deploy_ssm                       = "${var.deploy_ssm}"
   jupyter_bootstrap_script         = "${var.jupyter_bootstrap_script}"
   kernel                           = "${var.kernel}"
   jupyter_worker_drive_size        = "${var.jupyter_worker_drive_size}"

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -31,6 +31,9 @@ variable "peering_vpc_id" {
 
 variable "users_policy" {}
 
+variable "deploy_ssm" {
+  default = false
+}
 
 variable "worker_drive_size" {
   default = 30

--- a/tf_files/aws/modules/eks/README.md
+++ b/tf_files/aws/modules/eks/README.md
@@ -65,6 +65,7 @@ users_policy = "test-commons"
 | workflow_instance_type | For k8s workflow workers | string | t3.2xlarge |
 | bootstrap_script | Script to initialize the workers | string | [bootstrap.sh](https://github.com/uc-cdis/cloud-automation/tree/master/flavors/eks) |
 | jupyter_bootstrap_script | Script to initialize the jupyter workers | string | [bootstrap.sh](https://github.com/uc-cdis/cloud-automation/tree/master/flavors/eks) |
+| deploy_ssm | Should the endpoints to allow amazon SSM from the subnet be created | boolean | false |
 | jupyter_worker_drive_size | Drive Size for jupyter workers | string | 30GB |
 | peering_cidr | AdminVM's CIDR for peering connections | string | 10.128.0.0/20 (PlanX CSOC) |
 | jupyter_asg_desired_capacity | # of jupyter workers | number | 0 |

--- a/tf_files/aws/modules/eks/data.tf
+++ b/tf_files/aws/modules/eks/data.tf
@@ -57,6 +57,18 @@ data "aws_vpc_endpoint_service" "ec2" {
   service = "ec2"
 }
 
+data "aws_vpc_endpoint_service" "ssm" {
+  service = "ssm"
+}
+
+data "aws_vpc_endpoint_service" "ssmmessages" {
+  service = "ssmmessages"
+}
+
+data "aws_vpc_endpoint_service" "ec2messages" {
+  service = "ec2messages"
+}
+
 data "aws_vpc_endpoint_service" "autoscaling" {
   service = "autoscaling"
 }

--- a/tf_files/aws/modules/eks/endpoints.tf
+++ b/tf_files/aws/modules/eks/endpoints.tf
@@ -18,6 +18,61 @@ resource "aws_vpc_endpoint" "ec2" {
   }
 }
 
+# SSM endpoint
+resource "aws_vpc_endpoint" "ssm" {
+  count               = "${var.deploy_ssm ? 1 : 0}"
+  vpc_id              = "${data.aws_vpc.the_vpc.id}"
+  service_name        = "${data.aws_vpc_endpoint_service.ssm.service_name}"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [
+    "${data.aws_security_group.local_traffic.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  tags = {
+    Name         = "to ssm"
+    Environment  = "${var.vpc_name}"
+    Organization = "${var.organization_name}"
+  }
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  count               = "${var.deploy_ssm ? 1 : 0}"
+  vpc_id       = "${data.aws_vpc.the_vpc.id}"
+  service_name    = "${data.aws_vpc_endpoint_service.ssmmessages.service_name}"
+  vpc_endpoint_type = "Interface"
+  security_group_ids  = [
+    "${data.aws_security_group.local_traffic.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  tags = {
+    Name         = "to ssmmessages"
+    Environment  = "${var.vpc_name}"
+    Organization = "${var.organization_name}"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  count               = "${var.deploy_ssm ? 1 : 0}"
+  vpc_id       = "${data.aws_vpc.the_vpc.id}"
+  service_name    = "${data.aws_vpc_endpoint_service.ec2messages.service_name}"
+  vpc_endpoint_type = "Interface"
+  security_group_ids  = [
+    "${data.aws_security_group.local_traffic.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  tags = {
+    Name         = "to ec2messages"
+    Environment  = "${var.vpc_name}"
+    Organization = "${var.organization_name}"
+  }
+}
+
 # Required for sa-linked IAM roles
 resource "aws_vpc_endpoint" "sts" {
   vpc_id       = "${data.aws_vpc.the_vpc.id}"

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -103,6 +103,10 @@ variable "workflow_asg_min_size" {
   default = 0
 }
 
+variable "deploy_ssm" { 
+  default = false
+}
+
 variable "iam-serviceaccount" {
   default = false
 }


### PR DESCRIPTION
Add SSM endpoints to vpc. The deployment can be enabled by defining deploy_ssm = true in config.tf 


<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
Documentation is updated within the EKS module

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
