### PR TITLE
make aws region variable for ssjdispatcher

### DIFF
--- a/gen3/bin/kube-setup-ssjdispatcher.sh
+++ b/gen3/bin/kube-setup-ssjdispatcher.sh
@@ -122,6 +122,9 @@ EOM
   fi
   local ssjConfig="$(cat - <<EOM
 {
+    "AWS": {
+      "region": "${AWS_REGION}"
+    },
     "SQS": {
       "url": "${sqsUrl}"
     },

--- a/gen3/lib/g3k_manifest.sh
+++ b/gen3/lib/g3k_manifest.sh
@@ -242,6 +242,7 @@ g3k_manifest_filter() {
   declare -a kvList=()
 
   kvList+=('GEN3_DATE_LABEL' "date: \"$(date +%s)\"")
+  kvList+=('GEN3_AWS_REGION' "value: \"${AWS_REGION}\"")
 
   for key in $(g3k_config_lookup '.versions | keys[]' "$manifestPath"); do
     value="$(g3k_config_lookup ".versions[\"$key\"]" "$manifestPath")"

--- a/kube/services/ssjdispatcher/ssjdispatcher-deploy.yaml
+++ b/kube/services/ssjdispatcher/ssjdispatcher-deploy.yaml
@@ -52,7 +52,7 @@ spec:
             subPath: credentials.json
         env:
           - name: AWS_REGION
-            value: us-east-1
+            GEN3_AWS_REGION
           - name: AWS_STS_REGIONAL_ENDPOINTS
             value: regional  
           - name: GEN3_NAMESPACE


### PR DESCRIPTION
This PR adds GEN3_AWS_REGION to the standard substitution variables in g3_manifest_filter and adds it to the ssjdispatcher deployment as well as the creds.json file, therefore allowing deployment outside of us-east-1. 

This PR depends on https://github.com/uc-cdis/cloud-automation/pull/1967


Jira Ticket: [PXP-xxxx](https://ctds-planx.atlassian.net/browse/PXP-xxxx)
- [ ] Remove this line if you've changed the title to (PXP-xxxx): <title>
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.

support ssjdispatcher outside of us-east-1

- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
Fix ssjdispatcher outside of us-east-1

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
