### PR TITLE
Update web_whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -149,6 +149,7 @@ sa-update.space-pro.be
 security.debian.org
 services.mathworks.com
 streaming.stat.iastate.edu
+support.gen3.org
 us-east4-docker.pkg.dev
 us-central1-docker.pkg.dev
 www.google.com


### PR DESCRIPTION


### Improvements
- add `http://support.gen3.org` to squid whitelist

