### PR TITLE
Fix: set ARBORIST_URL using the kube-setup-ohdsi.sh

### DIFF
--- a/gen3/bin/kube-setup-ohdsi.sh
+++ b/gen3/bin/kube-setup-ohdsi.sh
@@ -87,7 +87,8 @@ setup_secrets() {
     export DB_HOST=$(jq -r ".db_host" <<< "$dbcreds")
 
     export FENCE_URL="https://${hostname}/user/user"
-    export ARBORIST_URL="http://arborist-service/auth/mapping"
+    # get arborist_url from manifest.json:
+    export ARBORIST_URL=$(g3k_manifest_lookup .global.arborist_url)
     export FENCE_METADATA_URL="https://${hostname}/.well-known/openid-configuration"
     export FENCE_CLIENT_ID=$(jq -r ".FENCE_CLIENT_ID" <<< "$appcreds")
     export FENCE_CLIENT_SECRET=$(jq -r ".FENCE_CLIENT_SECRET" <<< "$appcreds")

--- a/gen3/bin/kube-setup-ohdsi.sh
+++ b/gen3/bin/kube-setup-ohdsi.sh
@@ -87,6 +87,7 @@ setup_secrets() {
     export DB_HOST=$(jq -r ".db_host" <<< "$dbcreds")
 
     export FENCE_URL="https://${hostname}/user/user"
+    export ARBORIST_URL="https://${hostname}/auth/mapping"
     export FENCE_METADATA_URL="https://${hostname}/.well-known/openid-configuration"
     export FENCE_CLIENT_ID=$(jq -r ".FENCE_CLIENT_ID" <<< "$appcreds")
     export FENCE_CLIENT_SECRET=$(jq -r ".FENCE_CLIENT_SECRET" <<< "$appcreds")

--- a/gen3/bin/kube-setup-ohdsi.sh
+++ b/gen3/bin/kube-setup-ohdsi.sh
@@ -87,7 +87,7 @@ setup_secrets() {
     export DB_HOST=$(jq -r ".db_host" <<< "$dbcreds")
 
     export FENCE_URL="https://${hostname}/user/user"
-    export ARBORIST_URL="https://${hostname}/auth/mapping"
+    export ARBORIST_URL="http://arborist-service/auth/mapping"
     export FENCE_METADATA_URL="https://${hostname}/.well-known/openid-configuration"
     export FENCE_CLIENT_ID=$(jq -r ".FENCE_CLIENT_ID" <<< "$appcreds")
     export FENCE_CLIENT_SECRET=$(jq -r ".FENCE_CLIENT_SECRET" <<< "$appcreds")

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
@@ -56,7 +56,7 @@ stringData:
   security_oauth_callback_urlResolver: query
 
   security_ohdsi_custom_authorization_mode: teamproject
-  security_ohdsi_custom_authorization_url: $ARBORIST_URL
+  security_ohdsi_custom_authorization_url: $ARBORIST_URL/auth/mapping
 
   logging_level_root: info
   logging_level_org_ohdsi: info

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
@@ -56,7 +56,7 @@ stringData:
   security_oauth_callback_urlResolver: query
 
   security_ohdsi_custom_authorization_mode: teamproject
-  security_ohdsi_custom_authorization_url: $ARBORIST_URL/auth/mapping
+  security_ohdsi_custom_authorization_url: $ARBORIST_URL
 
   logging_level_root: info
   logging_level_org_ohdsi: info

--- a/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-deploy.yaml
@@ -59,13 +59,6 @@ spec:
       containers:
         - name: ohdsi-webapi
           GEN3_OHDSI-WEBAPI_IMAGE|-image: quay.io/cdis/ohdsi-webapi:latest-|
-          env:
-            - name: ARBORIST_URL
-              valueFrom:
-                configMapKeyRef:
-                  name: manifest-global
-                  key: arborist_url
-                  optional: true
           livenessProbe:
             httpGet:
               path: /WebAPI/info/


### PR DESCRIPTION
Jira Ticket: [VADC-775](https://ctds-planx.atlassian.net/browse/VADC-775)


### Bug Fixes
- reverts https://github.com/uc-cdis/cloud-automation/pull/2397 , to set ARBORIST_URL using the `gen3/bin/kube-setup-ohdsi.sh` script


### Deployment changes
- compared to previous PR, this one assumes the arborist service is located on the same host as OHDSI - WebAPI

[VADC-775]: https://ctds-planx.atlassian.net/browse/VADC-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ