### PR TITLE
Add values from external git repository

### DIFF
--- a/kube/services/datadog/datadog-application.yaml
+++ b/kube/services/datadog/datadog-application.yaml
@@ -5,14 +5,17 @@ metadata:
   namespace: argocd
 spec:
   project: default
-  source:
-    chart: datadog
+  sources:
+  - chart: datadog
     repoURL: 'https://helm.datadoghq.com'
     targetRevision: 3.6.4
     helm:
-      valueFiles: 
-      - https://raw.githubusercontent.com/uc-cdis/cloud-automation/master/kube/services/datadog/values.yaml
+      valueFiles:
+      - $values/kube/services/datadog/values.yaml
       releaseName: datadog
+  - repoURL: 'https://github.com/uc-cdis/cloud-automation.git'
+    targetRevision: master
+    ref: values
   destination:
     server: 'https://kubernetes.default.svc'
     namespace: datadog


### PR DESCRIPTION
### New Features


### Breaking Changes
- Requires argocd 2.6.1+ so run `gen3 kube-setup-argocd` first, or manually upgrade argocd to newest verison. 

### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
