### PR TITLE
EBSCSI Driver policy

### DIFF
--- a/gen3/bin/kube-setup-system-services.sh
+++ b/gen3/bin/kube-setup-system-services.sh
@@ -16,10 +16,10 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/gen3setup"
 
-kubeproxy=${kubeproxy:-1.22.11}
+kubeproxy=${kubeproxy:-1.24.7}
 coredns=${coredns:-1.8.7}
 kubednsautoscaler=${kubednsautoscaler:-1.8.6}
-cni=${cni:-1.12.0}
+cni=${cni:-1.12.2}
 calico=${calico:-1.7.8}
 
 

--- a/tf_files/aws/modules/eks-nodepool/cloud.tf
+++ b/tf_files/aws/modules/eks-nodepool/cloud.tf
@@ -162,6 +162,11 @@ resource "aws_iam_role_policy_attachment" "eks-node-AmazonEKS_CNI_Policy" {
   role       = "${aws_iam_role.eks_node_role.name}"
 }
 
+resource "aws_iam_role_policy_attachment" "eks-node-AmazonEKSCSIDriverPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  role       = "${aws_iam_role.eks_node_role.name}"
+}
+
 resource "aws_iam_role_policy_attachment" "eks-node-AmazonEC2ContainerRegistryReadOnly" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = "${aws_iam_role.eks_node_role.name}"

--- a/tf_files/aws/modules/eks/cloud.tf
+++ b/tf_files/aws/modules/eks/cloud.tf
@@ -429,6 +429,11 @@ resource "aws_iam_role_policy_attachment" "eks-node-AmazonEKS_CNI_Policy" {
   role       = "${aws_iam_role.eks_node_role.name}"
 }
 
+resource "aws_iam_role_policy_attachment" "eks-node-AmazonEKSCSIDriverPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+  role       = "${aws_iam_role.eks_node_role.name}"
+}
+
 resource "aws_iam_role_policy_attachment" "eks-node-AmazonEC2ContainerRegistryReadOnly" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = "${aws_iam_role.eks_node_role.name}"


### PR DESCRIPTION
adding EBSCSI Driver policy to the EKS Workers policy as the CSI Driver is required for clusters above 1.23
