### PR TITLE
editing kube-setup-argo script to contain a lifecycle policy

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-12-13T12:32:32Z",
+  "generated_at": "2022-12-16T19:37:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -338,7 +338,7 @@
         "hashed_secret": "40304f287a52d99fdbe086ad19dbdbf9cc1b3897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 182,
+        "line_number": 199,
         "type": "Secret Keyword"
       }
     ],

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2022-12-16T19:37:20Z",
+  "generated_at": "2022-12-16T20:29:01Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -338,7 +338,7 @@
         "hashed_secret": "40304f287a52d99fdbe086ad19dbdbf9cc1b3897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 199,
+        "line_number": 200,
         "type": "Secret Keyword"
       }
     ],

--- a/gen3/bin/kube-setup-argo.sh
+++ b/gen3/bin/kube-setup-argo.sh
@@ -123,8 +123,6 @@ EOF
     elif ! aws s3 mb "s3://${bucketName}"; then
       gen3_log_err "failed to create bucket ${bucketName}"
     fi
-    gen3_log_info "Creating bucket lifecycle policy"
-    aws s3api put-bucket-lifecycle --bucket ${bucketName} --lifecycle-configuration file://$bucketLifecyclePolicyFile
 
     gen3_log_info "Creating IAM user ${userName}"
     if ! aws iam get-user --user-name ${userName} > /dev/null 2>&1; then
@@ -156,6 +154,8 @@ EOF
     g3kubectl delete secret -n argo argo-s3-creds
   fi
 
+  gen3_log_info "Creating bucket lifecycle policy"
+  aws s3api put-bucket-lifecycle --bucket ${bucketName} --lifecycle-configuration file://$bucketLifecyclePolicyFile
 
   gen3_log_info "Creating s3 creds secret in argo namespace"
   if [[ -z $internalBucketName ]]; then

--- a/gen3/bin/kube-setup-argo.sh
+++ b/gen3/bin/kube-setup-argo.sh
@@ -154,9 +154,6 @@ EOF
     g3kubectl delete secret -n argo argo-s3-creds
   fi
 
-  gen3_log_info "Creating bucket lifecycle policy"
-  aws s3api put-bucket-lifecycle --bucket ${bucketName} --lifecycle-configuration file://$bucketLifecyclePolicyFile
-
   gen3_log_info "Creating s3 creds secret in argo namespace"
   if [[ -z $internalBucketName ]]; then
     g3kubectl create secret -n argo generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName}
@@ -167,8 +164,12 @@ EOF
 
   ## if new bucket then do the following
   # Get the aws keys from secret
+  # Create and attach lifecycle policy
   # Set bucket policies
   # Update secret to have new bucket
+
+  gen3_log_info "Creating bucket lifecycle policy"
+  aws s3api put-bucket-lifecycle --bucket ${bucketName} --lifecycle-configuration file://$bucketLifecyclePolicyFile
 
   # Always update the policy, in case manifest buckets change
   aws iam put-user-policy --user-name ${userName} --policy-name argo-bucket-policy --policy-document file://$policyFile

--- a/gen3/bin/kube-setup-argo.sh
+++ b/gen3/bin/kube-setup-argo.sh
@@ -103,11 +103,11 @@ EOF
 {
   "Rules": [
     {
-      "ID": "Store objects in Glacier after about 6 months",
+      "ID": "Store objects in Glacier after 4 months",
       "Prefix": "",
       "Status": "Enabled",
       "Transition": {
-        "Days": 190,
+        "Days": 120,
         "StorageClass": "GLACIER"
       }
     }


### PR DESCRIPTION
Adding a lifecycle policy for the argo bucket to the kube-setup-argocd script. Please see [GPE-544](https://ctds-planx.atlassian.net/browse/GPE-544) for more details. 