### PR TITLE
fix: bash comparison for true values in argo slack webhook notify

### DIFF
--- a/kube/services/argo/values.yaml
+++ b/kube/services/argo/values.yaml
@@ -72,7 +72,7 @@ controller:
                   name: slack-webhook-secret
             source: |
               failure_reason=$(echo {{workflow.failures}} | jq 'any(.[]; .message == "Step exceeded its deadline")' )
-              if [ "$failure_reason" ]; then
+              if [ "$failure_reason" = "true" ]; then
                 curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"ALERT: Workflow {{workflow.name}} has been killed due to timeout\"}" "$SLACK_WEBHOOK_URL"
               fi
 


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: N/A

### New Features

### Breaking Changes

### Bug Fixes
* [`any`](https://jqlang.github.io/jq/manual/#any) in jq will return string for either true or false, so bash needs to have string comparison

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
