### PR TITLE
Roll arborist before indexd

### DIFF
--- a/gen3/bin/kube-roll-all.sh
+++ b/gen3/bin/kube-roll-all.sh
@@ -51,18 +51,18 @@ fi
 
 gen3 kube-setup-networkpolicy disable
 #
-# Hopefull core secrets/config in place - start bringing up services
+# Hopefully core secrets/config in place - start bringing up services
 #
-if g3k_manifest_lookup .versions.indexd 2> /dev/null; then
-  gen3 kube-setup-indexd &
-else
-  gen3_log_info "no manifest entry for indexd"
-fi
-
 if g3k_manifest_lookup .versions.arborist 2> /dev/null; then
   gen3 kube-setup-arborist || gen3_log_err "arborist setup failed?"
 else
   gen3_log_info "no manifest entry for arborist"
+fi
+
+if g3k_manifest_lookup .versions.indexd 2> /dev/null; then
+  gen3 kube-setup-indexd &
+else
+  gen3_log_info "no manifest entry for indexd"
 fi
 
 if g3k_manifest_lookup '.versions["audit-service"]' 2> /dev/null; then


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

When indexd starts before arborist comes up, errors like this are observed:
```
[fence.blueprints.data.indexd][  ERROR] could not create new record in indexd; got response: {'error': 'Arborist is not configured; cannot perform authorization check'}
```

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
