### PR TITLE
PXP-10558 `gen3 kube-setup-pelicanjob` creates Fence client

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-02-01T22:29:59Z",
+  "generated_at": "2023-02-03T22:39:02Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/gen3/bin/kube-setup-pelicanjob.sh
+++ b/gen3/bin/kube-setup-pelicanjob.sh
@@ -26,9 +26,9 @@ if ! g3kubectl describe secret pelicanservice-g3auto | grep config.json > /dev/n
     access_key=$(jq -r .secret <<< $user)
 
     # setup fence OIDC client with client_credentials grant for access to MDS API
-    local hostname=$(gen3 api hostname)
+    hostname=$(gen3 api hostname)
     gen3_log_info "kube-setup-sower-jobs" "creating fence oidc client for $hostname"
-    local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client pelican-export-job --grant-types client_credentials | tail -1)
+    secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client pelican-export-job --grant-types client_credentials | tail -1)
     # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
     if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
         # try delete client
@@ -39,8 +39,8 @@ if ! g3kubectl describe secret pelicanservice-g3auto | grep config.json > /dev/n
             return 1
         fi
     fi
-    local pelican_export_client_id="${BASH_REMATCH[2]}"
-    local pelican_export_client_secret="${BASH_REMATCH[3]}"
+    pelican_export_client_id="${BASH_REMATCH[2]}"
+    pelican_export_client_secret="${BASH_REMATCH[3]}"
 
     cat - > "$credsFile" <<EOM
 {

--- a/gen3/bin/kube-setup-pelicanjob.sh
+++ b/gen3/bin/kube-setup-pelicanjob.sh
@@ -24,14 +24,36 @@ if ! g3kubectl describe secret pelicanservice-g3auto | grep config.json > /dev/n
     user=$(gen3 secrets decode $awsuser-g3auto awsusercreds.json)
     key_id=$(jq -r .id <<< $user)
     access_key=$(jq -r .secret <<< $user)
+
+    # setup fence OIDC client with client_credentials grant for access to MDS API
+    local hostname=$(gen3 api hostname)
+    gen3_log_info "kube-setup-sower-jobs" "creating fence oidc client for $hostname"
+    local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client pelican-export-job --grant-types client_credentials | tail -1)
+    # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
+    if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
+        # try delete client
+        g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client pelican-export-job > /dev/null 2>&1
+        secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client pelican-export-job --grant-types client_credentials | tail -1)
+        if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
+            gen3_log_err "kube-setup-sower-jobs" "Failed generating oidc client: $secrets"
+            return 1
+        fi
+    fi
+    local pelican_export_client_id="${BASH_REMATCH[2]}"
+    local pelican_export_client_secret="${BASH_REMATCH[3]}"
+
     cat - > "$credsFile" <<EOM
 {
   "manifest_bucket_name": "$bucketname",
   "hostname": "$hostname",
   "aws_access_key_id": "$key_id",
-  "aws_secret_access_key": "$access_key"
+  "aws_secret_access_key": "$access_key",
+  "fence_client_id": "$pelican_export_client_id",
+  "fence_client_secret": "$pelican_export_client_secret"
 }
 EOM
     gen3 secrets sync "initialize pelicanservice/config.json"
   fi
 fi
+
+gen3_log_warn "!!! The 'pelican-export-job' client must be granted access to (resource=/mds_gateway, method=access, service=mds_gateway) for the Pelican Export job to function"


### PR DESCRIPTION
Jira Ticket: [PXP-10558](https://ctds-planx.atlassian.net/browse/PXP-10558)

see https://github.com/uc-cdis/pelican/pull/69

### New Features
- The `gen3 kube-setup-pelicanjob` command now create a Fence OIDC client for use by the Pelican export job

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
