### PR TITLE
Jenkins dockerfiles improvements

### DIFF
--- a/.github/workflows/image_build_push.yaml
+++ b/.github/workflows/image_build_push.yaml
@@ -1,10 +1,10 @@
-name: Build Python Base Images and Push to Quay and ECR
+name: Build Python Base Images
 
 on: push
 
 jobs:
   python_3-9:
-    name: Python 3.9 Build and Push
+    name: Python 3.9
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/python-nginx/python3.9-buster/Dockerfile"
@@ -17,7 +17,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
   python_3-10:
-    name: Python 3.10 Build and Push
+    name: Python 3.10
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/python-nginx/python3.10-buster/Dockerfile"
@@ -30,7 +30,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
   awshelper:
-    name: AwsHelper Build and Push
+    name: AwsHelper
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/awshelper/Dockerfile"

--- a/.github/workflows/image_build_push_jenkins.yaml
+++ b/.github/workflows/image_build_push_jenkins.yaml
@@ -1,13 +1,14 @@
-name: Build Jenkins images and push to Quay
+name: Build Jenkins images
 
 on: 
   push:
     paths:
+      - .github/workflows/image_build_push_jenkins.yaml
       - Docker/jenkins/**
 
 jobs:
   jenkins:
-    name: Jenkins Build and Push
+    name: Jenkins
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/jenkins/Jenkins/Dockerfile"
@@ -21,7 +22,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}    
   jenkins2:
-    name: Jenkins2 Build and Push
+    name: Jenkins2
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/jenkins/Jenkins2/Dockerfile"
@@ -35,7 +36,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
   jenkins-ci-worker:
-    name: Jenkins-CI-Worker Build and Push
+    name: Jenkins-CI-Worker
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/jenkins/Jenkins-CI-Worker/Dockerfile"
@@ -49,7 +50,7 @@ jobs:
       QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
       QUAY_ROBOT_TOKEN: ${{ secrets.QUAY_ROBOT_TOKEN }}
   jenkins-qa-worker:
-    name: Jenkins-QA-Worker Build and Push
+    name: Jenkins-QA-Worker
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/jenkins/Jenkins-Worker/Dockerfile"

--- a/.github/workflows/image_build_push_squid.yaml
+++ b/.github/workflows/image_build_push_squid.yaml
@@ -1,13 +1,14 @@
-name: Build Squid images and push to Quay
+name: Build Squid images
 
 on: 
   push:
     paths:
+      - .github/workflows/image_build_push_squid.yaml
       - Docker/squid/**
 
 jobs:
   squid:
-    name: Squid Build and Push
+    name: Squid image
     uses: uc-cdis/.github/.github/workflows/image_build_push.yaml@master
     with:
       DOCKERFILE_LOCATION: "./Docker/squid/Dockerfile"

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-09-18T18:49:22Z",
+  "generated_at": "2023-10-26T21:32:44Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -79,7 +79,7 @@
         "hashed_secret": "10daf3a26c6a17242a5ab2438a12ebc8276c7603",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 122,
+        "line_number": 121,
         "type": "Secret Keyword"
       }
     ],

--- a/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
@@ -74,7 +74,7 @@ RUN sudo install -m 0755 -d /etc/apt/keyrings \
 
 # install nodejs
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get update && apt-get install -y nodejs
+RUN apt-get update && apt-get install -y nodejs npm
 
 # Install postgres 13 client
 RUN curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc| gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg && \

--- a/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
@@ -92,14 +92,12 @@ RUN chmod +x /root/tmp/install-python3.8.sh; sync && \
         unlink /usr/bin/python3 && \
         ln -s /usr/local/bin/python3.8 /usr/bin/python3
 
-RUN apt-get install -y python3-distutils
-
 # Fix shebang for lsb_release
 RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release && \
     sed -i 's/python3/python3.8/' /usr/bin/add-apt-repository
 
 # install aws cli, poetry, pytest, etc.
-RUN set -xe && python3.8 -m pip install --upgrade pip && python3.8 -m pip install awscli --upgrade && python3.8 -m pip install pytest --upgrade && python3.8 -m pip install poetry && python3.8 -m pip install PyYAML --upgrade && python3.8 -m pip install lxml --upgrade && python3.8 -m pip install yq --upgrade && python3.8 -m pip install datadog --upgrade
+RUN set -xe && python3.8 -m pip install --upgrade pip setuptools && python3.8 -m pip install awscli --upgrade && python3.8 -m pip install pytest --upgrade && python3.8 -m pip install poetry && python3.8 -m pip install PyYAML --upgrade && python3.8 -m pip install lxml --upgrade && python3.8 -m pip install yq --upgrade && python3.8 -m pip install datadog --upgrade
 
 # install terraform
 RUN curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_linux_amd64.zip \

--- a/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
@@ -93,6 +93,8 @@ RUN chmod +x /root/tmp/install-python3.8.sh; sync && \
         unlink /usr/bin/python3 && \
         ln -s /usr/local/bin/python3.8 /usr/bin/python3
 
+RUN apt-get install python3-distutils
+
 # Fix shebang for lsb_release
 RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release && \
     sed -i 's/python3/python3.8/' /usr/bin/add-apt-repository

--- a/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
@@ -34,11 +34,10 @@ RUN set -xe && apt-get update \
      zlib1g-dev \
      zsh \
      ca-certificates-java \
-     openjdk-11-jre-headless \
   && ln -s /usr/bin/lua5.3 /usr/local/bin/lua
 
 # Use jdk11
-ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+ENV JAVA_HOME="/opt/java/openjdk"
 ENV PATH="$JAVA_HOME/bin:$PATH"
 
 COPY ./certfix.sh /certfix.sh
@@ -93,7 +92,7 @@ RUN chmod +x /root/tmp/install-python3.8.sh; sync && \
         unlink /usr/bin/python3 && \
         ln -s /usr/local/bin/python3.8 /usr/bin/python3
 
-RUN apt-get install python3-distutils
+RUN apt-get install -y python3-distutils
 
 # Fix shebang for lsb_release
 RUN sed -i 's/python3/python3.8/' /usr/bin/lsb_release && \

--- a/Docker/jenkins/Jenkins-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-Worker/Dockerfile
@@ -8,6 +8,7 @@ RUN set -xe && apt-get update && apt-get install -y apt-utils dnsutils build-ess
 
 RUN apt-get update \
   && apt-get install -y lsb-release \
+      git \
      apt-transport-https \
      r-base \
      libffi-dev \
@@ -35,11 +36,6 @@ RUN apt-get update \
 
 # install Ruby.
 RUN apt-get install -y ruby-full
-
-# install GIT from buster-backports
-RUN echo "deb http://deb.debian.org/debian buster-backports main" > /etc/apt/sources.list.d/buster-backports.list \
-  && apt-get update \
-  && apt-get -t=buster-backports -y install git=1:2.30.*
 
 #
 # install docker tools:

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -260,7 +260,7 @@ spec:
               exit 1
             fi
             #-----------------
-            echo "awshelper downloading ${userYamlS3Path} to /mnt/shared/useryaml";
+            echo "awshelper downloading ${userYamlS3Path} to /mnt/shared/user.yaml";
             n=0
             until [ $n -ge 5 ]; do
               echo "Download attempt $n"


### PR DESCRIPTION
Data simulator now uses python 3.9, see https://github.com/uc-cdis/data-simulator/pull/99
Add setuptools to the Jenkins-CI-Worker image to fix `No module named 'distutils.cmd'` error ([ref](https://github.com/pypa/get-pip/issues/124))
Upgrade `git` version
And fix java install