### PR TITLE
Fix: use /auth/request instead of /auth/mapping Arborist endpoint

### DIFF
--- a/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
@@ -56,7 +56,7 @@ stringData:
   security_oauth_callback_urlResolver: query
 
   security_ohdsi_custom_authorization_mode: teamproject
-  security_ohdsi_custom_authorization_url: $ARBORIST_URL/auth/mapping
+  security_ohdsi_custom_authorization_url: $ARBORIST_URL/auth/request
 
   logging_level_root: info
   logging_level_org_ohdsi: info


### PR DESCRIPTION
Link to JIRA ticket if there is one:  https://ctds-planx.atlassian.net/browse/VADC-1554

### Bug Fixes
- fixes error `Two authorization rules expected for ‘teamproject’=/abc, found=3` by using the `/authz/request` endpoint instead of `/authz/mapping`
  - see also https://github.com/uc-cdis/WebAPI/pull/166