### PR TITLE
Revert/fallback_to_poetry_run

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -12,6 +12,7 @@ jobs:
     uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
     with:
       QUAY_REPO: "awshelper"
+      CLOUD_AUTO_BRANCH: "revert/fallback_to_poetry_run"
     secrets:
       CI_AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
       CI_AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -12,7 +12,6 @@ jobs:
     uses: uc-cdis/.github/.github/workflows/integration_tests.yaml@master
     with:
       QUAY_REPO: "awshelper"
-      CLOUD_AUTO_BRANCH: "revert/fallback_to_poetry_run"
     secrets:
       CI_AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
       CI_AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -351,6 +351,71 @@
         "line_number": 84
       }
     ],
+    "gen3/lib/testData/default/expectedFenceResult.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "0849046cdafcdb17f5a4bf5c528430d5e04ad295",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "gen3/lib/testData/default/expectedFenceResult.yaml",
+        "hashed_secret": "9ce05cf6168d15dfe02aac9ca9e0712c19c9436d",
+        "is_verified": false,
+        "line_number": 99
+      }
+    ],
     "gen3/lib/testData/default/expectedSheepdogResult.yaml": [
       {
         "type": "Secret Keyword",
@@ -570,6 +635,43 @@
         "line_number": 87
       }
     ],
+    "kube/services/argo/workflows/fence-usersync-wf.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/argo/workflows/fence-usersync-wf.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 108
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/argo/workflows/fence-usersync-wf.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 111
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/argo/workflows/fence-usersync-wf.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 114
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/argo/workflows/fence-usersync-wf.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 117
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/argo/workflows/fence-usersync-wf.yaml",
+        "hashed_secret": "ea73fcfdaa415890d5fde24d3b2245671be32f73",
+        "is_verified": false,
+        "line_number": 120
+      }
+    ],
     "kube/services/argocd/values.yaml": [
       {
         "type": "Secret Keyword",
@@ -638,6 +740,245 @@
         "hashed_secret": "4a8ce7ae6a8a7f2624e232b61b18c2ac9789c44b",
         "is_verified": false,
         "line_number": 23
+      }
+    ],
+    "kube/services/datasim/datasim-deploy.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/datasim/datasim-deploy.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/datasim/datasim-deploy.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 66
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/datasim/datasim-deploy.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/datasim/datasim-deploy.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/datasim/datasim-deploy.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "kube/services/fence/fence-canary-deploy.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 71
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 74
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "0849046cdafcdb17f5a4bf5c528430d5e04ad295",
+        "is_verified": false,
+        "line_number": 96
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fence/fence-canary-deploy.yaml",
+        "hashed_secret": "9ce05cf6168d15dfe02aac9ca9e0712c19c9436d",
+        "is_verified": false,
+        "line_number": 99
+      }
+    ],
+    "kube/services/fenceshib/fenceshib-canary-deploy.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 62
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 68
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 87
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "0849046cdafcdb17f5a4bf5c528430d5e04ad295",
+        "is_verified": false,
+        "line_number": 90
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-canary-deploy.yaml",
+        "hashed_secret": "9ce05cf6168d15dfe02aac9ca9e0712c19c9436d",
+        "is_verified": false,
+        "line_number": 93
+      }
+    ],
+    "kube/services/fenceshib/fenceshib-deploy.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 69
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 72
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 75
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 85
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "0849046cdafcdb17f5a4bf5c528430d5e04ad295",
+        "is_verified": false,
+        "line_number": 97
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "9ce05cf6168d15dfe02aac9ca9e0712c19c9436d",
+        "is_verified": false,
+        "line_number": 100
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/fenceshib/fenceshib-deploy.yaml",
+        "hashed_secret": "6c4789c3be186fd5dcbf06723462ccdd2c86dc37",
+        "is_verified": false,
+        "line_number": 103
       }
     ],
     "kube/services/frontend-framework/frontend-framework-deploy.yaml": [
@@ -730,6 +1071,71 @@
         "hashed_secret": "38ded89f83435a558169dedb91a38f72d6cebf41",
         "is_verified": false,
         "line_number": 27
+      }
+    ],
+    "kube/services/google-sa-validation/google-sa-validation-deploy.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 73
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "0849046cdafcdb17f5a4bf5c528430d5e04ad295",
+        "is_verified": false,
+        "line_number": 79
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/google-sa-validation/google-sa-validation-deploy.yaml",
+        "hashed_secret": "9ce05cf6168d15dfe02aac9ca9e0712c19c9436d",
+        "is_verified": false,
+        "line_number": 82
       }
     ],
     "kube/services/indexd/indexd-canary-deploy.yaml": [
@@ -921,6 +1327,50 @@
         "line_number": 54
       }
     ],
+    "kube/services/jobs/client-modify-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/client-modify-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 41
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/client-modify-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/client-modify-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 50
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/client-modify-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/client-modify-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/client-modify-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 60
+      }
+    ],
     "kube/services/jobs/cogwheel-register-client-job.yaml": [
       {
         "type": "Secret Keyword",
@@ -1040,6 +1490,111 @@
         "line_number": 35
       }
     ],
+    "kube/services/jobs/fence-cleanup-expired-ga4gh-info-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-cleanup-expired-ga4gh-info-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 43
+      }
+    ],
+    "kube/services/jobs/fence-cleanup-expired-ga4gh-info-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-cleanup-expired-ga4gh-info-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 36
+      }
+    ],
+    "kube/services/jobs/fence-db-migrate-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-db-migrate-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-db-migrate-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-db-migrate-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "kube/services/jobs/fence-delete-expired-clients-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-delete-expired-clients-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 38
+      }
+    ],
+    "kube/services/jobs/fence-visa-update-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-visa-update-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 42
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-visa-update-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 45
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-visa-update-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 48
+      }
+    ],
+    "kube/services/jobs/fence-visa-update-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-visa-update-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-visa-update-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fence-visa-update-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "kube/services/jobs/fencedb-create-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/fencedb-create-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 33
+      }
+    ],
     "kube/services/jobs/gdcdb-create-job.yaml": [
       {
         "type": "Secret Keyword",
@@ -1047,6 +1602,80 @@
         "hashed_secret": "79496491225eda4a7be9fcddee2825c85b1535cc",
         "is_verified": false,
         "line_number": 33
+      }
+    ],
+    "kube/services/jobs/gen3qa-check-bucket-access-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gen3qa-check-bucket-access-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 177
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gen3qa-check-bucket-access-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 180
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gen3qa-check-bucket-access-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gen3qa-check-bucket-access-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 190
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gen3qa-check-bucket-access-job.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 193
+      }
+    ],
+    "kube/services/jobs/gentestdata-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gentestdata-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gentestdata-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gentestdata-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gentestdata-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/gentestdata-job.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 83
       }
     ],
     "kube/services/jobs/google-bucket-manifest-job.yaml": [
@@ -1079,6 +1708,550 @@
         "hashed_secret": "ca3cdac59f2bfa45cb014190e4509bf6becf28fb",
         "is_verified": false,
         "line_number": 41
+      }
+    ],
+    "kube/services/jobs/google-create-bucket-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-create-bucket-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-create-bucket-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 81
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-create-bucket-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 84
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-create-bucket-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 91
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-create-bucket-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-create-bucket-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 97
+      }
+    ],
+    "kube/services/jobs/google-delete-expired-access-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-access-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-access-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-access-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 49
+      }
+    ],
+    "kube/services/jobs/google-delete-expired-access-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-access-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 36
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-access-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 39
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-access-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 42
+      }
+    ],
+    "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 57
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "kube/services/jobs/google-delete-expired-service-account-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 49
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-delete-expired-service-account-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
+    "kube/services/jobs/google-init-proxy-groups-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-cronjob.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
+    "kube/services/jobs/google-init-proxy-groups-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-init-proxy-groups-job.yaml",
+        "hashed_secret": "98f5a68541a6d981bf5825f23dffe6a0b150e457",
+        "is_verified": false,
+        "line_number": 62
+      }
+    ],
+    "kube/services/jobs/google-manage-account-access-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-cronjob.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-cronjob.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-cronjob.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "kube/services/jobs/google-manage-account-access-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-account-access-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
+    "kube/services/jobs/google-manage-keys-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-cronjob.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-cronjob.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-cronjob.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "kube/services/jobs/google-manage-keys-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-manage-keys-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 59
+      }
+    ],
+    "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 48
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 51
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 54
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 61
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 67
+      }
+    ],
+    "kube/services/jobs/google-verify-bucket-access-group-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/google-verify-bucket-access-group-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 59
       }
     ],
     "kube/services/jobs/graph-create-job.yaml": [
@@ -1221,6 +2394,108 @@
         "hashed_secret": "27f6dfe15698a3bfaa183c84701cfb2bf4115415",
         "is_verified": false,
         "line_number": 44
+      }
+    ],
+    "kube/services/jobs/usersync-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 67
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 70
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 77
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 80
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 83
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/usersync-job.yaml",
+        "hashed_secret": "ea73fcfdaa415890d5fde24d3b2245671be32f73",
+        "is_verified": false,
+        "line_number": 86
+      }
+    ],
+    "kube/services/jobs/useryaml-job.yaml": [
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
+        "is_verified": false,
+        "line_number": 40
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
+        "is_verified": false,
+        "line_number": 46
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
+        "is_verified": false,
+        "line_number": 53
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
+        "is_verified": false,
+        "line_number": 56
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
+        "is_verified": false,
+        "line_number": 59
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "kube/services/jobs/useryaml-job.yaml",
+        "hashed_secret": "ea73fcfdaa415890d5fde24d3b2245671be32f73",
+        "is_verified": false,
+        "line_number": 65
       }
     ],
     "kube/services/kayako-wrapper/kayako-wrapper-deploy.yaml": [

--- a/gen3/bin/api.sh
+++ b/gen3/bin/api.sh
@@ -68,9 +68,7 @@ gen3_access_token() {
   if [ "$skip_cache" != "true" ]; then
     gen3_access_token_from_cache "$username" && return 0
   fi
-  # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-  g3kubectl exec -c fence $(gen3 pod fence) -- fence-create token-create --scopes openid,user,fence,data,credentials,google_service_account --type access_token --exp ${exp} --username ${username} | tail -1 | gen3_access_token_to_cache "$username" || \
-    g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create token-create --scopes openid,user,fence,data,credentials,google_service_account --type access_token --exp ${exp} --username ${username} | tail -1 | gen3_access_token_to_cache "$username"
+  g3kubectl exec -c fence $(gen3 pod fence) -- fence-create token-create --scopes openid,user,fence,data,credentials,google_service_account --type access_token --exp ${exp} --username ${username} | tail -1 | gen3_access_token_to_cache "$username"
 }
 
 #

--- a/gen3/bin/dcf.sh
+++ b/gen3/bin/dcf.sh
@@ -218,14 +218,9 @@ create_gs_bucket() {
   echo "Start creating gs bucket ...."
 
   if [[ $public == "controlled" ]]; then
-    # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-    g3kubectl exec -c fence $(get_pod fence) -- fence-create google-bucket-create --unique-name $bucket_name --storage-class MULTI_REGIONAL --public False --project-auth-id $phsid --access-logs-bucket dcf-logs || \
-    g3kubectl exec -c fence $(get_pod fence) -- poetry run fence-create google-bucket-create --unique-name $bucket_name --storage-class MULTI_REGIONAL --public False --project-auth-id $phsid --access-logs-bucket dcf-logs
-
+    g3kubectl exec -c fence $(get_pod fence) -- fence-create google-bucket-create --unique-name $bucket_name --storage-class MULTI_REGIONAL --public False --project-auth-id $phsid --access-logs-bucket dcf-logs
   elif [[ $public == "public" ]]; then
-    # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-    g3kubectl exec -c fence $(get_pod fence) -- fence-create google-bucket-create --unique-name $bucket_name --storage-class MULTI_REGIONAL --public True --access-logs-bucket dcf-logs || \
-    g3kubectl exec -c fence $(get_pod fence) -- poetry run fence-create google-bucket-create --unique-name $bucket_name --storage-class MULTI_REGIONAL --public True --access-logs-bucket dcf-logs
+    g3kubectl exec -c fence $(get_pod fence) -- fence-create google-bucket-create --unique-name $bucket_name --storage-class MULTI_REGIONAL --public True --access-logs-bucket dcf-logs
   else
     echo "Can not create the bucket. $public is not supported"
     exit 1

--- a/gen3/bin/kube-setup-apache-guacamole.sh
+++ b/gen3/bin/kube-setup-apache-guacamole.sh
@@ -11,21 +11,12 @@ export namespace=$(gen3 api namespace)
 new_client() {
   gen3_log_info "kube-setup-apache-guacamole" "creating fence oidc client for Apache Guacamole"
   local fence_client="guacamole"
-  # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-  
-  local secrets=$(
-    (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client $fence_client --urls https://${hostname}/guac/guacamole/#/ --username guacamole --auto-approve --public --external --allowed-scopes openid profile email user | tail -1) 2>/dev/null || \
-      g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client $fence_client --urls https://${hostname}/guac/guacamole/#/ --username guacamole --auto-approve --public --external --allowed-scopes openid profile email user | tail -1
-  )
+  local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client $fence_client --urls https://${hostname}/guac/guacamole/#/ --username guacamole --auto-approve --public --external --allowed-scopes openid profile email user | tail -1)
   # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
   if [[ ! $secrets =~ (\'(.*)\', None) ]]; then
       # try delete client
-      g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client $fence_client > /dev/null 2>&1 || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-delete --client $fence_client > /dev/null 2>&1
-      secrets=$(
-        (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client $fence_client --urls https://${hostname}/guac/guacamole/#/ --username guacamole --auto-approve --public --external --allowed-scopes openid profile email user | tail -1) 2>/dev/null || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client $fence_client --urls https://${hostname}/guac/guacamole/#/ --username guacamole --auto-approve --public --external --allowed-scopes openid profile email user | tail -1
-      )
+      g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client $fence_client > /dev/null 2>&1
+      secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client $fence_client --urls https://${hostname}/guac/guacamole/#/ --username guacamole --auto-approve --public --external --allowed-scopes openid profile email user | tail -1)
       if [[ ! $secrets =~ (\'(.*)\', None) ]]; then
           gen3_log_err "kube-setup-apache-guacamole" "Failed generating oidc client for guacamole: $secrets"
           return 1

--- a/gen3/bin/kube-setup-cedar-wrapper.sh
+++ b/gen3/bin/kube-setup-cedar-wrapper.sh
@@ -5,15 +5,9 @@ create_client_and_secret() {
     local hostname=$(gen3 api hostname)
     local client_name="cedar_ingest_client"
     gen3_log_info "kube-setup-cedar-wrapper" "creating fence ${client_name} for $hostname"
-
-# Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
     # delete any existing fence cedar clients
-    g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client ${client_name} > /dev/null 2>&1 || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-delete --client ${client_name} > /dev/null 2>&1
-    local secrets=$(
-        (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client ${client_name} --grant-types client_credentials | tail -1) 2>/dev/null || \
-            g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client ${client_name} --grant-types client_credentials | tail -1
-    )
+    g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client ${client_name} > /dev/null 2>&1
+    local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client ${client_name} --grant-types client_credentials | tail -1)
     # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
     if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
         gen3_log_err "kube-setup-cedar-wrapper" "Failed generating ${client_name}"
@@ -42,10 +36,7 @@ setup_creds() {
     fi
 
     local client_name="cedar_ingest_client"
-    local client_list=$(
-        (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-list) 2>/dev/null || \
-            g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-list
-    )
+    local client_list=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-list)
     local client_count=$(echo "$client_list=" | grep -cE "'name':.*'${client_name}'")
     gen3_log_info "CEDAR client count = ${client_count}"
 

--- a/gen3/bin/kube-setup-metadata-delete-expired-objects-cronjob.sh
+++ b/gen3/bin/kube-setup-metadata-delete-expired-objects-cronjob.sh
@@ -12,22 +12,12 @@ setup_config() {
   if [[ ! -f "$secretsFolder/config.json" ]]; then
     local hostname=$(gen3 api hostname)
     gen3_log_info "kube-setup-metadata-delete-expired-objects-job" "creating fence oidc client for $hostname"
-    # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-    local secrets=$(
-      (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client metadata-delete-expired-objects-job --grant-types client_credentials | tail -1) 2>/dev/null || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client metadata-delete-expired-objects-job --grant-types client_credentials | tail -1
-      
-    )
+    local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client metadata-delete-expired-objects-job --grant-types client_credentials | tail -1)
     # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
     if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
         # try delete client
-        g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client metadata-delete-expired-objects-job > /dev/null 2>&1 || \
-          g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-delete --client metadata-delete-expired-objects-job > /dev/null 2>&1
-        secrets=$(
-          (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client metadata-delete-expired-objects-job --grant-types client_credentials | tail -1) 2>/dev/null || \
-            g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client metadata-delete-expired-objects-job --grant-types client_credentials | tail -1
-          
-        )
+        g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client metadata-delete-expired-objects-job > /dev/null 2>&1
+        secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client metadata-delete-expired-objects-job --grant-types client_credentials | tail -1)
         if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
             gen3_log_err "kube-setup-metadata-delete-expired-objects-job" "Failed generating oidc client: $secrets"
             return 1

--- a/gen3/bin/kube-setup-ohdsi.sh
+++ b/gen3/bin/kube-setup-ohdsi.sh
@@ -11,13 +11,7 @@ export namespace=$(gen3 api namespace)
 new_client() {
   atlas_hostname="atlas.${hostname}"
   gen3_log_info "kube-setup-ohdsi" "creating fence oidc client for $atlas_hostname"
-  
-  # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-  local secrets=$(
-    (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client atlas --urls https://${atlas_hostname}/WebAPI/user/oauth/callback?client_name=OidcClient --username atlas --allowed-scopes openid profile email user | tail -1) 2>/dev/null || \
-      g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client atlas --urls https://${atlas_hostname}/WebAPI/user/oauth/callback?client_name=OidcClient --username atlas --allowed-scopes openid profile email user | tail -1
-
-  )
+  local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client atlas --urls https://${atlas_hostname}/WebAPI/user/oauth/callback?client_name=OidcClient --username atlas --allowed-scopes openid profile email user | tail -1)
   # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
   if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
     gen3_log_err "kube-setup-ohdsi" "Failed generating oidc client for atlas: $secrets"

--- a/gen3/bin/kube-setup-superset.sh
+++ b/gen3/bin/kube-setup-superset.sh
@@ -8,20 +8,12 @@ new_client() {
   local hostname=$(gen3 api hostname)
   superset_hostname="superset.${hostname}"
   gen3_log_info "kube-setup-superset" "creating fence oidc client for $superset_hostname"
-  # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-  local secrets=$(
-    (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client superset --urls https://${superset_hostname}/oauth-authorized/fence --username superset | tail -1) 2>/dev/null || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client superset --urls https://${superset_hostname}/oauth-authorized/fence --username superset | tail -1
-  )
+  local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client superset --urls https://${superset_hostname}/oauth-authorized/fence --username superset | tail -1)
   # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
   if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
       # try delete client
-      g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client superset > /dev/null 2>&1 || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-delete --client superset > /dev/null 2>&1
-      secrets=$(
-        (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client superset --urls https://${superset_hostname}/oauth-authorized/fence --username superset | tail -1) 2>/dev/null || \
-            g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client superset --urls https://${superset_hostname}/oauth-authorized/fence --username superset | tail -1
-      )
+      g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client superset > /dev/null 2>&1
+      secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client superset --urls https://${superset_hostname}/oauth-authorized/fence --username superset | tail -1)
       if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
           gen3_log_err "kube-setup-superset" "Failed generating oidc client for superset: $secrets"
           return 1

--- a/gen3/bin/kube-setup-wts.sh
+++ b/gen3/bin/kube-setup-wts.sh
@@ -14,20 +14,12 @@ gen3_load "gen3/lib/kube-setup-init"
 new_client() {
   local hostname=$(gen3 api hostname)
   gen3_log_info "kube-setup-wts" "creating fence oidc client for $hostname"
-  # Adding a fallback to `poetry run fence-create` to cater to fence containers with amazon linux.
-  local secrets=$(
-    (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client wts --urls "https://${hostname}/wts/oauth2/authorize" --username wts --auto-approve | tail -1) 1>/dev/null || \
-      g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client wts --urls "https://${hostname}/wts/oauth2/authorize" --username wts --auto-approve | tail -1
-  )
+  local secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client wts --urls "https://${hostname}/wts/oauth2/authorize" --username wts --auto-approve | tail -1)
   # secrets looks like ('CLIENT_ID', 'CLIENT_SECRET')
   if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
       # try delete client
-      g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client wts > /dev/null 2>&1 || \
-        g3kubectl exec -c fence $(gen3 pod fence) -- poetry run  fence-create client-delete --client wts > /dev/null 2>&1
-      secrets=$(
-        (g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client wts --urls "https://${hostname}/wts/oauth2/authorize" --username wts --auto-approve | tail -1) 1>/dev/null || \
-              g3kubectl exec -c fence $(gen3 pod fence) -- poetry run fence-create client-create --client wts --urls "https://${hostname}/wts/oauth2/authorize" --username wts --auto-approve | tail -1
-      )
+      g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-delete --client wts > /dev/null 2>&1
+      secrets=$(g3kubectl exec -c fence $(gen3 pod fence) -- fence-create client-create --client wts --urls "https://${hostname}/wts/oauth2/authorize" --username wts --auto-approve | tail -1)
       if [[ ! $secrets =~ (\'(.*)\', \'(.*)\') ]]; then
           gen3_log_err "kube-setup-wts" "Failed generating oidc client for workspace token service: $secrets"
           return 1

--- a/gen3/lib/testData/default/expectedFenceResult.yaml
+++ b/gen3/lib/testData/default/expectedFenceResult.yaml
@@ -219,7 +219,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi
       initContainers:
       - name: fence-init
@@ -256,7 +256,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"

--- a/gen3/lib/testData/default/expectedFenceResult.yaml
+++ b/gen3/lib/testData/default/expectedFenceResult.yaml
@@ -257,10 +257,10 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            if (fence-create migrate --help || poetry run fence-create migrate --help) > /dev/null 2>&1; then
+            if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"
-                fence-create migrate || poetry run fence-create migrate
+                fence-create migrate
               else
                 echo "Db migration disabled in fence-config"
               fi

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -225,7 +225,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then bash /dockerrun.sh; fi
       initContainers:
       - name: fence-init
@@ -262,7 +262,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"

--- a/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
+++ b/gen3/lib/testData/test1.manifest.g3k/expectedFenceResult.yaml
@@ -263,11 +263,11 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            if (fence-create migrate --help || poetry run fence-create migrate --help) > /dev/null 2>&1; then
+            if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"
                 cd /fence
-                fence-create migrate || poetry run fence-create migrate
+                fence-create migrate
               else
                 echo "Db migration disabled in fence-config"
               fi

--- a/kube/services/argo/workflows/fence-usersync-wf.yaml
+++ b/kube/services/argo/workflows/fence-usersync-wf.yaml
@@ -204,7 +204,7 @@ spec:
             echo "${ADD_DBGAP}"
             echo "${ONLY_DBGAP}"
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             echo 'options use-vc' >> /etc/resolv.conf
             let count=0
             while [[ ! -f /mnt/shared/user.yaml && $count -lt 50 ]]; do

--- a/kube/services/argo/workflows/fence-usersync-wf.yaml
+++ b/kube/services/argo/workflows/fence-usersync-wf.yaml
@@ -215,10 +215,7 @@ spec:
             if [[ "$SYNC_FROM_DBGAP" != True && "$ADD_DBGAP" != "true" ]]; then
               if [[ -f /mnt/shared/user.yaml ]]; then
                 echo "running fence-create"
-                time (
-                  fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml || \
-                    poetry run fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml
-                )
+                time fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml
               else
                 echo "/mnt/shared/user.yaml did not appear within timeout :-("
                 false  # non-zero exit code
@@ -228,16 +225,10 @@ spec:
               output=$(mktemp "/tmp/fence-create-output_XXXXXX")
               if [[ -f /mnt/shared/user.yaml && "$ONLY_DBGAP" != "true" ]]; then
                 echo "Running fence-create dbgap-sync with user.yaml - see $output"
-                time (
-                  fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output" || \
-                    poetry run fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output"
-                )
+                time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output"
               else
                 echo "Running fence-create dbgap-sync without user.yaml - see $output"
-                time (
-                  fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output" || \
-                    poetry run fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output"
-                )
+                time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output"
               fi
               exitcode="${PIPESTATUS[0]}"
               echo "$output"

--- a/kube/services/datasim/datasim-deploy.yaml
+++ b/kube/services/datasim/datasim-deploy.yaml
@@ -188,10 +188,7 @@ spec:
               sleepTime=10
               # retry loop
               while [[ $count -lt 3 && $success == false ]]; do
-                if (
-                  fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp 36000 || \
-                    poetry run fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp 36000 
-                ) > "$tempFile"; then
+                if fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp 36000 > "$tempFile"; then
                   echo "fence-create success!"
                   tail -1 "$tempFile" > /mnt/shared/access_token.txt
                   # base64 --decode complains about invalid characters - don't know why

--- a/kube/services/datasim/datasim-deploy.yaml
+++ b/kube/services/datasim/datasim-deploy.yaml
@@ -171,7 +171,7 @@ spec:
             - "-c"
             - |
               echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-              poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+              python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
               if [ -f /fence/jwt-keys.tar ]; then
                 cd /fence
                 tar xvf jwt-keys.tar

--- a/kube/services/fence/fence-canary-deploy.yaml
+++ b/kube/services/fence/fence-canary-deploy.yaml
@@ -201,5 +201,5 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -225,7 +225,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then bash /dockerrun.sh; fi
       initContainers:
       - name: fence-init
@@ -262,7 +262,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"

--- a/kube/services/fence/fence-deploy.yaml
+++ b/kube/services/fence/fence-deploy.yaml
@@ -263,11 +263,11 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            if (fence-create migrate --help || poetry run fence-create migrate --help) > /dev/null 2>&1; then
+            if fence-create migrate --help > /dev/null 2>&1; then
               if ! grep -E 'ENABLE_DB_MIGRATION"?: *false' /var/www/fence/fence-config.yaml; then
                 echo "Running db migration: fence-create migrate"
                 cd /fence
-                fence-create migrate || poetry run fence-create migrate
+                fence-create migrate
               else
                 echo "Db migration disabled in fence-config"
               fi

--- a/kube/services/fenceshib/fenceshib-canary-deploy.yaml
+++ b/kube/services/fenceshib/fenceshib-canary-deploy.yaml
@@ -188,5 +188,5 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrun.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi

--- a/kube/services/fenceshib/fenceshib-deploy.yaml
+++ b/kube/services/fenceshib/fenceshib-deploy.yaml
@@ -235,5 +235,5 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             bash /fence/dockerrunshib.bash && if [[ -f /dockerrun.sh ]]; then /dockerrun.sh; fi

--- a/kube/services/google-sa-validation/google-sa-validation-deploy.yaml
+++ b/kube/services/google-sa-validation/google-sa-validation-deploy.yaml
@@ -111,7 +111,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             /fence/bin/google-user-sa-validation.sh
         volumeMounts:
           - name: "logo-volume"

--- a/kube/services/jobs/client-modify-job.yaml
+++ b/kube/services/jobs/client-modify-job.yaml
@@ -119,7 +119,7 @@ spec:
           - |
 
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"         
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
 
             #need a way to grab all the clients. 
 

--- a/kube/services/jobs/client-modify-job.yaml
+++ b/kube/services/jobs/client-modify-job.yaml
@@ -125,11 +125,11 @@ spec:
 
             echo Starting to collect client list     
 
-            CLIENT_LIST=$((fence-create client-list || poetry run fence-create client-list) | grep "'name'")
+            CLIENT_LIST=$(fence-create client-list | grep "'name'")
             CLIENT_LIST=${CLIENT_LIST//"'name': "/}
             CLIENT_LIST=${CLIENT_LIST//"'"/}
             CLIENT_LIST=${CLIENT_LIST//","/}
-            CLIENT_LIST=($(echo $CLIENT_LIST | xargs))
+            CLIENT_LIST=($(echo $CLIENT_LIST | tr " "))
 
             if [[ -z "$FIELD_NAME" ]]; then
                 echo Cannot update field. FIELD_NAME variable must be sepcified.
@@ -151,7 +151,7 @@ spec:
 
             for index in "${!CLIENT_LIST[@]}"
             do
-                $create_command --client ${CLIENT_LIST[index]} || poetry run $create_command --client ${CLIENT_LIST[index]}
+                $create_command --client ${CLIENT_LIST[index]}
             done
 
             if [[ $? != 0 ]]; then

--- a/kube/services/jobs/fence-cleanup-expired-ga4gh-info-cronjob.yaml
+++ b/kube/services/jobs/fence-cleanup-expired-ga4gh-info-cronjob.yaml
@@ -72,7 +72,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create cleanup-expired-ga4gh-information
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/fence-cleanup-expired-ga4gh-info-cronjob.yaml
+++ b/kube/services/jobs/fence-cleanup-expired-ga4gh-info-cronjob.yaml
@@ -74,7 +74,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create cleanup-expired-ga4gh-information || poetry run fence-create cleanup-expired-ga4gh-information
+                fence-create cleanup-expired-ga4gh-information
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/fence-cleanup-expired-ga4gh-info-job.yaml
+++ b/kube/services/jobs/fence-cleanup-expired-ga4gh-info-job.yaml
@@ -61,7 +61,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create cleanup-expired-ga4gh-information
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/fence-cleanup-expired-ga4gh-info-job.yaml
+++ b/kube/services/jobs/fence-cleanup-expired-ga4gh-info-job.yaml
@@ -62,7 +62,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create cleanup-expired-ga4gh-information || poetry run fence-create cleanup-expired-ga4gh-information
+            fence-create cleanup-expired-ga4gh-information
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/fence-db-migrate-job.yaml
+++ b/kube/services/jobs/fence-db-migrate-job.yaml
@@ -100,7 +100,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             cd /fence
             fence-create migrate
             if [[ $? != 0 ]]; then

--- a/kube/services/jobs/fence-db-migrate-job.yaml
+++ b/kube/services/jobs/fence-db-migrate-job.yaml
@@ -102,7 +102,7 @@ spec:
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             cd /fence
-            fence-create migrate || poetry run fence-create migrate
+            fence-create migrate
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/fence-delete-expired-clients-job.yaml
+++ b/kube/services/jobs/fence-delete-expired-clients-job.yaml
@@ -70,9 +70,9 @@ spec:
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if [[ "$slackWebHook" =~ ^http ]]; then
-              fence-create client-delete-expired --slack-webhook $slackWebHook --warning-days 7 || poetry run fence-create client-delete-expired --slack-webhook $slackWebHook --warning-days 7
+              fence-create client-delete-expired --slack-webhook $slackWebHook --warning-days 7
             else
-              fence-create client-delete-expired || poetry run fence-create client-delete-expired
+              fence-create client-delete-expired
             fi
             exit $?
       restartPolicy: Never

--- a/kube/services/jobs/fence-delete-expired-clients-job.yaml
+++ b/kube/services/jobs/fence-delete-expired-clients-job.yaml
@@ -68,7 +68,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if [[ "$slackWebHook" =~ ^http ]]; then
               fence-create client-delete-expired --slack-webhook $slackWebHook --warning-days 7
             else

--- a/kube/services/jobs/fence-visa-update-cronjob.yaml
+++ b/kube/services/jobs/fence-visa-update-cronjob.yaml
@@ -119,7 +119,7 @@ spec:
                     create_command+=" --concurrency $CONCURRENCY"
                 fi
 
-                $create_command || poetry run $create_command
+                $create_command
                 exitcode=$?
 
                 if [ "${slackWebHook}" != 'None' ]; then

--- a/kube/services/jobs/fence-visa-update-cronjob.yaml
+++ b/kube/services/jobs/fence-visa-update-cronjob.yaml
@@ -102,7 +102,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
 
                 create_command="fence-create update-visas"
 

--- a/kube/services/jobs/fence-visa-update-job.yaml
+++ b/kube/services/jobs/fence-visa-update-job.yaml
@@ -96,7 +96,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
 
             create_command="fence-create update-visas"
 

--- a/kube/services/jobs/fence-visa-update-job.yaml
+++ b/kube/services/jobs/fence-visa-update-job.yaml
@@ -113,7 +113,7 @@ spec:
                 create_command+=" --concurrency $CONCURRENCY"
             fi
 
-            $create_command || poetry run $create_command
+            $create_command
             exitcode=$?
 
             if [ "${slackWebHook}" != 'None' ]; then

--- a/kube/services/jobs/fencedb-create-job.yaml
+++ b/kube/services/jobs/fencedb-create-job.yaml
@@ -48,28 +48,14 @@ spec:
           - "-c"
           # Script always succeeds if it runs (echo exits with 0)
           - |
-            eval $(
-            if poetry run python 2> /dev/null <<EOM
-                import json
+            eval $(python 2> /dev/null <<EOM
+            import json
 
-                creds = json.load(open('/var/www/fence/creds.json', 'r'))
-                print('declare -A db_creds')
-                for key in ['db_host', 'db_username', 'db_password', 'db_database']:
-                  print("db_creds['%s']='%s'" % (key, creds[key]))
-                EOM
-            then
-                echo "Executed with Poetry successfully."
-            else
-                echo "Poetry failed, falling back to system Python."
-                python 2> /dev/null <<EOM
-                import json
-
-                creds = json.load(open('/var/www/fence/creds.json', 'r'))
-                print('declare -A db_creds')
-                for key in ['db_host', 'db_username', 'db_password', 'db_database']:
-                  print("db_creds['%s']='%s'" % (key, creds[key]))
-                EOM
-            fi
+            creds = json.load(open('/var/www/fence/creds.json', 'r'))
+            print('declare -A db_creds')
+            for key in ['db_host', 'db_username', 'db_password', 'db_database']:
+              print("db_creds['%s']='%s'" % (key, creds[key]))
+            EOM
             )
             userdatamodel-init --username "${db_creds[db_username]}" --password "${db_creds[db_password]}" --host "${db_creds[db_host]}" --db "${db_creds[db_database]}"
             echo "Exit code: $?"

--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -140,10 +140,7 @@ spec:
               sleepTime=10
               # retry loop
               while [[ $count -lt 3 && $success == false ]]; do
-                if (
-                fence-create --path fence token-create --type access_token --username $TEST_OPERATOR --scopes openid,user,test-client,data --exp $TOKEN_EXPIRATION || \
-                  poetry run fence-create --path fence token-create --type access_token --username $TEST_OPERATOR --scopes openid,user,test-client,data --exp $TOKEN_EXPIRATION
-                ) > "$tempFile"; then
+                if fence-create --path fence token-create --type access_token --username $TEST_OPERATOR --scopes openid,user,test-client,data --exp $TOKEN_EXPIRATION > "$tempFile"; then
                   echo "fence-create success!"
                   tail -1 "$tempFile" > /mnt/shared/access_token.txt
                   # base64 --decode complains about invalid characters - don't know why

--- a/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
+++ b/kube/services/jobs/gen3qa-check-bucket-access-job.yaml
@@ -123,7 +123,7 @@ spec:
             - "-c"
             - |
               echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-              poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+              python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
               if [ -f /fence/jwt-keys.tar ]; then
                 cd /fence
                 tar xvf jwt-keys.tar

--- a/kube/services/jobs/gentestdata-job.yaml
+++ b/kube/services/jobs/gentestdata-job.yaml
@@ -203,10 +203,7 @@ spec:
               sleepTime=10
               # retry loop
               while [[ $count -lt 3 && $success == false ]]; do
-                if (
-                  fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp $TOKEN_EXPIRATION || \
-                    poetry run fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp $TOKEN_EXPIRATION
-                )> "$tempFile"; then
+                if fence-create --path fence token-create --type access_token --username $SUBMISSION_USER  --scopes openid,user,test-client --exp $TOKEN_EXPIRATION > "$tempFile"; then
                   echo "fence-create success!"
                   tail -1 "$tempFile" > /mnt/shared/access_token.txt
                   # base64 --decode complains about invalid characters - don't know why

--- a/kube/services/jobs/gentestdata-job.yaml
+++ b/kube/services/jobs/gentestdata-job.yaml
@@ -186,7 +186,7 @@ spec:
             - "-c"
             - |
               echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-              poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+              python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
               if [ -f /fence/jwt-keys.tar ]; then
                 cd /fence
                 tar xvf jwt-keys.tar

--- a/kube/services/jobs/google-create-bucket-job.yaml
+++ b/kube/services/jobs/google-create-bucket-job.yaml
@@ -165,7 +165,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if [[ -z "$UNIQUE_BUCKET_NAME" ]]; then
                 echo Cannot create bucket. UNIQUE_BUCKET_NAME variable must be specified.
                 exit 1 # terminate and indicate error

--- a/kube/services/jobs/google-create-bucket-job.yaml
+++ b/kube/services/jobs/google-create-bucket-job.yaml
@@ -192,7 +192,7 @@ spec:
                 create_command+=" --access-logs-bucket $ACCESS_LOGS_BUCKET"
             fi
 
-            fence-create ${create_command} || poetry run fence-create ${create_command}
+            fence-create ${create_command}
 
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/google-delete-expired-access-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-access-cronjob.yaml
@@ -88,7 +88,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create delete-expired-google-access || poetry run fence-create delete-expired-google-access
+                fence-create delete-expired-google-access
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/google-delete-expired-access-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-access-cronjob.yaml
@@ -86,7 +86,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create delete-expired-google-access
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/google-delete-expired-access-job.yaml
+++ b/kube/services/jobs/google-delete-expired-access-job.yaml
@@ -76,7 +76,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create delete-expired-google-access || poetry run fence-create delete-expired-google-access
+            fence-create delete-expired-google-access
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/google-delete-expired-access-job.yaml
+++ b/kube/services/jobs/google-delete-expired-access-job.yaml
@@ -75,7 +75,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create delete-expired-google-access
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
@@ -127,7 +127,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create expired-service-account-delete || poetry run fence-create expired-service-account-delete
+                fence-create expired-service-account-delete
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-cronjob.yaml
@@ -125,7 +125,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create expired-service-account-delete
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/google-delete-expired-service-account-job.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-job.yaml
@@ -113,7 +113,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create expired-service-account-delete
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/google-delete-expired-service-account-job.yaml
+++ b/kube/services/jobs/google-delete-expired-service-account-job.yaml
@@ -114,7 +114,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create expired-service-account-delete || poetry run fence-create expired-service-account-delete
+            fence-create expired-service-account-delete
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
@@ -131,7 +131,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create google-init
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-cronjob.yaml
@@ -133,7 +133,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create google-init || poetry run fence-create google-init
+                fence-create google-init
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/google-init-proxy-groups-job.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-job.yaml
@@ -119,7 +119,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create google-init
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/google-init-proxy-groups-job.yaml
+++ b/kube/services/jobs/google-init-proxy-groups-job.yaml
@@ -120,7 +120,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create google-init || poetry run fence-create google-init
+            fence-create google-init
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/google-manage-account-access-cronjob.yaml
+++ b/kube/services/jobs/google-manage-account-access-cronjob.yaml
@@ -125,7 +125,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create google-manage-account-access
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/google-manage-account-access-cronjob.yaml
+++ b/kube/services/jobs/google-manage-account-access-cronjob.yaml
@@ -127,7 +127,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create google-manage-account-access || poetry run fence-create google-manage-account-access
+                fence-create google-manage-account-access
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/google-manage-account-access-job.yaml
+++ b/kube/services/jobs/google-manage-account-access-job.yaml
@@ -113,7 +113,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create google-manage-account-access
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/google-manage-account-access-job.yaml
+++ b/kube/services/jobs/google-manage-account-access-job.yaml
@@ -114,7 +114,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create google-manage-account-access || poetry run fence-create google-manage-account-access
+            fence-create google-manage-account-access
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/google-manage-keys-cronjob.yaml
+++ b/kube/services/jobs/google-manage-keys-cronjob.yaml
@@ -127,7 +127,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create google-manage-keys || poetry run fence-create google-manage-keys
+                fence-create google-manage-keys
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/google-manage-keys-cronjob.yaml
+++ b/kube/services/jobs/google-manage-keys-cronjob.yaml
@@ -125,7 +125,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create google-manage-keys
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/google-manage-keys-job.yaml
+++ b/kube/services/jobs/google-manage-keys-job.yaml
@@ -117,7 +117,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create google-manage-keys || poetry run fence-create google-manage-keys
+            fence-create google-manage-keys
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/google-manage-keys-job.yaml
+++ b/kube/services/jobs/google-manage-keys-job.yaml
@@ -116,7 +116,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create google-manage-keys
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
@@ -125,7 +125,7 @@ spec:
               - "-c"
               - |
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-                poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+                python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
                 fence-create bucket-access-group-verify
                 if [[ $? != 0 ]]; then

--- a/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-cronjob.yaml
@@ -127,7 +127,7 @@ spec:
                 echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
                 poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
                 echo 'options use-vc' >> /etc/resolv.conf
-                fence-create bucket-access-group-verify || poetry run fence-create bucket-access-group-verify
+                fence-create bucket-access-group-verify
                 if [[ $? != 0 ]]; then
                   echo "WARNING: non zero exit code: $?"
                 else

--- a/kube/services/jobs/google-verify-bucket-access-group-job.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-job.yaml
@@ -114,7 +114,7 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
-            fence-create bucket-access-group-verify || poetry run fence-create bucket-access-group-verify
+            fence-create bucket-access-group-verify
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"
             fi

--- a/kube/services/jobs/google-verify-bucket-access-group-job.yaml
+++ b/kube/services/jobs/google-verify-bucket-access-group-job.yaml
@@ -113,7 +113,7 @@ spec:
           - "-c"
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             fence-create bucket-access-group-verify
             if [[ $? != 0 ]]; then
               echo "WARNING: non zero exit code: $?"

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -190,7 +190,7 @@ spec:
           # Script always succeeds if it runs (echo exits with 0)
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             echo 'options use-vc' >> /etc/resolv.conf
             let count=0
             while [[ ! -f /mnt/shared/user.yaml && $count -lt 50 ]]; do

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -201,10 +201,7 @@ spec:
             if [[ "$SYNC_FROM_DBGAP" != True && "$ADD_DBGAP" != "true" ]]; then
               if [[ -f /mnt/shared/user.yaml ]]; then
                 echo "running fence-create"
-                time (
-                  fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml || \
-                    poetry run fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml
-                )
+                time fence-create sync --arborist http://arborist-service --yaml /mnt/shared/user.yaml
               else
                 echo "/mnt/shared/user.yaml did not appear within timeout :-("
                 false  # non-zero exit code
@@ -214,16 +211,10 @@ spec:
               output=$(mktemp "/tmp/fence-create-output_XXXXXX")
               if [[ -f /mnt/shared/user.yaml && "$ONLY_DBGAP" != "true" ]]; then
                 echo "Running fence-create dbgap-sync with user.yaml - see $output"
-                time (
-                  fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output" || \
-                    poetry run fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output"
-                )
+                time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml --yaml /mnt/shared/user.yaml 2>&1 | tee "$output"
               else
                 echo "Running fence-create dbgap-sync without user.yaml - see $output"
-                time (
-                  fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output" || \
-                    poetry run fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output"
-                )
+                time fence-create sync --arborist http://arborist-service --sync_from_dbgap "True" --projects /var/www/fence/projects.yaml 2>&1 | tee "$output"
               fi
               exitcode="${PIPESTATUS[0]}"
               echo "$output"

--- a/kube/services/jobs/useryaml-job.yaml
+++ b/kube/services/jobs/useryaml-job.yaml
@@ -147,7 +147,7 @@ spec:
           # Script always succeeds if it runs (echo exits with 0)
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if [ "$SYNC_FROM_DBGAP" = True ]; then
               fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /var/www/fence/user.yaml
             else

--- a/kube/services/jobs/useryaml-job.yaml
+++ b/kube/services/jobs/useryaml-job.yaml
@@ -149,11 +149,9 @@ spec:
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             if [ "$SYNC_FROM_DBGAP" = True ]; then
-              fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /var/www/fence/user.yaml || \
-                poetry run fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /var/www/fence/user.yaml
+              fence-create sync --arborist http://arborist-service --sync_from_dbgap $(SYNC_FROM_DBGAP) --projects /var/www/fence/projects.yaml --yaml /var/www/fence/user.yaml
             else
-              fence-create sync --arborist http://arborist-service --yaml /var/www/fence/user.yaml || \
-                poetry run fence-create sync --arborist http://arborist-service --yaml /var/www/fence/user.yaml
+              fence-create sync --arborist http://arborist-service --yaml /var/www/fence/user.yaml
             fi
             echo "Exit code: $?"
       restartPolicy: Never

--- a/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
+++ b/kube/services/presigned-url-fence/presigned-url-fence-deploy.yaml
@@ -220,8 +220,8 @@ spec:
           - |
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             echo -e "ENABLE_DB_MIGRATION: false" > "/var/www/fence/fence-config-bonus1.yaml"
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config-step1.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config-step1.yaml
-            poetry run python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-bonus1.yaml /var/www/fence/fence-config-step1.yaml > /var/www/fence/fence-config.yaml || python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-bonus1.yaml /var/www/fence/fence-config-step1.yaml > /var/www/fence/fence-config.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config-step1.yaml
+            python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-bonus1.yaml /var/www/fence/fence-config-step1.yaml > /var/www/fence/fence-config.yaml
             nginx_limit=$(cat /var/www/fence/fence-config.yaml | sed -n -e 's/^.*\"OVERRIDE_NGINX_RATE_LIMIT\": //p' | sed 's/.$//')
             if [ -z "$nginx_limit" ]; then
               nginx_limit=$(cat /fence/fence/config-default.yaml | sed -n -e 's/^.*OVERRIDE_NGINX_RATE_LIMIT: //p')


### PR DESCRIPTION
Reverting changes from 
* Add changes to ensure azlinux and mcrypt images are working fine (#2682)
* Add poetry run for fence-create with backwards compatibility (#2708)

Note: These changes were originally made to fallback to `poetry run python` or `poetry run fence-create` to support the new AL2-based fence image. However, updating the `PATH` variable in the Docker image allows us to avoid all this extra work.

This PR needs to be tested with both the current fence:master and the chore/ccrypt_usersync branch, as the latter uses Amazon Linux. We want to ensure that the changes in this cloud-auto branch work for both versions without causing any breakages.