### PR TITLE
adding qdr production to squid whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -169,3 +169,4 @@ vpodc.org
 yahoo.com
 idp.stage.qdr.org
 stage.qdr.org
+data.qdr.syr.edu


### PR DESCRIPTION
### New Features
Simply adding https://data.qdr.syr.edu/ to the whitelist to allow for HEAL functionality

