### PR TITLE
fix(pelican-log-ingestion): Remove pelican export log ingestion

### DIFF
--- a/kube/services/datadog/values.yaml
+++ b/kube/services/datadog/values.yaml
@@ -221,7 +221,7 @@ datadog:
       #   - send_distribution_buckets: true
       #     timeout: 5
 
-  containerExcludeLogs: "kube_namespace:logging kube_namespace:argo"
+  containerExcludeLogs: "kube_namespace:logging kube_namespace:argo name:pelican-export*"
 
 ## This is the Datadog Cluster Agent implementation that handles cluster-wide
 ## metrics more cleanly, separates concerns for better rbac, and implements


### PR DESCRIPTION
### New Features


### Breaking Changes


### Bug Fixes


### Improvements
Remove pelican export log ingestion due to too excess logging.

### Dependency updates


### Deployment changes
