### PR TITLE
adding a line to ignore custom suffix changes for the service_linked_role

### DIFF
--- a/tf_files-1.0/aws/modules/eks/cloud.tf
+++ b/tf_files-1.0/aws/modules/eks/cloud.tf
@@ -587,6 +587,9 @@ resource "aws_launch_template" "eks_launch_template" {
 resource "aws_iam_service_linked_role" "autoscaling" {
   aws_service_name = "autoscaling.amazonaws.com"
   custom_suffix = var.vpc_name
+  lifecycle {
+    ignore_changes  = ["custom_suffix"]
+  }
 }
 
 # Remember to grant access to the account in the KMS key policy too


### PR DESCRIPTION
adding a line to ignore custom suffix changes for the service_linked_role to prevent the "autoscaling" role from being destroyed and re-created. This will make things easier for us when migrating other commons to tf1.