### PR TITLE
adding changes necessary for cluster version 1.24 for Karpenter and F…

### DIFF
--- a/gen3/bin/kube-setup-fluentd.sh
+++ b/gen3/bin/kube-setup-fluentd.sh
@@ -45,8 +45,13 @@ if [[ "$ctxNamespace" == "default" || "$ctxNamespace" == "null" ]]; then
       if g3kubectl --namespace=logging get daemonset fluentd > /dev/null 2>&1; then
         g3kubectl "--namespace=logging" delete daemonset fluentd
       fi
-      (unset KUBECTL_NAMESPACE; gen3 gitops filter "${GEN3_HOME}/kube/services/fluentd/fluentd.yaml" GEN3_LOG_GROUP_NAME "${vpc_name}") | g3kubectl "--namespace=logging" apply -f -
-      (unset KUBECTL_NAMESPACE; gen3 gitops filter "${GEN3_HOME}/kube/services/fluentd/fluentd-karpenter.yaml" GEN3_LOG_GROUP_NAME "${vpc_name}") | g3kubectl "--namespace=logging" apply -f -
+      export clusterversion=`kubectl version --short -o json | jq -r .serverVersion.minor`
+      if [ "${clusterversion}" = "24+" ]; then
+        (unset KUBECTL_NAMESPACE; gen3 gitops filter "${GEN3_HOME}/kube/services/fluentd/fluentd-eks-1.24.yaml" GEN3_LOG_GROUP_NAME "${vpc_name}") | g3kubectl "--namespace=logging" apply -f -
+      else
+        (unset KUBECTL_NAMESPACE; gen3 gitops filter "${GEN3_HOME}/kube/services/fluentd/fluentd.yaml" GEN3_LOG_GROUP_NAME "${vpc_name}") | g3kubectl "--namespace=logging" apply -f -
+        (unset KUBECTL_NAMESPACE; gen3 gitops filter "${GEN3_HOME}/kube/services/fluentd/fluentd-karpenter.yaml" GEN3_LOG_GROUP_NAME "${vpc_name}") | g3kubectl "--namespace=logging" apply -f -
+      fi
       # We need this serviceaccount to be in the default namespace for the job and cronjob to properly work
       g3kubectl apply -f "${GEN3_HOME}/kube/services/fluentd/fluent-jobs-serviceaccount.yaml" -n default
       if [ ${fluentdVersion} == "v1.10.2-debian-cloudwatch-1.0" ];

--- a/gen3/bin/kube-setup-karpenter.sh
+++ b/gen3/bin/kube-setup-karpenter.sh
@@ -110,7 +110,7 @@ gen3_deploy_karpenter() {
   gen3_log_info "Remove cluster-autoscaler"
   gen3 kube-setup-autoscaler --remove
   # Ensure that fluentd is updated if karpenter is deployed to prevent containerd logging issues
-  gen3 kube-setup-fluentd
+  gen3 kube-setup-fluentd --force
   gen3_log_info "Adding node templates for karpenter"
   g3k_kv_filter ${GEN3_HOME}/kube/services/karpenter/nodeTemplateDefault.yaml VPC_NAME ${vpc_name} | g3kubectl apply -f -
   g3k_kv_filter ${GEN3_HOME}/kube/services/karpenter/nodeTemplateJupyter.yaml VPC_NAME ${vpc_name} | g3kubectl apply -f -

--- a/gen3/bin/kube-setup-karpenter.sh
+++ b/gen3/bin/kube-setup-karpenter.sh
@@ -16,7 +16,12 @@ gen3_deploy_karpenter() {
     # Ensure the spot instance service linked role is setup
     # It is required for running spot instances
     aws iam create-service-linked-role --aws-service-name spot.amazonaws.com || true
-    karpenter=${karpenter:-v0.22.0}
+    export clusterversion=`kubectl version --short -o json | jq -r .serverVersion.minor`
+      if [ "${clusterversion}" = "24+" ]; then
+      karpenter=${karpenter:-v0.24.0}
+      else
+      karpenter=${karpenter:-v0.22.0}
+      fi    
     echo '{
         "Statement": [
             {

--- a/kube/services/fluentd/fluentd-eks-1.24.yaml
+++ b/kube/services/fluentd/fluentd-eks-1.24.yaml
@@ -1,10 +1,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: fluentd-eks-1.24
+  name: fluentd
   namespace: logging
   labels:
-    k8s-app: fluentd--ks-1.24-logging
+    k8s-app: fluentd-eks-1.24-logging
     version: v1
     GEN3_DATE_LABEL
     kubernetes.io/cluster-service: "true"

--- a/kube/services/fluentd/fluentd-eks-1.24.yaml
+++ b/kube/services/fluentd/fluentd-eks-1.24.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluentd-eks-1.24
+  namespace: logging
+  labels:
+    k8s-app: fluentd--ks-1.24-logging
+    version: v1
+    GEN3_DATE_LABEL
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-eks-1.24-logging
+      version: v1
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-eks-1.24-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      priorityClassName: system-cluster-critical
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: "role"
+        operator: "Equal"
+        value: "jupyter"
+        effect: "NoSchedule"
+      - key: "role"
+        operator: "Equal"
+        value: "workflow"
+        effect: "NoSchedule"
+      containers:
+      - name: fluentd
+        # Hardcode fluentd version to ensure we don't run into containerd logging issues
+        image: fluent/fluentd-kubernetes-daemonset:v1.15.3-debian-cloudwatch-1.0
+        env:
+          # See https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          # Deploy with kube-setup-fluentd.sh ...
+          - name:  LOG_GROUP_NAME
+            GEN3_LOG_GROUP_NAME
+          - name: AWS_REGION
+            value: "us-east-1"
+          - name: FLUENTD_CONF
+            value: "gen3.conf"
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            value: "cri"
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        volumeMounts:
+        - name: fluentd-gen3
+          mountPath: /fluentd/etc/gen3.conf
+          subPath: gen3.conf
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+        command: ["/bin/bash" ]
+        args:
+          - "-c"
+          # Script always succeeds if it runs (echo exits with 0)
+          - |
+            /fluentd/entrypoint.sh
+      terminationGracePeriodSeconds: 30
+      serviceAccountName: fluentd
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers
+      - name: fluentd-gen3
+        configMap:
+          name: fluentd-gen3


### PR DESCRIPTION
We are planning on updating clusters to 1.24 and in order to do this we will need Karpenter to be running version 1.24. 
 
Fluentd will also need a specific environment variable to run on version 1.24 because all nodes will be using containerd. 
