### PR TITLE
Disabling support for TLS Versions 1.0 and 1.1

### DIFF
--- a/flavors/squid_auto/squid_running_on_docker.sh
+++ b/flavors/squid_auto/squid_running_on_docker.sh
@@ -20,7 +20,7 @@ SQUID_CONFIG_DIR="/etc/squid"
 SQUID_LOGS_DIR="/var/log/squid"
 SQUID_CACHE_DIR="/var/cache/squid"
 SQUID_PID_DIR="/var/run/squid"
-SQUID_IMAGE_TAG="squid-5.3" #"feat_ha-squid"
+SQUID_IMAGE_TAG="master" #"feat_ha-squid"
 #SQUID_VERSION="squid-4.14"
 
 HOSTNAME=$(command -v hostname)

--- a/flavors/squid_auto/squid_running_on_docker.sh
+++ b/flavors/squid_auto/squid_running_on_docker.sh
@@ -20,7 +20,7 @@ SQUID_CONFIG_DIR="/etc/squid"
 SQUID_LOGS_DIR="/var/log/squid"
 SQUID_CACHE_DIR="/var/cache/squid"
 SQUID_PID_DIR="/var/run/squid"
-SQUID_IMAGE_TAG="master" #"feat_ha-squid"
+SQUID_IMAGE_TAG="squid-5.3" #"feat_ha-squid"
 #SQUID_VERSION="squid-4.14"
 
 HOSTNAME=$(command -v hostname)

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,8 +22,8 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent options=NO_SSLv2,NO_SSLv3,NO_TLSv1,NO_TLSv1_2
-sslproxy_options NO_SSLv2,NO_SSLv3,NO_TLSv1,NO_TLSv1_2
+https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent sslproxy_cipher TLSv1.2+HIGH:!SSLv2:!SSLv3:!TLSv1.0:!TLSv1.1
+
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,9 +22,7 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
-
-openssl_options TLSv1.2+ -TLSv1.0 -TLSv1.1
+https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent options=NO_TLSv1,NO_TLSv1_1
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,7 +22,8 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent ssl-min-version=TLSv1.2
+https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent options=NO_SSLv2,NO_SSLv3,NO_TLSv1,NO_TLSv1_2
+sslproxy_options NO_SSLv2,NO_SSLv3,NO_TLSv1,NO_TLSv1_2
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -23,8 +23,9 @@ http_port 3129 intercept # We may be able to go without this
 http_access allow web_whitelist
 
 https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
-ssl_min_version TLSv1.2
 
+ssl_min_version TLSv1.2
+ssl_max_version TLSv1.3
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,7 +22,7 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent options=NO_TLSv1,NO_TLSv1_1
+https_port 3130 cert=/etc/squid/ssl/squid.pem options=NO_TLSv1,NO_TLSv1_1 ssl-bump intercept name=transparent
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -24,6 +24,7 @@ http_access allow web_whitelist
 
 https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
 
+sslproxy_options NO_SSLv3,NO_TLSv1.0
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,7 +22,8 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent sslproxy_cipher TLSv1.2+HIGH:!SSLv2:!SSLv3:!TLSv1.0:!TLSv1.1
+https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
+sslproxy_cipher TLSv1.2+HIGH:!SSLv2:!SSLv3:!TLSv1.0:!TLSv1.1
 
 
 acl CONNECT method CONNECT

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,7 +22,7 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
+https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent ssl-min-version=TLSv1.2
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -24,7 +24,7 @@ http_access allow web_whitelist
 
 https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
 
-sslproxy_options NO_SSLv3,NO_TLSv1.0
+tls_outgoing_options min-version=1.2
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -24,7 +24,7 @@ http_access allow web_whitelist
 
 https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
 
-tls_outgoing_options min-version=1.2
+openssl_options TLSv1.2+ -TLSv1.0 -TLSv1.1
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -24,8 +24,6 @@ http_access allow web_whitelist
 
 https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
 
-ssl_min_version TLSv1.2
-ssl_max_version TLSv1.3
 
 acl CONNECT method CONNECT
 

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -23,7 +23,7 @@ http_port 3129 intercept # We may be able to go without this
 http_access allow web_whitelist
 
 https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent
-sslproxy_cipher TLSv1.2+HIGH:!SSLv2:!SSLv3:!TLSv1.0:!TLSv1.1
+ssl_min_version TLSv1.2
 
 
 acl CONNECT method CONNECT

--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -22,7 +22,7 @@ http_port 3129 intercept # We may be able to go without this
 
 http_access allow web_whitelist
 
-https_port 3130 cert=/etc/squid/ssl/squid.pem options=NO_TLSv1,NO_TLSv1_1 ssl-bump intercept name=transparent
+https_port 3130 cert=/etc/squid/ssl/squid.pem ssl-bump intercept name=transparent options=NO_TLSv1,NO_TLSv1_1
 
 acl CONNECT method CONNECT
 

--- a/gen3/bin/kube-setup-ingress.sh
+++ b/gen3/bin/kube-setup-ingress.sh
@@ -298,7 +298,7 @@ EOM
 }
 
 gen3_ingress_deploy_helm_chart() {
-  kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller//crds?ref=master"
+  kubectl apply -k "github.com/aws/eks-charts/stable/aws-load-balancer-controller/crds?ref=master"
   if (! helm status aws-load-balancer-controller -n kube-system > /dev/null 2>&1 )  || [[ "$1" == "--force" ]]; then
     helm repo add eks https://aws.github.io/eks-charts 2> >(grep -v 'This is insecure' >&2)
     helm repo update 2> >(grep -v 'This is insecure' >&2)

--- a/kube/services/ingress/ingress.yaml
+++ b/kube/services/ingress/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
     alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=600
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/ssl-policy: "ELBSecurityPolicy-TLS-1-2-2017-01"
 spec:
   ingressClassName: alb
   rules:


### PR DESCRIPTION
We would like to only support TLS versions 1.2 or higher per GPE-900. 