### PR TITLE
updated revproxy documentation

### DIFF
--- a/doc/kube-setup-revproxy.md
+++ b/doc/kube-setup-revproxy.md
@@ -5,7 +5,8 @@ Configure and launch the reverse proxy.
 ## References
 
 * the reverse proxy [readme](../kube/services/revproxy/README.md) has more details.
-* WAF - the reverse proxy deploys the [modsecurity web application firewall](./waf.md). (This is only deployed if the "deploy_elb" flag is set to true in the manifest-global configmap (set/added via the global section of the manifest.json).deploy the revproxy-ELB-service and WAF)
+* WAF - the reverse proxy deploys the [modsecurity web application firewall](./waf.md).
+* IMPORTANT: The modsecurity WAF and Revproxy ELB service is only deployed if the "deploy_elb" flag is set to true in the manifest-global configmap. The Revproxy ELB is now deprecated- we suggest deploying an AWS ALB instead (please see kube-setup-ingress script)
 * Please see https://github.com/uc-cdis/cloud-automation/blob/master/doc/kube-setup-ingress.md as AWS WAF and ALB is recommended. 
 * [maintenance mode](./maintenance.md)
 * the [ip blacklist](../gen3/lib/manifestDefaults/revproxy/) may be configured with a custom `manifests/revproxy/blacklist.conf`

--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -295,4 +295,4 @@ fi
 
 if [ "$deployELB" = true ]; then
   gen3_deploy_revproxy_elb
-fi
+fi 


### PR DESCRIPTION
Jira Ticket: [GPE-679](https://ctds-planx.atlassian.net/browse/GPE-679)

We are deprecating the Revproxy Service ELB in favor of an AWS ALB. We strongly recommend deploying the AWS ALB via kube-setup-ingress instead.
Documentation was updated to reflect this change. Please see [kube-setup-revproxy.md](https://github.com/uc-cdis/cloud-automation/blob/master/doc/kube-setup-revproxy.md) and [kube-setup-ingress.md](https://github.com/uc-cdis/cloud-automation/blob/master/doc/kube-setup-ingress.md)

**Improvements**
The Revproxy Service ELB is no longer deployed by default. You now have to add/set the new "deploy_elb" flag to true in the "manifest-global" configmap to deploy it.
The previous PR was merged without release notes. Lines 16-21, 264-266, 292-298 were added to the "kube-setup-revproxy" script. You can see the original PR[ here](https://github.com/uc-cdis/cloud-automation/pull/2079)