### PR TITLE
fix: fail for g3k_manifest_lookup

### DIFF
--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -149,13 +149,12 @@ if [[ $current_namespace == "default" ]]; then
   fi
 fi
 
-if g3k_manifest_lookup .global.document_url  > /dev/null 2>&1; then
-  documentUrl="$(g3k_manifest_lookup .global.document_url)"
-  if [[ "$documentUrl" != null ]]; then
-    filePath="$scriptDir/gen3.nginx.conf/documentation-site/documentation-site.conf"
-    confFileList+=("--from-file" "$filePath")
-  fi
+documentUrl="$(g3k_manifest_lookup .global.document_url; true)"
+if [[ $documentUrl != "null" ]]; then
+  filePath="$scriptDir/gen3.nginx.conf/documentation-site/documentation-site.conf"
+  confFileList+=("--from-file" "$filePath")
 fi
+
 #
 # Funny hook to load the portal-workspace-parent nginx config
 #


### PR DESCRIPTION
Because all the scripts use `set -e` and `g3k_manifest_lookup` use jq/yq — it will return non-zero exit code for situations when the field doesn't exist (in this case — `.global.document_url`).

To mitigate this, the subshell for `documentUrl` need to treat the non-zero code separately (which is kind of hacky), but it will work in this specific case.

Link for extra information on this: https://mywiki.wooledge.org/BashFAQ/105#line-187

---

Jira Ticket: N/A

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes
* fix revproxy-deployment

### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
