### PR TITLE
correcting networkpolicy format for ssjdispatcher and sower

### DIFF
--- a/kube/services/netpolicy/gen3/services/sower_netpolicy.yaml
+++ b/kube/services/netpolicy/gen3/services/sower_netpolicy.yaml
@@ -3,7 +3,6 @@ kind: NetworkPolicy
 metadata:
   name: netpolicy-sowerjob
 spec:
-  spec:
   podSelector:
     matchLabels:
       app: sowerjob

--- a/kube/services/netpolicy/gen3/services/ssjdispatcherjob_netpolicy.yaml
+++ b/kube/services/netpolicy/gen3/services/ssjdispatcherjob_netpolicy.yaml
@@ -3,7 +3,6 @@ kind: NetworkPolicy
 metadata:
   name: netpolicy-ssjdispatcherjob
 spec:
-  spec:
   podSelector:
     matchLabels:
       app: ssjdispatcherjob


### PR DESCRIPTION
PFB exports are not working when networkpolicies are deployed. It appears that this was due to an error with the networkpolicy for sowerjobs, so I am correcting that here. 
