### PR TITLE
update datadog helm chart version

### DIFF
--- a/gen3/bin/kube-setup-datadog.sh
+++ b/gen3/bin/kube-setup-datadog.sh
@@ -44,7 +44,7 @@ if [[ "$ctxNamespace" == "default" || "$ctxNamespace" == "null" ]]; then
       fi
       helm repo add datadog https://helm.datadoghq.com --force-update 2> >(grep -v 'This is insecure' >&2)
       helm repo update 2> >(grep -v 'This is insecure' >&2)
-      helm upgrade --install datadog -f "$GEN3_HOME/kube/services/datadog/values.yaml" datadog/datadog -n datadog --version 2.33.8 2> >(grep -v 'This is insecure' >&2)
+      helm upgrade --install datadog -f "$GEN3_HOME/kube/services/datadog/values.yaml" datadog/datadog -n datadog --version 3.1.9 2> >(grep -v 'This is insecure' >&2)
     )
   else
     gen3_log_info "kube-setup-datadog exiting - datadog already deployed, use --force to redeploy"


### PR DESCRIPTION

### Bug Fixes

Upgrade datadog helm chart version to 3.1.9 to include the fixes for system-probe errors.
