### PR TITLE
Feat: add new config for integrating teamproject and arborist check

### DIFF
--- a/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
@@ -56,7 +56,7 @@ stringData:
   security_oauth_callback_urlResolver: query
 
   security_ohdsi_custom_authorization_mode: teamproject
-  security_ohdsi_custom_authorization_url: http://arborist-service:80/auth/mapping
+  security_ohdsi_custom_authorization_url: $ARBORIST_URL/auth/mapping
 
   logging_level_root: info
   logging_level_org_ohdsi: info

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
@@ -55,6 +55,9 @@ stringData:
   security_oauth_callback_api: https://atlas.$hostname/WebAPI/user/oauth/callback
   security_oauth_callback_urlResolver: query
 
+  security_ohdsi_custom_authorization_mode: teamproject
+  security_ohdsi_custom_authorization_url: http://arborist-service:80/auth/mapping
+
   logging_level_root: info
   logging_level_org_ohdsi: info
   logging_level_org_apache_shiro: info

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
@@ -59,6 +59,13 @@ spec:
       containers:
         - name: ohdsi-webapi
           GEN3_OHDSI-WEBAPI_IMAGE|-image: quay.io/cdis/ohdsi-webapi:latest-|
+          env:
+            - name: ARBORIST_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: manifest-global
+                  key: arborist_url
+                  optional: true
           livenessProbe:
             httpGet:
               path: /WebAPI/info/

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
@@ -61,6 +61,7 @@ spec:
           GEN3_OHDSI-WEBAPI_IMAGE|-image: quay.io/cdis/ohdsi-webapi:latest-|
           env:
             - name: ARBORIST_URL
+              value: http://arborist-service
               valueFrom:
                 configMapKeyRef:
                   name: manifest-global

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
@@ -61,7 +61,6 @@ spec:
           GEN3_OHDSI-WEBAPI_IMAGE|-image: quay.io/cdis/ohdsi-webapi:latest-|
           env:
             - name: ARBORIST_URL
-              value: http://arborist-service
               valueFrom:
                 configMapKeyRef:
                   name: manifest-global


### PR DESCRIPTION
Jira Ticket: [VADC-775](https://ctds-planx.atlassian.net/browse/VADC-775)

### New Features
- Add new config for integrating teamproject and arborist check: these properties are needed for enabling "teamproject" authorization mode in WebAPI and telling WebAPI where the Arborist endpoint is living for actually getting authorization information.


### Dependency updates
- The WebAPI deployment now depends not only on Fence, but also needs a direct link to Arborist

### Deployment changes
- This assumes Arborist and WebAPI are on the same internal network

[VADC-775]: https://ctds-planx.atlassian.net/browse/VADC-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ