### PR TITLE
Making ES7 domain default

### DIFF
--- a/gen3/bin/kube-setup-aws-es-proxy.sh
+++ b/gen3/bin/kube-setup-aws-es-proxy.sh
@@ -18,7 +18,7 @@ envname="$(gen3 api environment)"
 
 if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
   if [ "$esDomain" != "null" ]; then
-    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${esDomain}"  --query "DomainStatusList[*].Endpoints" --output text)" \
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${envname}"-gen3-metadata-2  --query "DomainStatusList[*].Endpoints" --output text)" \
         && [[ -n "${ES_ENDPOINT}" && -n "${esDomain}" ]]; then
       gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
            g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-priority-class.yaml"
@@ -33,8 +33,8 @@ if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
       gen3 kube-setup-networkpolicy service aws-es-proxy
       g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
     fi
-  elif [ "$es7" = true ]; then
-    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${envname}"-gen3-metadata-2 --query "DomainStatusList[*].Endpoints" --output text)" \
+  elif [ "$es7" = false ]; then
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${esDomain}" --query "DomainStatusList[*].Endpoints" --output text)" \
         && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
       gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
       g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-priority-class.yaml"

--- a/gen3/bin/kube-setup-aws-es-proxy.sh
+++ b/gen3/bin/kube-setup-aws-es-proxy.sh
@@ -18,10 +18,10 @@ envname="$(gen3 api environment)"
 
 if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
   if [ "$esDomain" != "null" ]; then
-    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${envname}"-gen3-metadata-2  --query "DomainStatusList[*].Endpoints" --output text)" \
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${esDomain}"  --query "DomainStatusList[*].Endpoints" --output text)" \
         && [[ -n "${ES_ENDPOINT}" && -n "${esDomain}" ]]; then
       gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
-           g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-priority-class.yaml"
+      g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-priority-class.yaml"
       g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-service.yaml"
       gen3_log_info "kube-setup-aws-es-proxy" "The aws-es-proxy service has been deployed onto the k8s cluster."
     else
@@ -34,7 +34,7 @@ if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
       g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
     fi
   elif [ "$es7" = false ]; then
-    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${esDomain}" --query "DomainStatusList[*].Endpoints" --output text)" \
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${envname}"-gen3-metadata --query "DomainStatusList[*].Endpoints" --output text)" \
         && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
       gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
       g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-priority-class.yaml"
@@ -50,9 +50,10 @@ if g3kubectl get secrets/aws-es-proxy > /dev/null 2>&1; then
       g3kubectl patch deployment "aws-es-proxy-deployment" -p  '{"spec":{"template":{"metadata":{"labels":{"netvpc":"yes"}}}}}' || true
     fi
   else
-    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${envname}"-gen3-metadata --query "DomainStatusList[*].Endpoints" --output text)" \
+    if ES_ENDPOINT="$(aws es describe-elasticsearch-domains --domain-names "${envname}"-gen3-metadata-2 --query "DomainStatusList[*].Endpoints" --output text)" \
         && [[ -n "${ES_ENDPOINT}" && -n "${envname}" ]]; then
       gen3 roll aws-es-proxy GEN3_ES_ENDPOINT "${ES_ENDPOINT}"
+      g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-priority-class.yaml"
       g3kubectl apply -f "${GEN3_HOME}/kube/services/aws-es-proxy/aws-es-proxy-service.yaml"
       gen3_log_info "kube-setup-aws-es-proxy" "The aws-es-proxy service has been deployed onto the k8s cluster."
     else


### PR DESCRIPTION
### Deployment changes
Elasticsearch 7 endpoint will be the default. If you want to use ES6, make sure to set "ES7" "false" in the manfist.json.
