### PR TITLE
modifying the kube-setup-aws-es-proxy scipt to look for a second clus…

### DIFF
--- a/gen3/bin/kube-setup-aws-es-proxy.sh
+++ b/gen3/bin/kube-setup-aws-es-proxy.sh
@@ -33,7 +33,7 @@ if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
       g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
     fi
   else
-    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names ${envname}-gen3-metadata-2 --query "DomainStatusList[*].Endpoints" --output text)" \
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names ${envname}-gen3-metadata --query "DomainStatusList[*].Endpoints" --output text)" \
         && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
       gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
       g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-service.yaml"

--- a/gen3/bin/kube-setup-aws-es-proxy.sh
+++ b/gen3/bin/kube-setup-aws-es-proxy.sh
@@ -8,23 +8,45 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/lib/kube-setup-init"
 
+# Deploy Datadog with argocd if flag is set in the manifest path
+manifestPath=$(g3k_manifest_path)
+es7="$(jq -r ".[\"global\"][\"es7\"]" < "$manifestPath" | tr '[:upper:]' '[:lower:]')"
+
 [[ -z "$GEN3_ROLL_ALL" ]] && gen3 kube-setup-secrets
 
 if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
   envname="$(gen3 api environment)"
-  if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names ${envname}-gen3-metadata --query "DomainStatusList[*].Endpoints" --output text)" \
-      && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
-    gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
-    g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-service.yaml"
-    gen3_log_info "kube-setup-aws-es-proxy" "The aws-es-proxy service has been deployed onto the k8s cluster."
+
+  if [ "$es7" = true ]; then
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names ${envname}-gen3-metadata-2 --query "DomainStatusList[*].Endpoints" --output text)" \
+        && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
+      gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
+      g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-service.yaml"
+      gen3_log_info "kube-setup-aws-es-proxy" "The aws-es-proxy service has been deployed onto the k8s cluster."
+    else
+      #
+      # probably running in jenkins or job environment
+      # try to make sure network policy labels are up to date
+      #
+      gen3_log_info "kube-setup-aws-es-proxy" "Not deploying aws-es-proxy, no endpoint to hook it up."
+      gen3 kube-setup-networkpolicy service aws-es-proxy
+      g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
+    fi
   else
-    #
-    # probably running in jenkins or job environment
-    # try to make sure network policy labels are up to date
-    #
-    gen3_log_info "kube-setup-aws-es-proxy" "Not deploying aws-es-proxy, no endpoint to hook it up."
-    gen3 kube-setup-networkpolicy service aws-es-proxy
-    g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names ${envname}-gen3-metadata-2 --query "DomainStatusList[*].Endpoints" --output text)" \
+        && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
+      gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
+      g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-service.yaml"
+      gen3_log_info "kube-setup-aws-es-proxy" "The aws-es-proxy service has been deployed onto the k8s cluster."
+    else
+      #
+      # probably running in jenkins or job environment
+      # try to make sure network policy labels are up to date
+      #
+      gen3_log_info "kube-setup-aws-es-proxy" "Not deploying aws-es-proxy, no endpoint to hook it up."
+      gen3 kube-setup-networkpolicy service aws-es-proxy
+      g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
+    fi
   fi
   gen3 job cron es-garbage '@daily'
 else


### PR DESCRIPTION
modifying the kube-setup-aws-es-proxy script to look for a second cluster for the es7 upgrade as we want to preserve the old cluster while pointing to the new one. This way we can maintain the old cluster and switch to the new cluster. This will prevent large downtimes for our commons in case we need to rollback.

Commons will be connected to a new es7 cluster if the es7 flag is set to "true" in the manifest.json