### PR TITLE
adding a toleration to prometheus

### DIFF
--- a/kube/services/monitoring/values.yaml
+++ b/kube/services/monitoring/values.yaml
@@ -1540,11 +1540,20 @@ prometheus-node-exporter:
     - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
   service:
     portName: http-metrics
-  tolerations:
-    - key: eks.amazonaws.com/compute-type
-      operator: Equal
-      value: fargate
-      effect: NoSchedule
+  # tolerations:
+  #   - key: eks.amazonaws.com/compute-type
+  #     operator: Equal
+  #     value: fargate
+  #     effect: NoSchedule
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: "eks.amazonaws.com/compute-type"
+                operator: NotIn
+                values:
+                  - fargate
   prometheus:
     monitor:
       enabled: true

--- a/kube/services/monitoring/values.yaml
+++ b/kube/services/monitoring/values.yaml
@@ -1540,11 +1540,6 @@ prometheus-node-exporter:
     - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
   service:
     portName: http-metrics
-  # tolerations:
-  #   - key: eks.amazonaws.com/compute-type
-  #     operator: Equal
-  #     value: fargate
-  #     effect: NoSchedule
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/kube/services/monitoring/values.yaml
+++ b/kube/services/monitoring/values.yaml
@@ -1540,6 +1540,11 @@ prometheus-node-exporter:
     - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
   service:
     portName: http-metrics
+  tolerations:
+    - key: eks.amazonaws.com/compute-type
+      operator: Equal
+      value: fargate
+      effect: NoSchedule
   prometheus:
     monitor:
       enabled: true


### PR DESCRIPTION
adding node affinity, to prevent prometheus exporter pods from getting created for fargate nodes
 