### PR TITLE
Removing Squid Cache

### DIFF
--- a/flavors/squid_auto/startup_configs/squid.conf
+++ b/flavors/squid_auto/startup_configs/squid.conf
@@ -56,7 +56,6 @@ http_access deny all
 
 persistent_request_timeout 5 seconds
 
-cache_dir ufs /var/cache/squid 100 16 256
 pid_filename /var/run/squid/squid.pid
 
 # vi:syntax=squid.conf


### PR DESCRIPTION
Removing squid cache to see if that resolves self-signed certificate errors we have been seeing with our Java applications. Tested this change in qaplanetv1, devplanetv2/qaplanetv1, and unfunded clusters. 