### PR TITLE
Hide Revproxy ELB Behind a Flag

### DIFF
--- a/gen3/bin/kube-setup-revproxy.sh
+++ b/gen3/bin/kube-setup-revproxy.sh
@@ -295,4 +295,4 @@ fi
 
 if [ "$deployELB" = true ]; then
   gen3_deploy_revproxy_elb
-fi
+fi 


### PR DESCRIPTION
Jira Ticket: [GPE-679](https://ctds-planx.atlassian.net/browse/GPE-679)

- We are deprecating the Revproxy Service ELB in favor of an AWS ALB. We strongly recommend deploying the AWS ALB via kube-setup-ingress instead. 
- Documentation was updated to reflect this change. Please see [kube-setup-revproxy.md](https://github.com/uc-cdis/cloud-automation/blob/master/doc/kube-setup-revproxy.md) and [kube-setup-ingress.md](https://github.com/uc-cdis/cloud-automation/blob/master/doc/kube-setup-ingress.md)


### Improvements
- The Revproxy Service ELB is no longer deployed by default. You now have to add/set the new "deploy_elb" flag to true in the "manifest-global" configmap to deploy it. 
- The previous PR was merged without release notes. Lines 16-21, 264-266, 292-298 were added to the "kube-setup-revproxy" script. You can see the original PR [here](https://github.com/uc-cdis/cloud-automation/pull/2079)

