### PR TITLE
feat: add doc url

### DIFF
--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -149,11 +149,12 @@ if [[ $current_namespace == "default" ]]; then
   fi
 fi
 
-
-documentUrl="$(g3k_manifest_lookup .global.document_url)"
-if [[ "$documentUrl" != null ]]; then
-  filePath="$scriptDir/gen3.nginx.conf/documentation-site/documentation-site.conf"
-  confFileList+=("--from-file" "$filePath")
+if g3k_manifest_lookup .global.document_url  > /dev/null 2>&1; then
+  documentUrl="$(g3k_manifest_lookup .global.document_url)"
+  if [[ "$documentUrl" != null ]]; then
+    filePath="$scriptDir/gen3.nginx.conf/documentation-site/documentation-site.conf"
+    confFileList+=("--from-file" "$filePath")
+  fi
 fi
 #
 # Funny hook to load the portal-workspace-parent nginx config

--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -149,6 +149,12 @@ if [[ $current_namespace == "default" ]]; then
   fi
 fi
 
+
+documentUrl="$(g3k_manifest_lookup .global.document_url)"
+if [[ "$documentUrl" != null ]]; then
+  filePath="$scriptDir/gen3.nginx.conf/documentation-site/documentation-site.conf"
+  confFileList+=("--from-file" "$filePath")
+fi
 #
 # Funny hook to load the portal-workspace-parent nginx config
 #

--- a/kube/services/revproxy/gen3.nginx.conf/documentation-site/documentation-site.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/documentation-site/documentation-site.conf
@@ -1,9 +1,9 @@
-        location /documentation/ {
+        location /documentation {
             if ($csrf_check !~ ^ok-\S.+$) {
             return 403 "failed csrf check";
             }
 
             set $document_url "$document_url_env";
 
-            rewrite ^/documentation/(.*)$ $document_url/$1 redirect;
+            rewrite ^/documentation/?(.*)$ $document_url/$1 redirect;
         }

--- a/kube/services/revproxy/gen3.nginx.conf/documentation-site/documentation-site.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/documentation-site/documentation-site.conf
@@ -1,0 +1,9 @@
+        location /documentation/ {
+            if ($csrf_check !~ ^ok-\S.+$) {
+            return 403 "failed csrf check";
+            }
+
+            set $document_url "$document_url_env";
+
+            rewrite ^/documentation/(.*)$ $document_url/$1 redirect;
+        }

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -24,6 +24,7 @@ env MAINTENANCE_MODE;
 env INDEXD_AUTHZ;
 env MDS_AUTHZ;
 env FRONTEND_ROOT;
+env DOCUMENT_URL;
 
 events {
 worker_connections 768;
@@ -76,6 +77,8 @@ js_set $black_list_check checkBlackList;
 
 # Modsecurity and blacklist configuration
 include /etc/nginx/gen3_server*.conf;
+
+perl_set $document_url_env 'sub { return $ENV{"DOCUMENT_URL"} || ""; }';
 
 # see portal-conf
 perl_set $maintenance_mode_env 'sub { return $ENV{"MAINTENANCE_MODE"} || "undefined"; }';
@@ -411,6 +414,9 @@ server {
   #}
 
   include /etc/nginx/gen3.conf/*.conf;
+  if ($document_url_env != "") {
+    include /etc/nginx/gen3.conf/documentation-site/*.conf;
+  }
   if ($frontend_root_service = "portal") {
       include /etc/nginx/gen3.conf/portal-as-root/*.conf;
   }

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -95,6 +95,12 @@ spec:
                 name: manifest-global
                 key: maintenance_mode
                 optional: true
+          - name: DOCUMENT_URL
+            valueFrom:
+              configMapKeyRef:
+                name: manifest-global
+                key: document_url
+                optional: true
           - name: FRONTEND_ROOT
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
In the future we would like to improve this from using `redirect` to `proxy_pass` so we can preserve the URL in browser

### New Features
- specific a `document_url` in `manifest-global` to let `<HOSTNAME>/documentation` redirects to that external doc site

