### PR TITLE
changing "parallelism" parameter from 10 to 3 per GPE-876

### DIFF
--- a/kube/services/argo/values.yaml
+++ b/kube/services/argo/values.yaml
@@ -1,5 +1,5 @@
 controller:
-  parallelism: 10
+  parallelism: 3
   metricsConfig:
     # -- Enables prometheus metrics server
     enabled: true


### PR DESCRIPTION
We have recently changed the amount of workflows allowed at once on Prod to be 3 (down from 10). This will change back to 10 every time we deploy Argo.