### PR TITLE
PXP-8028 Fence DB migration: cd to where it can find Alembic files

### DIFF
--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -275,6 +275,7 @@ spec:
             if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"
+                cd /fence
                 fence-create migrate
               else
                 echo "Db migration disabled in fence-config"

--- a/kube/services/jobs/fence-db-migrate-job.yaml
+++ b/kube/services/jobs/fence-db-migrate-job.yaml
@@ -89,6 +89,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            cd /fence
             fence-create migrate
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"


### PR DESCRIPTION
Jira Ticket: [PXP-8028](https://ctds-planx.atlassian.net/browse/PXP-8028)

To run Fence DB migrations with Alembic, we need Alembic to be able to find its configuration files, which are at `/fence`

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
