### PR TITLE
remove gcloud

### DIFF
--- a/Docker/awshelper/Dockerfile
+++ b/Docker/awshelper/Dockerfile
@@ -58,7 +58,7 @@ RUN export CLOUD_SDK_REPO="cloud-sdk" && \
     apt-get update && \
     apt-get install -y kubectl && \
     apt-get install -y --no-install-recommends nodejs && \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*  &&\
     kubectl version --client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/*

--- a/Docker/awshelper/Dockerfile
+++ b/Docker/awshelper/Dockerfile
@@ -56,15 +56,9 @@ RUN export CLOUD_SDK_REPO="cloud-sdk" && \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
     curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
     apt-get update && \
-    apt-get install -y google-cloud-sdk \
-        google-cloud-sdk-cbt \
-        kubectl && \
+    apt-get install -y kubectl && \
     apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/* \
-    gcloud config set core/disable_usage_reporting true && \
-    gcloud config set component_manager/disable_update_check true && \
-    gcloud config set metrics/environment github_docker_image && \
-    gcloud --version && \
     kubectl version --client && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/log/*


### PR DESCRIPTION
remove gcloud from awshelper

Jira Ticket: [GPE-789](https://ctds-planx.atlassian.net/browse/GPE-789)

### Breaking Changes
Removing google-cloud-sdk as an effort to make a lighter awshelper image.


[GPE-789]: https://ctds-planx.atlassian.net/browse/GPE-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ