### PR TITLE
chore(karpenter-fluentd): Force karpenter deployments to deploy new f…

### DIFF
--- a/gen3/bin/kube-setup-karpenter.sh
+++ b/gen3/bin/kube-setup-karpenter.sh
@@ -104,7 +104,8 @@ gen3_deploy_karpenter() {
 
   gen3_log_info "Remove cluster-autoscaler"
   gen3 kube-setup-autoscaler --remove
-
+  # Ensure that fluentd is updated if karpenter is deployed to prevent containerd logging issues
+  gen3 kube-setup-fluentd
   gen3_log_info "Adding node templates for karpenter"
   g3k_kv_filter ${GEN3_HOME}/kube/services/karpenter/nodeTemplateDefault.yaml VPC_NAME ${vpc_name} | g3kubectl apply -f -
   g3k_kv_filter ${GEN3_HOME}/kube/services/karpenter/nodeTemplateJupyter.yaml VPC_NAME ${vpc_name} | g3kubectl apply -f -

--- a/kube/services/fluentd/fluentd-karpenter.yaml
+++ b/kube/services/fluentd/fluentd-karpenter.yaml
@@ -43,7 +43,8 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: fluentd
-        GEN3_FLUENTD_IMAGE
+        # Hardcode fluentd version to ensure we don't run into containerd logging issues
+        image: fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0
         env:
           # See https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes
           - name: K8S_NODE_NAME

--- a/kube/services/fluentd/fluentd.yaml
+++ b/kube/services/fluentd/fluentd.yaml
@@ -43,7 +43,8 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: fluentd
-        GEN3_FLUENTD_IMAGE
+        # Hardcode fluentd version to match karpenter daemonset
+        image: fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0
         env:
           # See https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes
           - name: K8S_NODE_NAME


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Force karpenter deployments to deploy new fluentd configuration and hardcode image to prevent old cdis-manifest repos from breaking fluentd version

### Dependency updates


### Deployment changes
