### PR TITLE
Using Mimir for Hatchery Reaper Job

### DIFF
--- a/gen3/bin/jupyter.sh
+++ b/gen3/bin/jupyter.sh
@@ -245,8 +245,8 @@ gen3_jupyter_idle_pods() {
         current_time=$(date +%s)
         age=$((current_time - pod_creation))
 
-        # potential workspaces to be reaped for inactivity must be at least 60 minutes old
-        if ((age >= 3600)); then
+        # potential workspaces to be reaped for inactivity must be at least 1 minute old- REVERT THIS CHANGE (ONLY FOR TESTING)
+        if ((age >= 60)); then
           gen3_log_info "try to kill pod $name in $jnamespace"
           g3kubectl delete pod --namespace "$jnamespace" "$name" 1>&2
         fi

--- a/gen3/bin/jupyter.sh
+++ b/gen3/bin/jupyter.sh
@@ -191,7 +191,7 @@ gen3_jupyter_metrics() {
 # @see https://prometheus.io/docs/prometheus/latest/querying/examples/
 #
 gen3_jupyter_idle_pods() {
-  local ttl=12h
+  local ttl=5m
   local namespace="$(gen3 db namespace)"
   local tokenKey="none"
   local command="list"

--- a/gen3/bin/jupyter.sh
+++ b/gen3/bin/jupyter.sh
@@ -210,7 +210,7 @@ gen3_jupyter_idle_pods() {
   fi
 
   # Get the list of idle ambassador clusters from prometheus
-  local promQuery="sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{kubernetes_namespace=\"${namespace}\"}[${ttl}]))"
+  local promQuery="sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{namespace=\"${namespace}\"}[${ttl}]))"
   local tempClusterFile="$(mktemp "$XDG_RUNTIME_DIR/idle_apps.json_XXXXXX")"
   gen3 prometheus query "$promQuery" "${tokenKey#none}" | jq -e -r '.data.result[] | { "cluster": .metric.envoy_cluster_name, "rate": .value[1] } | select(.rate == "0")' | tee "$tempClusterFile" 1>&2
   if [[ $? != 0 ]]; then

--- a/gen3/bin/jupyter.sh
+++ b/gen3/bin/jupyter.sh
@@ -212,7 +212,7 @@ gen3_jupyter_idle_pods() {
   # Get the list of idle ambassador clusters from prometheus
   local promQuery="sum by (envoy_cluster_name) (rate(envoy_cluster_upstream_rq_total{namespace=\"${namespace}\"}[${ttl}]))"
   local tempClusterFile="$(mktemp "$XDG_RUNTIME_DIR/idle_apps.json_XXXXXX")"
-  gen3 prometheus query "$promQuery" "${tokenKey#none}" | jq -e -r '.data.result[] | { "cluster": .metric.envoy_cluster_name, "rate": .value[1] } | select(.rate == "0")' | tee "$tempClusterFile" 1>&2
+  gen3 prometheus query "$promQuery" "${tokenKey#none}" | jq -e -r '.data.result[] | { "cluster": .metric.envoy_cluster_name, "rate": .value[1] }' | tee "$tempClusterFile" 1>&2
   if [[ $? != 0 ]]; then
     gen3_log_info "no idle ambassadore clusters found"
     rm "$tempClusterFile"

--- a/gen3/bin/kube-setup-ambassador.sh
+++ b/gen3/bin/kube-setup-ambassador.sh
@@ -68,11 +68,9 @@ case "$command" in
     ;;
   "hatchery")
     deploy_hatchery_proxy "$@"
-    gen3 kube-setup-prometheus prometheus
     ;;
   *)
     deploy_hatchery_proxy "$@"
     deploy_api_gateway "$@"
-    gen3 kube-setup-prometheus prometheus
     ;;
 esac

--- a/gen3/bin/prometheus.sh
+++ b/gen3/bin/prometheus.sh
@@ -4,9 +4,7 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/gen3setup"
 
-
-#export GEN3_PROMHOST="${GEN3_PROMHOST:-"http://prometheus-server.prometheus.svc.cluster.local"}"
-export GEN3_PROMHOST="${GEN3_PROMHOST:-"http://prometheus-operated.monitoring.svc.cluster.local:9090"}"
+export GEN3_PROMHOST="${GEN3_PROMHOST:-"https://mimir.planx-pla.net"}"
 
 gen3_prom_help() {
   gen3 help prometheus
@@ -16,11 +14,11 @@ function gen3_prom_curl() {
   local urlBase="$1"
   shift || return 1
   local hostOrKey="${1:-${GEN3_PROMHOST}}"
-  local urlPath="api/v1/$urlBase"
+  local urlPath="/prometheus/api/v1/$urlBase"
     
   if [[ "$hostOrKey" =~ ^http ]]; then
     gen3_log_info "fetching $hostOrKey/$urlPath"
-    curl -s -H 'Accept: application/json' "$hostOrKey/$urlPath"
+    curl -s -H 'Accept: application/json' -H "X-Scope-OrgID: anonymous" "$hostOrKey/$urlPath"
   else
     gen3 api curl "$urlPath" "$hostOrKey"
   fi

--- a/gen3/bin/prometheus.sh
+++ b/gen3/bin/prometheus.sh
@@ -14,7 +14,7 @@ function gen3_prom_curl() {
   local urlBase="$1"
   shift || return 1
   local hostOrKey="${1:-${GEN3_PROMHOST}}"
-  local urlPath="/prometheus/api/v1/$urlBase"
+  local urlPath="prometheus/api/v1/$urlBase"
     
   if [[ "$hostOrKey" =~ ^http ]]; then
     gen3_log_info "fetching $hostOrKey/$urlPath"

--- a/kube/services/jobs/hatchery-reaper-job.yaml
+++ b/kube/services/jobs/hatchery-reaper-job.yaml
@@ -110,7 +110,7 @@ spec:
               done
 
               # legacy reaper code
-              gen3_log_info "Running legacy reaper job (based on local cluster/ prometheus)"
+              gen3_log_info "Running legacy reaper job (based on Mimir)"
               if appList="$(gen3 jupyter idle none "$(gen3 db namespace)" kill)" && [[ -n "$appList" && -n "$slackWebHook" && "$slackWebHook" != "None" ]]; then
                 curl -X POST --data-urlencode "payload={\"text\": \"hatchery-reaper in $gen3Hostname: \n\`\`\`\n${appList}\n\`\`\`\"}" "${slackWebHook}"
               fi


### PR DESCRIPTION
making changes so hatchery reaper job relies on mimir instead of Prometheus. Also, removing Prometheus from "kube-setup-ambassador"
