### PR TITLE
Fix/make cloud automation configurable

### DIFF
--- a/gen3/bin/kube-setup-workvm.sh
+++ b/gen3/bin/kube-setup-workvm.sh
@@ -303,7 +303,7 @@ EOF
 
   if ! grep 'GEN3_HOME=' ${WORKSPACE}/.${RC_FILE} > /dev/null; then
     cat - >>${WORKSPACE}/.${RC_FILE} <<EOF
-export GEN3_HOME=${WORKSPACE}/cloud-automation
+export GEN3_HOME=${GEN3_HOME}
 if [ -f "\${GEN3_HOME}/gen3/gen3setup.sh" ]; then
   source "\${GEN3_HOME}/gen3/gen3setup.sh"
 fi

--- a/gen3/bin/workon.sh
+++ b/gen3/bin/workon.sh
@@ -113,7 +113,7 @@ if [[ ! -f "$bucketCheckFlag" && "$GEN3_FLAVOR" == "AWS" ]]; then
   }
 EOM
 )
-    gen3_aws_run aws s3api create-bucket --acl private --bucket "$GEN3_S3_BUCKET" --create-bucket-configuration ‘{“LocationConstraint”:“‘$(aws configure get $GEN3_PROFILE.region)‘“}’
+    gen3_aws_run aws s3api create-bucket --acl private --bucket "$GEN3_S3_BUCKET" --create-bucket-configuration LocationConstraint="$(aws configure get $GEN3_PROFILE.region)"
     sleep 5 # Avoid race conditions
     if gen3_aws_run aws s3api put-bucket-encryption --bucket "$GEN3_S3_BUCKET" --server-side-encryption-configuration "$S3_POLICY"; then
       touch "$bucketCheckFlag"

--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -31,6 +31,7 @@ module "cdis_vpc" {
   vpc_flow_logs                  = "${var.vpc_flow_logs}"
   vpc_flow_traffic               = "${var.vpc_flow_traffic}"
 
+  availability_zones             = "${var.availability_zones}"
   #private_kube_route             = "${aws_route_table.private_kube.id}"
   branch                         = "${var.branch}"
   fence-bot_bucket_access_arns   = "${var.fence-bot_bucket_access_arns}"

--- a/tf_files/aws/commons/cloud.tf
+++ b/tf_files/aws/commons/cloud.tf
@@ -15,6 +15,7 @@ provider "aws" {}
 
 module "cdis_vpc" {
   ami_account_id                 = "${var.ami_account_id}"
+  availability_zones             = "${var.availability_zones}"
   squid_image_search_criteria    = "${var.squid_image_search_criteria}"
   source                         = "../modules/vpc"
   vpc_cidr_block                 = "${var.vpc_cidr_block}"

--- a/tf_files/aws/commons/kube.tf
+++ b/tf_files/aws/commons/kube.tf
@@ -117,10 +117,13 @@ resource "aws_db_instance" "db_indexd" {
 # See https://www.postgresql.org/docs/9.6/static/runtime-config-logging.html
 # and https://www.postgresql.org/docs/9.6/static/runtime-config-query.html#RUNTIME-CONFIG-QUERY-ENABLE
 # for detail parameter descriptions
+locals {
+  pg_family_version = "${replace( var.indexd_engine_version ,"/\\.[0-9]/", "" )}"
+}
 
 resource "aws_db_parameter_group" "rds-cdis-pg" {
   name   = "${var.vpc_name}-rds-cdis-pg"
-  family = "postgres9.6"
+  family = "postgres${local.pg_family_version}"
 
   # make index searches cheaper per row
   parameter {

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -134,6 +134,11 @@ variable "gdcapi_secret_key" {}
 # password for write access to indexd
 variable "gdcapi_indexd_password" {}
 
+variable "availability_zones" {
+  type = "list"
+  default = ["us-east-1a","us-east-1b","us-east-1c"]
+}
+
 #
 # DEPRECATED - should no longer be necessary
 # gdcapi's oauth2 client id (fence as oauth2 provider)

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -57,6 +57,11 @@ variable "indexd_prefix" {
   default = "dg.XXXX/"
 }
 
+variable "availability_zones" {
+  type = "list"
+  default = ["us-east-1a","us-east-1b","us-east-1c"]
+}
+
 variable "db_password_peregrine" {}
 
 variable "db_password_sheepdog" {}

--- a/tf_files/aws/commons/variables.tf
+++ b/tf_files/aws/commons/variables.tf
@@ -134,11 +134,6 @@ variable "gdcapi_secret_key" {}
 # password for write access to indexd
 variable "gdcapi_indexd_password" {}
 
-variable "availability_zones" {
-  type = "list"
-  default = ["us-east-1a","us-east-1b","us-east-1c"]
-}
-
 #
 # DEPRECATED - should no longer be necessary
 # gdcapi's oauth2 client id (fence as oauth2 provider)

--- a/tf_files/aws/csoc_admin_vm/root.tf
+++ b/tf_files/aws/csoc_admin_vm/root.tf
@@ -10,6 +10,7 @@ module "admin_vm" {
   ami_account_id   = "${var.ami_account_id}"
   source           = "../modules/admin-vm"
   child_account_id = "${var.child_account_id}"
+  cloud-automation_repository = "${var.cloud-automation_repository}"
   child_name       = "${var.child_name}"
   vpc_cidr_list    = "${var.vpc_cidr_list}"
   csoc_account_id  = "${var.csoc_account_id}"

--- a/tf_files/aws/csoc_admin_vm/variables.tf
+++ b/tf_files/aws/csoc_admin_vm/variables.tf
@@ -12,6 +12,10 @@ variable "aws_region" {
   default = "us-east-1"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "csoc_vpc_id" {
   default = "vpc-e2b51d99"
 }

--- a/tf_files/aws/eks/root.tf
+++ b/tf_files/aws/eks/root.tf
@@ -20,6 +20,7 @@ module "eks" {
   jupyter_instance_type            = "${var.jupyter_instance_type}"
   workers_subnet_size              = "${var.workers_subnet_size}"
   bootstrap_script                 = "${var.bootstrap_script}"
+  deploy_ssm                       = "${var.deploy_ssm}"
   jupyter_bootstrap_script         = "${var.jupyter_bootstrap_script}"
   kernel                           = "${var.kernel}"
   jupyter_worker_drive_size        = "${var.jupyter_worker_drive_size}"

--- a/tf_files/aws/eks/variables.tf
+++ b/tf_files/aws/eks/variables.tf
@@ -31,6 +31,9 @@ variable "peering_vpc_id" {
 
 variable "users_policy" {}
 
+variable "deploy_ssm" {
+  default = false
+}
 
 variable "worker_drive_size" {
   default = 30

--- a/tf_files/aws/modules/admin-vm/cloud.tf
+++ b/tf_files/aws/modules/admin-vm/cloud.tf
@@ -176,7 +176,7 @@ sudo hostnamectl set-hostname '${var.child_name}'_admin
 
 #Requirements for cloud-automation
 cd /home/ubuntu
-sudo git clone https://github.com/uc-cdis/cloud-automation.git 
+sudo git clone "${var.cloud-automation_repository}"
 sudo apt install -y unzip
 sudo apt-get -y install jq
 #sudo wget -O /tmp/terraform.zip  \$(echo "https://releases.hashicorp.com/terraform/$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')/terraform_\$(curl -s https://checkpoint-api.hashicorp.com/v1/check/terraform | jq -r -M '.current_version')_linux_amd64.zip")

--- a/tf_files/aws/modules/admin-vm/variables.tf
+++ b/tf_files/aws/modules/admin-vm/variables.tf
@@ -20,6 +20,10 @@ variable "child_account_id" {
   # default = "707767160287"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "child_name" {
   # name of child account - ex: kidsfirst, cdistest  # default = "cdistest"
 }

--- a/tf_files/aws/modules/eks/README.md
+++ b/tf_files/aws/modules/eks/README.md
@@ -65,6 +65,7 @@ users_policy = "test-commons"
 | workflow_instance_type | For k8s workflow workers | string | t3.2xlarge |
 | bootstrap_script | Script to initialize the workers | string | [bootstrap.sh](https://github.com/uc-cdis/cloud-automation/tree/master/flavors/eks) |
 | jupyter_bootstrap_script | Script to initialize the jupyter workers | string | [bootstrap.sh](https://github.com/uc-cdis/cloud-automation/tree/master/flavors/eks) |
+| deploy_ssm | Should the endpoints to allow amazon SSM from the subnet be created | boolean | false |
 | jupyter_worker_drive_size | Drive Size for jupyter workers | string | 30GB |
 | peering_cidr | AdminVM's CIDR for peering connections | string | 10.128.0.0/20 (PlanX CSOC) |
 | jupyter_asg_desired_capacity | # of jupyter workers | number | 0 |

--- a/tf_files/aws/modules/eks/data.tf
+++ b/tf_files/aws/modules/eks/data.tf
@@ -57,6 +57,18 @@ data "aws_vpc_endpoint_service" "ec2" {
   service = "ec2"
 }
 
+data "aws_vpc_endpoint_service" "ssm" {
+  service = "ssm"
+}
+
+data "aws_vpc_endpoint_service" "ssmmessages" {
+  service = "ssmmessages"
+}
+
+data "aws_vpc_endpoint_service" "ec2messages" {
+  service = "ec2messages"
+}
+
 data "aws_vpc_endpoint_service" "autoscaling" {
   service = "autoscaling"
 }

--- a/tf_files/aws/modules/eks/endpoints.tf
+++ b/tf_files/aws/modules/eks/endpoints.tf
@@ -18,6 +18,61 @@ resource "aws_vpc_endpoint" "ec2" {
   }
 }
 
+# SSM endpoint
+resource "aws_vpc_endpoint" "ssm" {
+  count               = "${var.deploy_ssm ? 1 : 0}"
+  vpc_id              = "${data.aws_vpc.the_vpc.id}"
+  service_name        = "${data.aws_vpc_endpoint_service.ssm.service_name}"
+  vpc_endpoint_type   = "Interface"
+  security_group_ids  = [
+    "${data.aws_security_group.local_traffic.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  tags = {
+    Name         = "to ssm"
+    Environment  = "${var.vpc_name}"
+    Organization = "${var.organization_name}"
+  }
+}
+
+resource "aws_vpc_endpoint" "ssmmessages" {
+  count               = "${var.deploy_ssm ? 1 : 0}"
+  vpc_id       = "${data.aws_vpc.the_vpc.id}"
+  service_name    = "${data.aws_vpc_endpoint_service.ssmmessages.service_name}"
+  vpc_endpoint_type = "Interface"
+  security_group_ids  = [
+    "${data.aws_security_group.local_traffic.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  tags = {
+    Name         = "to ssmmessages"
+    Environment  = "${var.vpc_name}"
+    Organization = "${var.organization_name}"
+  }
+}
+
+resource "aws_vpc_endpoint" "ec2messages" {
+  count               = "${var.deploy_ssm ? 1 : 0}"
+  vpc_id       = "${data.aws_vpc.the_vpc.id}"
+  service_name    = "${data.aws_vpc_endpoint_service.ec2messages.service_name}"
+  vpc_endpoint_type = "Interface"
+  security_group_ids  = [
+    "${data.aws_security_group.local_traffic.id}"
+  ]
+
+  private_dns_enabled = true
+  subnet_ids       = ["${aws_subnet.eks_private.*.id}"]
+  tags = {
+    Name         = "to ec2messages"
+    Environment  = "${var.vpc_name}"
+    Organization = "${var.organization_name}"
+  }
+}
+
 # Required for sa-linked IAM roles
 resource "aws_vpc_endpoint" "sts" {
   vpc_id       = "${data.aws_vpc.the_vpc.id}"

--- a/tf_files/aws/modules/eks/variables.tf
+++ b/tf_files/aws/modules/eks/variables.tf
@@ -103,6 +103,10 @@ variable "workflow_asg_min_size" {
   default = 0
 }
 
+variable "deploy_ssm" { 
+  default = false
+}
+
 variable "iam-serviceaccount" {
   default = false
 }

--- a/tf_files/aws/modules/squid_auto/README.md
+++ b/tf_files/aws/modules/squid_auto/README.md
@@ -63,6 +63,8 @@ There are mandatory variables, and there are a few other optionals that are set 
 | organization_name | For tagging purposes  | string | Basic Services  |
 | squid_instance_drive_size | Volume size for the root partition  | integer | 8 |
 | extra_vars | Additional information to be bassed on the bootstrap script | list | ["squid_image=master"] |
+| branch | Branch to checkout from cloud-automation repository | string | "master" | 
+| cloud-automation_repository | the source repository for cloud-automation | string | "https://github.com/uc-cdis/cloud-automation.git" |  
 | deploy_ha_squid | If to deploy this module | boolean | true |
 
 

--- a/tf_files/aws/modules/squid_auto/cloud.tf
+++ b/tf_files/aws/modules/squid_auto/cloud.tf
@@ -142,7 +142,7 @@ CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
     sudo yum update -y
     sudo yum install git lsof -y
   fi
-  git clone https://github.com/uc-cdis/cloud-automation.git
+  git clone "${var.cloud-automation_repository}"
   cd $CLOUD_AUTOMATION
   git pull
 

--- a/tf_files/aws/modules/squid_auto/variables.tf
+++ b/tf_files/aws/modules/squid_auto/variables.tf
@@ -81,6 +81,10 @@ variable "route_53_zone_id" {
   description = "DNS zone for .internal.io"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "branch" {
   description = "branch to use in bootstrap script"
   default     = "master"

--- a/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
+++ b/tf_files/aws/modules/squid_nlb_central_csoc/cloud.tf
@@ -260,7 +260,7 @@ resource "aws_launch_configuration" "squid_nlb" {
 user_data = <<EOF
 #!/bin/bash
 cd /home/ubuntu
-sudo git clone https://github.com/uc-cdis/cloud-automation.git
+sudo git clone "${var.cloud-automation_repository}"
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 cd /home/ubuntu/cloud-automation
 git pull

--- a/tf_files/aws/modules/squid_nlb_central_csoc/variables.tf
+++ b/tf_files/aws/modules/squid_nlb_central_csoc/variables.tf
@@ -28,7 +28,9 @@ variable "csoc_cidr" {
   default = "10.128.0.0/20"
 }
 
-
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
 
 variable "env_pub_subnet_routetable_id" {
   default = "rtb-1cb66860"

--- a/tf_files/aws/modules/squidnlb/cloud.tf
+++ b/tf_files/aws/modules/squidnlb/cloud.tf
@@ -195,7 +195,7 @@ resource "aws_launch_configuration" "squid_nlb" {
 user_data = <<EOF
 #!/bin/bash
 cd /home/ubuntu
-sudo git clone https://github.com/uc-cdis/cloud-automation.git
+sudo git clone "${var.cloud-automation_repository}"
 sudo chown -R ubuntu. /home/ubuntu/cloud-automation
 cd /home/ubuntu/cloud-automation
 git pull

--- a/tf_files/aws/modules/squidnlb/variables.tf
+++ b/tf_files/aws/modules/squidnlb/variables.tf
@@ -45,8 +45,9 @@ variable "ssh_key_name" {
   default = "rarya_id_rsa"
 }
 
-
-
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
 
 variable "allowed_principals_list" {
   type = "list"

--- a/tf_files/aws/modules/utility-vm/README.md
+++ b/tf_files/aws/modules/utility-vm/README.md
@@ -1,4 +1,4 @@
-# TL;DR
+ TL;DR
 
 UtilityVM is intended to make the spin up of new VMs more easily. The whole idea is to offload any package installation to a file within the cloud-automation folder.
 
@@ -78,3 +78,5 @@ This variables are not initialized but you can change them if needed.
 | authorized_keys | Path to file containing ssh keys that will be copied to `/home/ubuntu/.ssh/authorized_keys`. | string | "files/authorized_keys/ops_team" |
 | branch | For testing purposes | string | "master" |
 | user_policy | additional policy for the role | string | "" |
+| cloud-automation_repository | the source repository for cloud-automation | string | "https://github.com/uc-cdis/cloud-automation.git" | 
+

--- a/tf_files/aws/modules/utility-vm/cloud.tf
+++ b/tf_files/aws/modules/utility-vm/cloud.tf
@@ -208,7 +208,7 @@ CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
 (
   source /etc/profile.d/99-proxy.sh
   cd $USER_HOME
-  git clone https://github.com/uc-cdis/cloud-automation.git
+  git clone "${var.cloud-automation_repository}"
   cd $CLOUD_AUTOMATION
   git pull
   cat $CLOUD_AUTOMATION/${var.authorized_keys} | sudo tee --append $USER_HOME/.ssh/authorized_keys

--- a/tf_files/aws/modules/utility-vm/variables.tf
+++ b/tf_files/aws/modules/utility-vm/variables.tf
@@ -94,6 +94,10 @@ variable "organization_name" {
   default     = "Basic Service"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "branch" {
   description = "For testing purposes"
   default     = "master"

--- a/tf_files/aws/modules/vpc/README.md
+++ b/tf_files/aws/modules/vpc/README.md
@@ -70,6 +70,8 @@ There are mandatory variables, and there are a few other optionals that are set 
 | squid_cluster_min_size | If ha squid is enabled and you want to set your own min size | int | 1 |
 | squid_cluster_max_size | If ha squid is enabled and you want to set your own max size | int | 3 | 
 | branch | For development purposes only | string | master |
+| cloud-automation_repository | the source repository for cloud-automation | string | "https://github.com/uc-cdis/cloud-automation.git" | 
+
 
 
 

--- a/tf_files/aws/modules/vpc/cloud.tf
+++ b/tf_files/aws/modules/vpc/cloud.tf
@@ -38,6 +38,7 @@ module "squid-auto" {
   squid_instance_type            = "${var.squid_instance_type}"
   bootstrap_script               = "${var.squid_bootstrap_script}"
   extra_vars                     = "${var.squid_extra_vars}"
+  cloud-automation_repository    = "${var.cloud-automation_repository}"
   branch                         = "${var.branch}"
   deploy_ha_squid                = "${var.deploy_ha_squid}"
   cluster_max_size               = "${var.squid_cluster_max_size}"

--- a/tf_files/aws/modules/vpc/variables.tf
+++ b/tf_files/aws/modules/vpc/variables.tf
@@ -84,6 +84,10 @@ variable "squid_extra_vars" {
   #default     = ["squid_image=master"]
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "branch" {
   description = "For testing purposes, when something else than the master"
   default     = "master"

--- a/tf_files/aws/slurm/README.md
+++ b/tf_files/aws/slurm/README.md
@@ -166,6 +166,8 @@ source_buckets = ["sorce1","source3"]
 | controller_info | extra information about the controllers | map |
 | woker_info | extra information about the workers | map |
 | source_bucket | should the cluster have access to buckets, which ones | list |
+| cloud-automation_repository | the source repository for cloud-automation | string | "https://github.com/uc-cdis/cloud-automation.git" | 
+
 
 
 ## 5. Outputs

--- a/tf_files/aws/slurm/main.tf
+++ b/tf_files/aws/slurm/main.tf
@@ -51,7 +51,7 @@ CLOUD_AUTOMATION="$USER_HOME/cloud-automation"
 
 source /etc/profile.d/99-proxy.sh
 cd $USER_HOME
-git clone https://github.com/uc-cdis/cloud-automation.git
+git clone "${var.cloud-automation_repository}"
 cd $CLOUD_AUTOMATION
 git pull
 

--- a/tf_files/aws/slurm/variables.tf
+++ b/tf_files/aws/slurm/variables.tf
@@ -130,6 +130,10 @@ variable "main_os_user" {
   default     = "ubuntu"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "branch" {
   description = "for testing purposes"
   default     = "master"

--- a/tf_files/aws/squid_auto/root.tf
+++ b/tf_files/aws/squid_auto/root.tf
@@ -37,6 +37,7 @@ module "squid_auto" {
   cluster_min_size           = "${var.cluster_min_size}"
   network_expansion          = "${var.network_expansion}"
   branch                     = "${var.branch}"
+  cloud-automation_repository = "${var.cloud-automation_repository}"
   activation_id              = "${var.activation_id}"
   customer_id                = "${var.customer_id}"  
   slack_webhook              = "${var.slack_webhook}"

--- a/tf_files/aws/squid_auto/variables.tf
+++ b/tf_files/aws/squid_auto/variables.tf
@@ -84,6 +84,10 @@ variable "route_53_zone_id" {
   description = "DNS zone for .internal.io"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "branch" {
   description = "branch to use in bootstrap script"
   default     = "master"

--- a/tf_files/aws/squid_nlb_central/root.tf
+++ b/tf_files/aws/squid_nlb_central/root.tf
@@ -17,6 +17,7 @@ module "squid_nlb" {
   env_nlb_name     = "${var.env_nlb_name}"
   ami_account_id   = "${var.ami_account_id}"
   csoc_cidr        = "${var.csoc_cidr}"
+  cloud-automation_repository = "${var.cloud-automation_repository}"
   env_pub_subnet_routetable_id = "${var.env_pub_subnet_routetable_id}"
   ssh_key_name     = "${var.ssh_key_name}"
   allowed_principals_list  = "${var.allowed_principals_list}"

--- a/tf_files/aws/squid_nlb_central/variables.tf
+++ b/tf_files/aws/squid_nlb_central/variables.tf
@@ -29,7 +29,9 @@ variable "csoc_cidr" {
   default = "10.128.0.0/20"
 }
 
-
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
 
 variable "env_pub_subnet_routetable_id" {
   default = "rtb-1cb66860"

--- a/tf_files/aws/squidnlb_standalone/root.tf
+++ b/tf_files/aws/squidnlb_standalone/root.tf
@@ -19,6 +19,7 @@ module "squid_nlb" {
   env_nlb_name     = "${var.env_nlb_name}"
   ami_account_id   = "${var.ami_account_id}"
   csoc_cidr        = "${var.csoc_cidr}"
+  cloud-automation_repository = "${var.cloud-automation_repository}"
   env_public_subnet_routetable_id = "${var.env_public_subnet_routetable_id}"
   ssh_key_name     = "${var.ssh_key_name}"
   allowed_principals_list  = "${var.allowed_principals_list}"

--- a/tf_files/aws/squidnlb_standalone/variables.tf
+++ b/tf_files/aws/squidnlb_standalone/variables.tf
@@ -33,6 +33,9 @@ variable "csoc_cidr" {
   default = "10.128.0.0/20"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
 
 
 variable "env_public_subnet_routetable_id" {

--- a/tf_files/aws/utility_vm/root.tf
+++ b/tf_files/aws/utility_vm/root.tf
@@ -25,6 +25,7 @@ module "utility_vm" {
   proxy                      = "${var.proxy}"
   authorized_keys            = "${var.authorized_keys}"
   organization_name          = "${var.organization_name}"
+  cloud-automation_repository = "${var.cloud-automation_repository}"
   branch                     = "${var.branch}"
   user_policy                = "${var.user_policy}"
   activation_id              = "${var.activation_id}"

--- a/tf_files/aws/utility_vm/variables.tf
+++ b/tf_files/aws/utility_vm/variables.tf
@@ -75,6 +75,10 @@ variable "organization_name" {
   default     = "Basic Service"
 }
 
+variable "cloud-automation_repository" {
+  default = "https://github.com/uc-cdis/cloud-automation.git"
+}
+
 variable "branch" {
   default = "master"
 }


### PR DESCRIPTION
currently cloud-automation is hard coded in all infrastructure. as a result an external provider cannot influence the key material deployed to those machines. This rather large patch exposes the cloud-automation repository as a variable throughout the AWS tf tiles. 

This should be a non-breaking change, as the default still points to uc-cdis

Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
