### PR TITLE
the gitops-sa account was not able to access the argo namespace

### DIFF
--- a/kube/services/jenkins/rolebinding-devops.yaml
+++ b/kube/services/jenkins/rolebinding-devops.yaml
@@ -15,11 +15,13 @@ roleRef:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: argo-binding
+  name: argo-role-binding
   namespace: argo
 subjects:
 - kind: ServiceAccount
   name: gitops-sa
+  namespace: default
+  apiGroup: ""
 roleRef:
   kind: ClusterRole
   name: admin


### PR DESCRIPTION
the gitops-sa account was not able to access the argo namespace because the default namespace was not provided to reference gitops-sa. 