### PR TITLE
Add rmq.n3c.ncats.io to Squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -145,6 +145,7 @@ repos.sensuapp.org
 repo.vmware.com
 repository.cloudera.com
 resource.metadatacenter.org
+rmq.n3c.ncats.io
 rules.emergingthreats.net
 rweb.quant.ku.edu
 sa-update.dnswl.org


### PR DESCRIPTION
Needed to connect to Regenstrief's Rabbitmq server from a MIDRC VM (`regenstrief-uchicago-rabbitmq`)