### PR TITLE
Upgrade jenkins

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-10-26T21:32:44Z",
+  "generated_at": "2023-12-24T11:04:20Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -79,7 +79,7 @@
         "hashed_secret": "10daf3a26c6a17242a5ab2438a12ebc8276c7603",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 121,
+        "line_number": 124,
         "type": "Secret Keyword"
       }
     ],
@@ -88,7 +88,7 @@
         "hashed_secret": "10daf3a26c6a17242a5ab2438a12ebc8276c7603",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 143,
+        "line_number": 139,
         "type": "Secret Keyword"
       }
     ],

--- a/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-CI-Worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:jdk21
+FROM jenkins/inbound-agent:jdk11
 
 USER root
 

--- a/Docker/jenkins/Jenkins-Worker/Dockerfile
+++ b/Docker/jenkins/Jenkins-Worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/inbound-agent:jdk21
+FROM jenkins/inbound-agent:jdk11
 
 USER root
 

--- a/Docker/jenkins/Jenkins/Dockerfile
+++ b/Docker/jenkins/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.433-jdk21
+FROM jenkins/jenkins:2.426-jdk21
 
 USER root
 

--- a/Docker/jenkins/Jenkins/Dockerfile
+++ b/Docker/jenkins/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.415-jdk11
+FROM jenkins/jenkins:2.426.2-jdk11
 
 USER root
 

--- a/Docker/jenkins/Jenkins/Dockerfile
+++ b/Docker/jenkins/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.437-jdk21
+FROM jenkins/jenkins:2.433-jdk21
 
 USER root
 

--- a/Docker/jenkins/Jenkins/Dockerfile
+++ b/Docker/jenkins/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.426-jdk21
+FROM jenkins/jenkins:2.426.1-jdk21
 
 USER root
 

--- a/Docker/jenkins/Jenkins/Dockerfile
+++ b/Docker/jenkins/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.426.1-jdk21
+FROM jenkins/jenkins:2.437-jdk11
 
 USER root
 

--- a/Docker/jenkins/Jenkins/Dockerfile
+++ b/Docker/jenkins/Jenkins/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.437-jdk11
+FROM jenkins/jenkins:2.415-jdk11
 
 USER root
 

--- a/Docker/jenkins/Jenkins2/Dockerfile
+++ b/Docker/jenkins/Jenkins2/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.415-jdk11
+FROM jenkins/jenkins:2.437-jdk11
 
 USER root
 

--- a/Docker/jenkins/Jenkins2/Dockerfile
+++ b/Docker/jenkins/Jenkins2/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.437-jdk11
+FROM jenkins/jenkins:2.415-jdk11
 
 USER root
 


### PR DESCRIPTION
Logs are overly masked in 2.434. We are seeing the same behavior logged in https://issues.jenkins.io/browse/JENKINS-72412 even though we don't have one character secrets

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
