### PR TITLE
Fix/ingress outside us

### DIFF
--- a/gen3/bin/kube-setup-ingress.sh
+++ b/gen3/bin/kube-setup-ingress.sh
@@ -263,7 +263,7 @@ EOM
     helm repo update 2> >(grep -v 'This is insecure' >&2)
    
    #  # TODO: Move to values.yaml file
-    helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$(gen3 api environment) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller 2> >(grep -v 'This is insecure' >&2)
+    helm upgrade --install aws-load-balancer-controller eks/aws-load-balancer-controller -n kube-system --set clusterName=$(gen3 api environment) --set serviceAccount.create=false --set serviceAccount.name=aws-load-balancer-controller --set region=$AWS_REGION 2> >(grep -v 'This is insecure' >&2)
   else
     gen3_log_info "kube-setup-ingress exiting - ingress already deployed, use --force to redeploy"
   fi

--- a/gen3/lib/utils.sh
+++ b/gen3/lib/utils.sh
@@ -8,7 +8,7 @@ export WORKSPACE="${WORKSPACE:-$HOME}"
 export XDG_DATA_HOME=${XDG_DATA_HOME:-"${WORKSPACE}/.local/share"}
 export GEN3_ETC_FOLDER="${XDG_DATA_HOME}/gen3/etc"
 export GEN3_CACHE_DIR="${XDG_DATA_HOME}/gen3/cache"
-
+export AWS_REGION=$(aws configure get region)
 
 # Jenkins special cases
 if [[ -n "$JENKINS_HOME" && -n "$WORKSPACE" && -d "$WORKSPACE" ]]; then


### PR DESCRIPTION
Currently setting up the ingress outside of the US is not working. This patch does two things: 
1. in utils.sh it defines a global shell variable $AWS_REGION2. 
2. in kube-setup-ingress.sh it uses the defined shell variable3. 

Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
