### PR TITLE
fix: skip study if it is neither registered nor unregistered

### DIFF
--- a/files/scripts/healdata/heal-cedar-data-ingest.py
+++ b/files/scripts/healdata/heal-cedar-data-ingest.py
@@ -169,6 +169,9 @@ while((limit + offset <= total)):
                     print("Metadata is already registered. Updating MDS record")
                 elif mds_res["_guid_type"] == "unregistered_discovery_metadata":
                     print("Metadata has not been registered. Registering it in MDS record")
+                else:
+                    print(f"This metadata data record has a special GUID type \"{mds_res['_guid_type']}\" and will be skipped")
+                    continue
 
                 if "clinicaltrials_gov" in cedar_record:
                     mds_clinical_trials = cedar_record["clinicaltrials_gov"]


### PR DESCRIPTION

### Bug Fixes
- HEAL CEDAR ingestion script: ignore study metadata record that is neither unregistered nor registered

