### PR TITLE
Update usersync-job.yaml

### DIFF
--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -93,7 +93,7 @@ spec:
             name: "projects"
       containers:
       - name: usersync
-        GEN3_FENCE_IMAGE
+        image: "quay.io/cdis/fence:10.4.0"
         imagePullPolicy: Always
         env:
           - name: prometheus_multiproc_dir


### PR DESCRIPTION
### Deployment changes
The new Al2 based Fence image does not have the mcrypt binary installed. Because of this, we need to pin the version of Fence that is used for Usersync job until we are able to create a sidecar image that will do this for us. 
