### PR TITLE
updating the kube-setup-indexd job to apply single table driver settings.py for specific environments.

### DIFF
--- a/apis_configs/indexd_multi_table/indexd_settings.py
+++ b/apis_configs/indexd_multi_table/indexd_settings.py
@@ -1,0 +1,79 @@
+from indexd.index.drivers.alchemy import SQLAlchemyIndexDriver
+from indexd.alias.drivers.alchemy import SQLAlchemyAliasDriver
+from indexd.auth.drivers.alchemy import SQLAlchemyAuthDriver
+from indexd.index.drivers.single_table_alchemy import SingleTableSQLAlchemyIndexDriver
+import config_helper
+from os import environ
+import json
+
+APP_NAME = "indexd"
+
+
+def load_json(file_name):
+    return config_helper.load_json(file_name, APP_NAME)
+
+
+conf_data = load_json("creds.json")
+
+usr = conf_data.get("db_username", "{{db_username}}")
+db = conf_data.get("db_database", "{{db_database}}")
+psw = conf_data.get("db_password", "{{db_password}}")
+pghost = conf_data.get("db_host", "{{db_host}}")
+pgport = 5432
+index_config = conf_data.get("index_config")
+CONFIG = {}
+
+CONFIG["JSONIFY_PRETTYPRINT_REGULAR"] = False
+
+dist = environ.get("DIST", None)
+if dist:
+    CONFIG["DIST"] = json.loads(dist)
+
+arborist = environ.get("ARBORIST", "false").lower() == "true"
+
+USE_SINGLE_TABLE = True
+
+if USE_SINGLE_TABLE is True:
+    
+
+    CONFIG["INDEX"] = {        
+        "driver": SingleTableSQLAlchemyIndexDriver(
+            "postgresql+psycopg2://{usr}:{psw}@{pghost}:{pgport}/{db}".format(
+                usr=usr, psw=psw, pghost=pghost, pgport=pgport, db=db
+            ),
+            index_config=index_config,
+        )
+    }   
+else:
+    CONFIG["INDEX"] = {
+        "driver": SQLAlchemyIndexDriver(
+            "postgresql+psycopg2://{usr}:{psw}@{pghost}:{pgport}/{db}".format(
+                usr=usr, psw=psw, pghost=pghost, pgport=pgport, db=db
+            ),
+            index_config=index_config,
+        )
+    }
+
+CONFIG["ALIAS"] = {
+    "driver": SQLAlchemyAliasDriver(
+        "postgresql+psycopg2://{usr}:{psw}@{pghost}:{pgport}/{db}".format(
+            usr=usr, psw=psw, pghost=pghost, pgport=pgport, db=db
+        )
+    )
+}
+
+if arborist:
+    AUTH = SQLAlchemyAuthDriver(
+        "postgresql+psycopg2://{usr}:{psw}@{pghost}:{pgport}/{db}".format(
+            usr=usr, psw=psw, pghost=pghost, pgport=pgport, db=db
+        ),
+        arborist="http://arborist-service/",
+    )
+else:
+    AUTH = SQLAlchemyAuthDriver(
+        "postgresql+psycopg2://{usr}:{psw}@{pghost}:{pgport}/{db}".format(
+            usr=usr, psw=psw, pghost=pghost, pgport=pgport, db=db
+        )
+    )
+
+settings = {"config": CONFIG, "auth": AUTH}

--- a/gen3/bin/kube-setup-indexd.sh
+++ b/gen3/bin/kube-setup-indexd.sh
@@ -6,6 +6,9 @@
 source "${GEN3_HOME}/gen3/lib/utils.sh"
 gen3_load "gen3/lib/kube-setup-init"
 
+manifestPath=$(g3k_manifest_path)
+singleTable="$(jq -r ".[\"global\"][\"indexd_single_table\"]" < "$manifestPath" | tr '[:upper:]' '[:lower:]')"
+
 [[ -z "$GEN3_ROLL_ALL" ]] && gen3 kube-setup-secrets
 
 if [[ ! -f "$(gen3_secrets_folder)/.rendered_indexd_userdb" ]]; then
@@ -19,8 +22,12 @@ if [[ ! -f "$(gen3_secrets_folder)/.rendered_indexd_userdb" ]]; then
 fi
 
 g3kubectl delete secrets/indexd-secret > /dev/null 2>&1 || true;
-g3kubectl create secret generic indexd-secret --from-file=local_settings.py="${GEN3_HOME}/apis_configs/indexd_settings.py" "--from-file=${GEN3_HOME}/apis_configs/config_helper.py"
-  
+if "$singleTable" = true; then
+    g3kubectl create secret generic indexd-secret --from-file=local_settings.py="${GEN3_HOME}/apis_configs/indexd_multi_table/indexd_settings.py" "--from-file=${GEN3_HOME}/apis_configs/config_helper.py"
+else
+    g3kubectl create secret generic indexd-secret --from-file=local_settings.py="${GEN3_HOME}/apis_configs/indexd_settings.py" "--from-file=${GEN3_HOME}/apis_configs/config_helper.py"
+fi
+
 gen3 roll indexd
 g3kubectl apply -f "${GEN3_HOME}/kube/services/indexd/indexd-service.yaml"
 gen3 roll indexd-canary || true


### PR DESCRIPTION
dcf prod needs to use a new "indexd_settings.py" file in order to use the new single table for indexd. We can add a new settings.py file that will look in the "indexd_multi_table" directory for this configuration. 

The kube-setup-indexd script will check the manifest.json to see if "indexd_single_table" is set to "true". 