### PR TITLE
adding .pedscommons.org to whitelist

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -75,6 +75,7 @@
 .paloaltonetworks.com
 .pandemicresponsecommons.org
 .perl.org
+.pedscommons.org
 .planx-ci.io
 .planx-pla.net
 .postgresql.org


### PR DESCRIPTION


### Improvements
Adding .pedscommons.org to whitelist