### PR TITLE
chore/read gen3 license from g3auto secret

### DIFF
--- a/kube/services/jobs/distribute-licenses-job.yaml
+++ b/kube/services/jobs/distribute-licenses-job.yaml
@@ -48,10 +48,11 @@ spec:
             configMapKeyRef:
               name: manifest-hatchery
               key: "user-namespace"
-        - name: GEN3_LICENSE_SECRET_NAME
-          value: stata-workspace-gen3-license
-        - name: GEN3_LICENSE_KEY
-          value: licenseSecrets
+        - name: GEN3_STATA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              name: stata-workspace-gen3-license-g3auto
+              key: "stata_license.txt"
         command: ["python"]
         args: 
           - "-c"
@@ -100,19 +101,10 @@ spec:
             used_licenses.sort()
             print(f"Licenses currently in use: {used_licenses}")
 
-            # The license keys should be stored in a kubernetes secret.
+            # The Gen3 Stata license strings should be stored in a kubernetes secret using g3auto.
             # The format of the secret is one license string per line.
             # The license strings are generated with 'stinit' using the information in a license PDF.
-            # The secret can be generated from a temporary file with a kubectl command, eg
-            # kubectl create secret generic GEN3_LICENSE_SECRET_NAME --from-file=GEN3_LICENSE_KEY=/path/to/file.lic
-
-            # Get license from kubernetes secret
-            print("Ready to read secret")
-            secret_name = os.environ['GEN3_LICENSE_SECRET_NAME']
-            secret_key = os.environ['GEN3_LICENSE_KEY']
-            license_secrets = os.popen(
-              f"kubectl get secret {secret_name} --template={{{{.data.{secret_key}}}}} | base64 -d"
-            ).read()
+            license_secrets = os.environ['GEN3_STATA_LICENSE']
             license_secrets = license_secrets.strip()
 
             licenses = license_secrets.split("\n")


### PR DESCRIPTION
Jira Ticket: [HP-1106](https://ctds-planx.atlassian.net/browse/HP-1106)

### New Features


### Breaking Changes


### Bug Fixes


### Improvements

* Read the Stata Gen3 licenses from a kubernetes secret managed by g3auto

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[HP-1106]: https://ctds-planx.atlassian.net/browse/HP-1106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ