### PR TITLE
Switch gen3Env to hostname instead of environment

### DIFF
--- a/kube/services/jobs/etl-cronjob.yaml
+++ b/kube/services/jobs/etl-cronjob.yaml
@@ -79,7 +79,7 @@ spec:
                 valueFrom:
                     configMapKeyRef:
                       name: global
-                      key: environment
+                      key: hostname
               volumeMounts:
               - name: "creds-volume"
                 readOnly: true

--- a/kube/services/jobs/fence-db-migrate-job.yaml
+++ b/kube/services/jobs/fence-db-migrate-job.yaml
@@ -47,11 +47,6 @@ spec:
           GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
           imagePullPolicy: Always
           env:
-            - name: gen3Env
-              valueFrom:
-                configMapKeyRef:
-                  name: global
-                  key: environment
             - name: JENKINS_HOME
               value: ""
             - name: GEN3_NOPROXY
@@ -116,11 +111,6 @@ spec:
         GEN3_AWSHELPER_IMAGE|-image: quay.io/cdis/awshelper:master-|
         imagePullPolicy: Always
         env:
-          - name: gen3Env
-            valueFrom:
-              configMapKeyRef:
-                name: global
-                key: environment
           - name: JENKINS_HOME
             value: ""
           - name: GEN3_NOPROXY

--- a/kube/services/jobs/fence-visa-update-cronjob.yaml
+++ b/kube/services/jobs/fence-visa-update-cronjob.yaml
@@ -73,7 +73,7 @@ spec:
                   valueFrom:
                       configMapKeyRef:
                         name: global
-                        key: environment
+                        key: hostname
                 - name: FENCE_PUBLIC_CONFIG
                   valueFrom:
                     configMapKeyRef:

--- a/kube/services/jobs/fence-visa-update-job.yaml
+++ b/kube/services/jobs/fence-visa-update-job.yaml
@@ -67,7 +67,7 @@ spec:
               valueFrom:
                   configMapKeyRef:
                     name: global
-                    key: environment
+                    key: hostname
             - name: FENCE_PUBLIC_CONFIG
               valueFrom:
                 configMapKeyRef:

--- a/kube/services/jobs/s3sync-cronjob.yaml
+++ b/kube/services/jobs/s3sync-cronjob.yaml
@@ -57,7 +57,7 @@ spec:
                   valueFrom:
                       configMapKeyRef:
                         name: global
-                        key: environment
+                        key: hostname
                 - name: SOURCE_BUCKET
                   GEN3_SOURCE_BUCKET
                 - name: TARGET_BUCKET

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -125,7 +125,7 @@ spec:
             valueFrom:
                 configMapKeyRef:
                   name: global
-                  key: environment
+                  key: hostname
           - name: FENCE_PUBLIC_CONFIG
             valueFrom:
               configMapKeyRef:
@@ -294,7 +294,7 @@ spec:
             valueFrom:
               configMapKeyRef:
                 name: global
-                key: environment
+                key: hostname
           - name: slackWebHook
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
For qa environments, we want the slack notifications to display the specific environment instead of "qaplanetv1"

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
