### PR TITLE
GPE-964

### DIFF
--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -268,6 +268,7 @@ if [[ "$GEN3_ROLL_FAST" != "true" ]]; then
   #
   gen3 kube-setup-networkpolicy disable &
   gen3 kube-setup-networkpolicy &
+  gen3 kube-setup-pdb
 else
   gen3_log_info "roll fast mode - skipping k8s base services and netpolicy setup"
 fi

--- a/gen3/bin/kube-setup-pdb.sh
+++ b/gen3/bin/kube-setup-pdb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Apply pods diruption budgets to the core services of the commons
+#
+
+source "${GEN3_HOME}/gen3/lib/utils.sh"
+gen3_load "gen3/gen3setup"
+
+serverVersion="$(g3kubectl version -o json | jq -r '.serverVersion.major + "." + .serverVersion.minor' | head -c4)"
+echo "Server version $serverVersion"
+if [ "$serverVersion" \< "1.21" ]; then
+  gen3_log_info "kube-setup-pdb" "K8s server version $serverVersion does not support pod disruption budgets. Server must be version 1.21 or higher"
+  exit 0
+fi
+
+deployments=$(kubectl get deployments | awk '{print $1}' | tail -n +2)
+
+if [[ "$(g3k_manifest_lookup .global.pdb)" == "on" ]]; then
+ for deployment in $deployments
+ do
+   replicas=$(kubectl get deployment $deployment -o=jsonpath='{.spec.replicas}')
+   if [[ "$replicas" -gt "1" ]]; then
+     echo "There were $replicas replicas"
+     service=$(echo "$deployment" | awk -F '-' '{print $1}')
+     echo "We are on the $service service"
+     filePath="${GEN3_HOME}/kube/services/pod-disruption-budget/${service}.yaml"
+     if [[ -f "$filePath" ]]; then
+       g3kubectl apply -f "$filePath"
+     else
+       echo "No PDB file found for service $service"
+     fi
+   else
+     echo "Skipping PDB for deployment $deployment because it has only 1 replica"
+   fi
+ done
+ else
+  echo "You need to set pdb = 'on' in the manifest.json"
+fi

--- a/kube/services/pod-disruption-budget/ambassador.yaml
+++ b/kube/services/pod-disruption-budget/ambassador.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ambassador-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: ambassador

--- a/kube/services/pod-disruption-budget/arborist.yaml
+++ b/kube/services/pod-disruption-budget/arborist.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: arborist-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: arborist

--- a/kube/services/pod-disruption-budget/argo-wrapper.yaml
+++ b/kube/services/pod-disruption-budget/argo-wrapper.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: argo-wrapper-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: argo-wrapper

--- a/kube/services/pod-disruption-budget/arranger.yaml
+++ b/kube/services/pod-disruption-budget/arranger.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: arranger-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: arranger

--- a/kube/services/pod-disruption-budget/audit-service.yaml
+++ b/kube/services/pod-disruption-budget/audit-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: audit-service-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: audit-service

--- a/kube/services/pod-disruption-budget/aws-es-proxy.yaml
+++ b/kube/services/pod-disruption-budget/aws-es-proxy.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: esproxy-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: esproxy

--- a/kube/services/pod-disruption-budget/dicom-server.yaml
+++ b/kube/services/pod-disruption-budget/dicom-server.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dicom-server-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dicom-server

--- a/kube/services/pod-disruption-budget/dicom-viewer.yaml
+++ b/kube/services/pod-disruption-budget/dicom-viewer.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: dicom-viewer-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: dicom-viewer

--- a/kube/services/pod-disruption-budget/fence.yaml
+++ b/kube/services/pod-disruption-budget/fence.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fence-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: fence

--- a/kube/services/pod-disruption-budget/guppy.yaml
+++ b/kube/services/pod-disruption-budget/guppy.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: guppy-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: guppy

--- a/kube/services/pod-disruption-budget/hatchery.yaml
+++ b/kube/services/pod-disruption-budget/hatchery.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: hatchery-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: hatchery

--- a/kube/services/pod-disruption-budget/indexd.yaml
+++ b/kube/services/pod-disruption-budget/indexd.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: indexd-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: indexd

--- a/kube/services/pod-disruption-budget/manifestservice.yaml
+++ b/kube/services/pod-disruption-budget/manifestservice.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: manifestservice-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: manifestservice

--- a/kube/services/pod-disruption-budget/metadata.yaml
+++ b/kube/services/pod-disruption-budget/metadata.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: metadata-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: metadata

--- a/kube/services/pod-disruption-budget/peregrine.yaml
+++ b/kube/services/pod-disruption-budget/peregrine.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: peregrine-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: peregrine

--- a/kube/services/pod-disruption-budget/pidgin.yaml
+++ b/kube/services/pod-disruption-budget/pidgin.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pidgin-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pidgin

--- a/kube/services/pod-disruption-budget/portal.yaml
+++ b/kube/services/pod-disruption-budget/portal.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: portal-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: portal

--- a/kube/services/pod-disruption-budget/requestor.yaml
+++ b/kube/services/pod-disruption-budget/requestor.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: requestor-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: requestor

--- a/kube/services/pod-disruption-budget/revproxy.yaml
+++ b/kube/services/pod-disruption-budget/revproxy.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: revproxy-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: revproxy

--- a/kube/services/pod-disruption-budget/sheepdog.yaml
+++ b/kube/services/pod-disruption-budget/sheepdog.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: sheepdog-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: sheepdog

--- a/kube/services/pod-disruption-budget/ssjdispatcher.yaml
+++ b/kube/services/pod-disruption-budget/ssjdispatcher.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: ssjdispatcher-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: ssjdispatcher

--- a/kube/services/pod-disruption-budget/wts.yaml
+++ b/kube/services/pod-disruption-budget/wts.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: wts-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: wts


### PR DESCRIPTION
Improvements
Pod disruption budgets will help increase our availability by making sure we always have at least 1 replica available at all times. We are also expanding this to ensure that every services has at least 2 replicas, so if a pod gets evicted the service will remain running.


adding pod disruption budgets for every service that will get applied via the roll all or by running kube-setup-pdb. The pdb will only be applied to the cluster if the service in question has more than 1 replica.