### PR TITLE
pinning the pyyaml version due to bug.

### DIFF
--- a/Docker/awshelper/Dockerfile
+++ b/Docker/awshelper/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get upgrade -y \
       wget \
       gettext-base
 
-#can remove one https://github.com/yaml/pyyaml/issues/724 is solved
+#can remove once https://github.com/yaml/pyyaml/issues/724 is solved
 RUN pip install pyyaml==5.3.1
 
 RUN  python3 -m pip install --upgrade pip \

--- a/Docker/awshelper/Dockerfile
+++ b/Docker/awshelper/Dockerfile
@@ -38,6 +38,9 @@ RUN apt-get update && apt-get upgrade -y \
       wget \
       gettext-base
 
+#can remove one https://github.com/yaml/pyyaml/issues/724 is solved
+RUN pip install pyyaml==5.3.1
+
 RUN  python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade setuptools \
     && python3 -m pip install -U crcmod \


### PR DESCRIPTION
We were getting the following error due to an issue with pyyaml 5.4:
#12 22.63           raise AttributeError(attr)
#12 22.63       AttributeError: cython_sources
#12 22.63       [end of output]
please see: https://github.com/yaml/pyyaml/issues/724

pinning the pyyaml version until it is resolved. 