### PR TITLE
Increase portal memory limit to 6gb

### DIFF
--- a/kube/services/portal/portal-deploy.yaml
+++ b/kube/services/portal/portal-deploy.yaml
@@ -85,7 +85,7 @@ spec:
           limits:
             # portal pigs out on resources at startup, then settles down
             cpu: 2
-            memory: 4096Mi
+            memory: 6144Mi
         ports:
         - containerPort: 80
         - containerPort: 443


### PR DESCRIPTION
### Deployment changes
Increased portal memory limit to 6gb to accomodate for complex portal builds. 

<!-- This section should only contain important things devops should know when updating service versions. -->
