### PR TITLE
PPS-588 add guppy csrf

### DIFF
--- a/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
@@ -1,4 +1,8 @@
           location /guppy/ {
+              if ($csrf_check !~ ^ok-\S.+$) {
+                return 403 "failed csrf check";
+              }
+              
               proxy_connect_timeout 600s;
               proxy_send_timeout 600s;
               proxy_read_timeout 600s;

--- a/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
+++ b/kube/services/revproxy/gen3.nginx.conf/guppy-service.conf
@@ -1,6 +1,6 @@
           location /guppy/ {
               if ($csrf_check !~ ^ok-\S.+$) {
-                return 403 "failed csrf check";
+                return 403 "failed csrf check, make sure data-portal version >= 2023.12 or >= 5.19.0";
               }
               
               proxy_connect_timeout 600s;


### PR DESCRIPTION
Jira Ticket: [PPS-588](https://ctds-planx.atlassian.net/browse/PPS-588)


### Improvements
- Add CSRF protection for Guppy paths

### Deployment changes
- After merging this, envs must use a data-portal version that contains https://github.com/uc-cdis/data-portal/pull/1464. Otherwise the communication between portal and guppy will be interrupted

[PPS-588]: https://ctds-planx.atlassian.net/browse/PPS-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ