### PR TITLE
s3-creds Secret 

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-01-23T11:54:50Z",
+  "generated_at": "2023-02-01T22:29:59Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -338,7 +338,7 @@
         "hashed_secret": "40304f287a52d99fdbe086ad19dbdbf9cc1b3897",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 200,
+        "line_number": 217,
         "type": "Secret Keyword"
       }
     ],

--- a/gen3/bin/kube-setup-argo.sh
+++ b/gen3/bin/kube-setup-argo.sh
@@ -126,7 +126,7 @@ EOF
 
     gen3_log_info "Creating IAM user ${userName}"
     if ! aws iam get-user --user-name ${userName} > /dev/null 2>&1; then
-      aws iam create-user --user-name ${userName}
+      aws iam create-user --user-name ${userName} || true
     else
       gen3_log_info "IAM user ${userName} already exits.."
     fi
@@ -134,9 +134,9 @@ EOF
     secret=$(aws iam create-access-key --user-name ${userName})
     if ! g3kubectl get namespace argo > /dev/null 2>&1; then
       gen3_log_info "Creating argo namespace"
-      g3kubectl create namespace argo
-      g3kubectl label namespace argo app=argo
-      g3kubectl create rolebinding argo-admin --clusterrole=admin --serviceaccount=argo:default -n argo
+      g3kubectl create namespace argo || true
+      g3kubectl label namespace argo app=argo || true
+      g3kubectl create rolebinding argo-admin --clusterrole=admin --serviceaccount=argo:default -n argo || true
     fi
   else
     # Else we want to recreate the argo-s3-creds secret so make a temp file with the current creds and delete argo-s3-creds secret
@@ -151,29 +151,30 @@ EOF
 }
 EOF
     secret=$(cat $secretFile)
-    g3kubectl delete secret -n argo argo-s3-creds
   fi
 
   gen3_log_info "Creating s3 creds secret in argo namespace"
   if [[ "$ctxNamespace" == "default" || "$ctxNamespace" == "null" ]]; then
     if [[ -z $internalBucketName ]]; then
-      g3kubectl create secret -n argo generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName}
-      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName}
-
+      g3kubectl delete secret -n argo argo-s3-creds || true
+      g3kubectl create secret -n argo generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} || true
+      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} || true
     else
-      g3kubectl create secret -n argo generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} --from-literal=internalbucketname=${internalBucketName}
-      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName}
+      g3kubectl delete secret -n argo argo-s3-creds || true
+      g3kubectl create secret -n argo generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} --from-literal=internalbucketname=${internalBucketName} || true
+      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} || true
     fi
   else
     g3kubectl create sa argo || true
     # Grant admin access within the current namespace to the argo SA in the current namespace
     g3kubectl create rolebinding argo-admin --clusterrole=admin --serviceaccount=$(gen3 db namespace):argo -n $(gen3 db namespace) || true
-    aws iam put-user-policy --user-name ${userName} --policy-name argo-bucket-policy --policy-document file://$policyFile
+    aws iam put-user-policy --user-name ${userName} --policy-name argo-bucket-policy --policy-document file://$policyFile || true
     if [[ -z $internalBucketName ]]; then
-      aws iam put-user-policy --user-name ${userName} --policy-name argo-internal-bucket-policy --policy-document file://$internalBucketPolicyFile
-      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName}
+      aws iam put-user-policy --user-name ${userName} --policy-name argo-internal-bucket-policy --policy-document file://$internalBucketPolicyFile || true
+      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} || true
     else
-      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} --from-literal=internalbucketname=${internalBucketName}
+      g3kubectl create secret generic argo-s3-creds --from-literal=AccessKeyId=$(echo $secret  | jq -r .AccessKey.AccessKeyId) --from-literal=SecretAccessKey=$(echo $secret  | jq -r .AccessKey.SecretAccessKey) --from-literal=bucketname=${bucketName} --from-literal=internalbucketname=${internalBucketName} || true
+
     fi
   fi
 


### PR DESCRIPTION
editing the kube-setup-argo script to prevent it from deleting the s3 cred secret in the argo ns if run a non-default ns since it won't be re-created in that case.