### PR TITLE
gen3 logs snapshot: also get initContainers logs

### DIFF
--- a/gen3/lib/logs/snapshot.sh
+++ b/gen3/lib/logs/snapshot.sh
@@ -36,10 +36,11 @@ gen3_logs_snapshot_container() {
 # Snapshot all the pods
 #
 gen3_logs_snapshot_all() {
+  # For each pod for which we can list the containers, get the pod name and get its list of containers
+  # (container names + initContainers names). Diplay them as lines of "<pod name>  <container name>".
   g3kubectl get pods -o json | \
-    jq -r '.items | map(select(.status.phase != "Pending" and .status.phase != "Unknown")) | map( {pod: .metadata.name, containers: .spec.containers | map(.name) } ) | map( .pod as $pod | .containers | map( { pod: $pod, cont: .})[]) | map(select(.cont != "pause" and .cont != "jupyterhub"))[] | .pod + "  " + .cont' | \
+    jq -r '.items | map(select(.status.phase != "Pending" and .status.phase != "Unknown")) | map( {pod: .metadata.name, containers: [(.spec.containers | select(.!=null) | map(.name)), (.spec.initContainers | select(.!=null) | map(.name)) | add ] } ) | map( .pod as $pod | .containers | map( { pod: $pod, cont: .})[]) | map(select(.cont != "pause" and .cont != "jupyterhub"))[] | .pod + "  " + .cont' | \
     while read -r line; do
       gen3_logs_snapshot_container $line
     done
 }
-


### PR DESCRIPTION

### New Features
- `gen3 logs snapshot`: in addition to `containers` logs, also get `initContainers` logs

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
