### PR TITLE
Fix apiversion of cronjobs and fix cluster-autoscaler

### DIFF
--- a/gen3/bin/job.sh
+++ b/gen3/bin/job.sh
@@ -60,7 +60,7 @@ g3k_job2cronjson(){
 
   local cronScript="$(cat - <<EOM
 {
-  "apiVersion": "batch/v1beta1",
+  "apiVersion": "batch/v1",
   "kind": "CronJob",
   "metadata": {
     "name": "$jobName"

--- a/gen3/bin/kube-setup-networkpolicy.sh
+++ b/gen3/bin/kube-setup-networkpolicy.sh
@@ -6,7 +6,7 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/gen3setup"
 
-serverVersion="$(g3kubectl version server -o json | jq -r '.serverVersion.major + "." + .serverVersion.minor' | head -c4).0"
+serverVersion="$(g3kubectl version -o json | jq -r '.serverVersion.major + "." + .serverVersion.minor' | head -c4).0"
 if ! semver_ge "$serverVersion" "1.8.0"; then
   gen3_log_info "kube-setup-netpolciy" "K8s server version $serverVersion does not yet support network policy"
   exit 0

--- a/kube/services/autoscaler/cluster-autoscaler-autodiscover.yaml
+++ b/kube/services/autoscaler/cluster-autoscaler-autodiscover.yaml
@@ -62,6 +62,16 @@ rules:
     resourceNames: ["cluster-autoscaler"]
     resources: ["leases"]
     verbs: ["get", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+     - storageclasses
+     - csinodes
+     - csidrivers
+     - csistoragecapacities
+    verbs:
+     - watch
+     - list
+     - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -142,8 +152,8 @@ spec:
           name: cluster-autoscaler
           resources:
             limits:
-              cpu: 100m
-              memory: 600Mi
+              cpu: 1000m
+              memory: 1600Mi
             requests:
               cpu: 100m
               memory: 300Mi


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Updated cronjob apiVersion to `batch/v1` from `batch/v1beta1` that is deprecated. 
- Small fix for network-policies to get the server version
- Gave cluster-autoscaler more memory/cpu and permissions 

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
