### PR TITLE
Fix/restart argo events jobs

### DIFF
--- a/gen3/bin/kube-setup-karpenter.sh
+++ b/gen3/bin/kube-setup-karpenter.sh
@@ -140,7 +140,9 @@ gen3_deploy_karpenter() {
           --set serviceAccount.name=karpenter \
           --set serviceAccount.create=false \
           --set controller.env[0].name=AWS_REGION \
-          --set controller.env[0].value=us-east-1
+          --set controller.env[0].value=us-east-1 \
+          --set controller.resources.requests.memory="2Gi"
+          --set controller.resources.requests.cpu="2"
     fi
     gen3 awsrole sa-annotate karpenter "karpenter-controller-role-$vpc_name" karpenter
     gen3_log_info "Remove cluster-autoscaler"

--- a/gen3/bin/kube-setup-karpenter.sh
+++ b/gen3/bin/kube-setup-karpenter.sh
@@ -141,8 +141,10 @@ gen3_deploy_karpenter() {
           --set serviceAccount.create=false \
           --set controller.env[0].name=AWS_REGION \
           --set controller.env[0].value=us-east-1 \
-          --set controller.resources.requests.memory="2Gi"
-          --set controller.resources.requests.cpu="2"
+          --set controller.resources.requests.memory="2Gi" \
+          --set controller.resources.requests.cpu="2" \
+          --set controller.resources.limits.memory="2Gi" \
+          --set controller.resources.limits.cpu="2"
     fi
     gen3 awsrole sa-annotate karpenter "karpenter-controller-role-$vpc_name" karpenter
     gen3_log_info "Remove cluster-autoscaler"

--- a/kube/services/argo-events/workflows/sensor-completed.yaml
+++ b/kube/services/argo-events/workflows/sensor-completed.yaml
@@ -56,4 +56,4 @@ spec:
                         env:
                           - name: WORKFLOW_NAME
                             value: ""
-                backoffLimit: 0
+                backoffLimit: 20

--- a/kube/services/argo-events/workflows/sensor-completed.yaml
+++ b/kube/services/argo-events/workflows/sensor-completed.yaml
@@ -43,18 +43,17 @@ spec:
                 parallelism: 1
                 template:
                   spec:
-                    restartPolicy: Never
+                    restartPolicy: OnFailure
                     containers:
                       - name: karpenter-resource-creator
                         image: quay.io/cdis/awshelper
                         command: ["/bin/sh"]
-                        args: 
+                        args:
                           - "-c"
                           - |
                             kubectl delete awsnodetemplate workflow-$WORKFLOW_NAME
                             kubectl delete provisioners workflow-$WORKFLOW_NAME
                         env:
-                        - name: WORKFLOW_NAME
-                          value: ""
+                          - name: WORKFLOW_NAME
+                            value: ""
                 backoffLimit: 0
-

--- a/kube/services/argo-events/workflows/sensor-created.yaml
+++ b/kube/services/argo-events/workflows/sensor-created.yaml
@@ -51,7 +51,7 @@ spec:
                 parallelism: 1
                 template:
                   spec:
-                    restartPolicy: Never
+                    restartPolicy: OnFailure
                     containers:
                       - name: karpenter-resource-creator
                         image: quay.io/cdis/awshelper

--- a/kube/services/argo-events/workflows/sensor-created.yaml
+++ b/kube/services/argo-events/workflows/sensor-created.yaml
@@ -77,4 +77,4 @@ spec:
                       - name: karpenter-templates-volume
                         configMap:
                           name: karpenter-templates
-                backoffLimit: 0
+                backoffLimit: 20

--- a/kube/services/argo-events/workflows/sensor-deleted.yaml
+++ b/kube/services/argo-events/workflows/sensor-deleted.yaml
@@ -39,18 +39,17 @@ spec:
                 parallelism: 1
                 template:
                   spec:
-                    restartPolicy: Never
+                    restartPolicy: OnFailure
                     containers:
                       - name: karpenter-resource-creator
                         image: quay.io/cdis/awshelper
                         command: ["/bin/sh"]
-                        args: 
+                        args:
                           - "-c"
                           - |
                             kubectl delete awsnodetemplate workflow-$WORKFLOW_NAME
                             kubectl delete provisioners workflow-$WORKFLOW_NAME
                         env:
-                        - name: WORKFLOW_NAME
-                          value: ""
+                          - name: WORKFLOW_NAME
+                            value: ""
                 backoffLimit: 0
-

--- a/kube/services/argo-events/workflows/sensor-deleted.yaml
+++ b/kube/services/argo-events/workflows/sensor-deleted.yaml
@@ -52,4 +52,4 @@ spec:
                         env:
                           - name: WORKFLOW_NAME
                             value: ""
-                backoffLimit: 0
+                backoffLimit: 20


### PR DESCRIPTION

### New Features


### Breaking Changes


### Bug Fixes
- Adding changes related to preventing Argo workflows from getting stuck due to Karpenter not being available. 
- The fixes include:
  - raising the limits and the requests for karpenter pods to 2Gi, 2 cores
  - Adding a backOffLimit of 20 to the jobs created by Argo Events in response to a workflow being launched.
  - Adding a restartPolicy of OnFailure to the jobs 


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
