### PR TITLE
Add azure blob storage to web_wildcard_whitelist

### DIFF
--- a/packer/configs/web_wildcard_whitelist
+++ b/packer/configs/web_wildcard_whitelist
@@ -44,4 +44,5 @@
 .yahooapis.com
 .cloudfront.net
 .docker.io
+.blob.core.windows.net
 .googleapis.com


### PR DESCRIPTION


### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
- Add azure blob storage to web_wildcard_whitelist