### PR TITLE
increase wait time for K8sReset

### DIFF
--- a/gen3/bin/kube-wait4-pods.sh
+++ b/gen3/bin/kube-wait4-pods.sh
@@ -11,20 +11,20 @@ help() {
       in the 'waiting' state.
       Use to wait till all launched services
       are up and healthy before performing some action.
-      Waits for up to 15 minutes.  Non-zero exit code
-      if 15 minutes expires, and pods are still not ready.
+      Waits for up to 60 minutes.  Non-zero exit code
+      if 60 minutes expires, and pods are still not ready.
 EOM
   return 0
 }
 
 
-MAX_RETRIES=${1:-180}
+MAX_RETRIES=${1:-360}
 IS_K8S_RESET="${2:-false}"
 
 if [[ ! "$MAX_RETRIES" =~ ^[0-9]+$ ]];
 then
   gen3_log_err "ignoring invalid retry count: $1"
-  MAX_RETRIES=180
+  MAX_RETRIES=360
 fi
 
 if [[ ! "$IS_K8S_RESET" =~ ^(true$|false$) ]];


### PR DESCRIPTION
Even though K8sReset stage waits for 90 minutes, the limit of 30 minutes here causes PRs to fail if the pods do not roll within 30 minutes.

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
