### PR TITLE
Removing duplicate value

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -31,7 +31,6 @@ centos.mirrors.hoobly.com
 centos.mirrors.tds.net
 centos.mirrors.wvstateu.edu
 cernvm.cern.ch
-charts.bitnami.com
 charts.helm.sh
 cloud.r-project.org
 coredns.github.io


### PR DESCRIPTION
charts.bitnami.com is in the squid_whitelist twice