### PR TITLE
 update squid web whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -123,6 +123,7 @@ orcid.org
 pgp.mit.edu
 ppa.launchpad.net
 prometheus-community.github.io
+proxy.golang.org
 public.ecr.aws
 pubmirrors.dal.corespace.com
 reflector.westga.edu


### PR DESCRIPTION

### Improvements
add  proxy.golang.org to squid web whitelist
