### PR TITLE
VPC CNI Migration From Calico

### DIFF
--- a/gen3/bin/kube-setup-system-services.sh
+++ b/gen3/bin/kube-setup-system-services.sh
@@ -19,7 +19,7 @@ gen3_load "gen3/gen3setup"
 kubeproxy=${kubeproxy:-1.24.7}
 coredns=${coredns:-1.8.7}
 kubednsautoscaler=${kubednsautoscaler:-1.8.6}
-cni=${cni:-1.12.2}
+cni=${cni:-1.14.1}
 calico=${calico:-1.7.8}
 
 

--- a/kube/services/karpenter/nodeTemplateDefault.yaml
+++ b/kube/services/karpenter/nodeTemplateDefault.yaml
@@ -37,6 +37,7 @@ spec:
     sudo  dracut -f
     # configure grub
     sudo /sbin/grubby --update-kernel=ALL --args="fips=1"
+    sudo mount -t bpf bpffs /sys/fs/bpf
 
     --BOUNDARY
     Content-Type: text/cloud-config; charset="us-ascii"

--- a/kube/services/karpenter/nodeTemplateGPU.yaml
+++ b/kube/services/karpenter/nodeTemplateGPU.yaml
@@ -37,6 +37,7 @@ spec:
     sudo  dracut -f
     # configure grub
     sudo /sbin/grubby --update-kernel=ALL --args="fips=1"
+    sudo mount -t bpf bpffs /sys/fs/bpf
 
     --BOUNDARY
     Content-Type: text/cloud-config; charset="us-ascii"

--- a/kube/services/karpenter/nodeTemplateJupyter.yaml
+++ b/kube/services/karpenter/nodeTemplateJupyter.yaml
@@ -37,6 +37,7 @@ spec:
     sudo  dracut -f
     # configure grub
     sudo /sbin/grubby --update-kernel=ALL --args="fips=1"
+    sudo mount -t bpf bpffs /sys/fs/bpf
 
     --BOUNDARY
     Content-Type: text/cloud-config; charset="us-ascii"

--- a/kube/services/karpenter/nodeTemplateWorkflow.yaml
+++ b/kube/services/karpenter/nodeTemplateWorkflow.yaml
@@ -37,6 +37,7 @@ spec:
     sudo  dracut -f
     # configure grub
     sudo /sbin/grubby --update-kernel=ALL --args="fips=1"
+    sudo mount -t bpf bpffs /sys/fs/bpf
 
     --BOUNDARY
     Content-Type: text/cloud-config; charset="us-ascii"

--- a/kube/services/revproxy/revproxy-deploy.yaml
+++ b/kube/services/revproxy/revproxy-deploy.yaml
@@ -21,6 +21,7 @@ spec:
         app: revproxy
         # allow access from workspaces
         userhelper: "yes"
+        internet: "yes"
         GEN3_DATE_LABEL
     spec:
       affinity:


### PR DESCRIPTION
### Improvements
- Adding "internet: yes" label
We are switching off of Calico to AWS VPC CNI to manage our network policies. We believe AWS VPC CNI to have more restrictive defaults than our previous version of Calico, so revproxy needs to have an explicit allow for all egress traffic. 
- Updating AWS VPC CNI version
We are moving off of Calico and to AWS VPC CNI to manage our networkpolicies. The VPC CNI plugin is able to manage network policies in version 1.14.1
- Mounting the BPF File System
Mounting this file system in the "user data" section of all our Karpenter node templates as this is required for the VPC CNI plugin to manage network policies