### PR TITLE
adding changes to give argo UI access to buckets so artifacts can be viewed in the UI

### DIFF
--- a/gen3/bin/awsrole.sh
+++ b/gen3/bin/awsrole.sh
@@ -14,7 +14,6 @@ gen3_load "gen3/gen3setup"
 gen3_awsrole_help() {
   gen3 help awsrole
 }
-
 #
 # Assume-role policy - allows SA's to assume role.
 # NOTE: service-account to role is 1 to 1
@@ -71,7 +70,8 @@ function gen3_awsrole_ar_policy() {
           "${issuer_url}:aud": "sts.amazonaws.com",
           "${issuer_url}:sub": [
             "system:serviceaccount:*:${serviceAccount}",
-            "system:serviceaccount:argo:default"
+            "system:serviceaccount:argo:default",
+            "system:serviceaccount:argo:argo-argo-workflows-server"
           ]
         }
       }

--- a/gen3/bin/kube-setup-argo.sh
+++ b/gen3/bin/kube-setup-argo.sh
@@ -188,11 +188,13 @@ EOF
       roleArn=$(aws iam get-role --role-name "${roleName}" --query 'Role.Arn' --output text)
       gen3_log_info "Role annotate"
       g3kubectl annotate serviceaccount default eks.amazonaws.com/role-arn=${roleArn} --overwrite -n $argo_namespace
+      g3kubectl annotate serviceaccount argo-argo-workflows-server eks.amazonaws.com/role-arn=${roleArn} --overwrite -n $argo_namespace
       g3kubectl annotate serviceaccount argo eks.amazonaws.com/role-arn=${roleArn} --overwrite -n $nameSpace
   else
         gen3 awsrole create $roleName argo $nameSpace -all_namespaces
         roleArn=$(aws iam get-role --role-name "${roleName}" --query 'Role.Arn' --output text)
         g3kubectl annotate serviceaccount default eks.amazonaws.com/role-arn=${roleArn} -n $argo_namespace
+        g3kubectl annotate serviceaccount argo-argo-workflows-server eks.amazonaws.com/role-arn=${roleArn} -n $argo_namespace
   fi
 
   # Grant access within the current namespace to the argo SA in the current namespace


### PR DESCRIPTION
The argo UI uses a separate service account, so that service account needs to be annotated with the aws Role so artifacts can be viewed in the UI