### PR TITLE
Feat/datadog nginx integration

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/status.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/status.conf
@@ -1,0 +1,12 @@
+#This is needed to enable the Datadog integration with Nginx. More details can be found here: https://docs.datadoghq.com/integrations/nginx/?tab=kubernetes
+server {
+  listen 18080;
+
+  location /nginx_status {
+    stub_status on;
+  }
+
+  location / {
+    return 404;
+  }
+}

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -401,8 +401,6 @@ server {
 
   location /nginx_status {
       stub_status;
-      allow 127.0.0.1;
-      deny all;
       access_log off;
   }
 

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -4,17 +4,6 @@ metadata:
   name: revproxy-deployment
   annotations:
     gen3.io/network-ingress: "portal,sowerjob"
-    ad.datadoghq.com/revproxy.checks: |
-      {
-        "nginx": {
-          "init_config": {},
-          "instances": [
-            {
-              "nginx_status_url":"http://%%host%%:81/nginx_status/"
-            }
-          ]
-        }
-      }
 spec:
   selector:
     # Only select pods based on the 'app' label
@@ -33,6 +22,18 @@ spec:
         # allow access from workspaces
         userhelper: "yes"
         GEN3_DATE_LABEL
+      annotations:
+        ad.datadoghq.com/revproxy.checks: |
+          {
+            "nginx": {
+              "init_config": {},
+              "instances": [
+                {
+                  "nginx_status_url":"http://revproxy-service.default.svc.cluster.local/nginx_status/"
+                }
+              ]
+            }
+          }
     spec:
       affinity:
         podAntiAffinity:

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -4,6 +4,17 @@ metadata:
   name: revproxy-deployment
   annotations:
     gen3.io/network-ingress: "portal,sowerjob"
+    ad.datadoghq.com/revproxy.checks: |
+      {
+        "nginx": {
+          "init_config": {},
+          "instances": [
+            {
+              "nginx_status_url":"http://%%host%%:81/nginx_status/"
+            }
+          ]
+        }
+      }
 spec:
   selector:
     # Only select pods based on the 'app' label
@@ -88,6 +99,7 @@ spec:
         - containerPort: 80
         - containerPort: 443
         - containerPort: 6567
+        - containerPort: 18080
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/kube/services/revproxy/revproxy-service-elb.yaml
+++ b/kube/services/revproxy/revproxy-service-elb.yaml
@@ -25,4 +25,8 @@ spec:
       port: 80
       targetPort: $TARGET_PORT_HTTP
       name: http
+    - protocol: TCP
+      port: 81
+      targetPort: 18080
+      name: status
   type: LoadBalancer


### PR DESCRIPTION
### New Features
Updated the revproxy configuration to enable Datadog to scrape metrics using the Nginx integration. This involved adding an annotation to the pod, as well as changing the config of the /nginx_status endpoint to allow connections from outside the pod. This may be a risk, so we'll want to discuss and possibly adjust. 

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
