### PR TITLE
Update deprecated js_include in nginx configs

### DIFF
--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -282,4 +282,4 @@ function gen3_workspace_authorize_handler(req) {
   }
 }
 
-export default {userid, isCredentialsAllowed};
+export default {userid, isCredentialsAllowed, checkBlackList};

--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -38,7 +38,7 @@ function atob(input) {
   return output;
 }
 
-export default {userid, isCredentialsAllowed};
+
 
 /**
  * nginscript helper for parsing user out of JWT tokens.
@@ -281,3 +281,5 @@ function gen3_workspace_authorize_handler(req) {
     req.return(400, '{ "status": "redirect failed validation" }');
   }
 }
+
+export default {userid, isCredentialsAllowed};

--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -282,4 +282,4 @@ function gen3_workspace_authorize_handler(req) {
   }
 }
 
-export default {userid, isCredentialsAllowed, checkBlackList};
+export default {userid, isCredentialsAllowed, checkBlackList, getServiceReleases};

--- a/kube/services/revproxy/helpers.js
+++ b/kube/services/revproxy/helpers.js
@@ -38,6 +38,8 @@ function atob(input) {
   return output;
 }
 
+export default {userid, isCredentialsAllowed};
+
 /**
  * nginscript helper for parsing user out of JWT tokens.
  * We appear to have access to the 'access_token' variable

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -247,7 +247,7 @@ server {
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 
   # update service release cookie
-  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
+  # add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
 
   if ($request_method = 'OPTIONS') {
     return 204;

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -76,7 +76,7 @@ default_type application/octet-stream;
 #
 js_import helpers.js;
 js_set $userid helpers.userid;
-#js_set $black_list_check helpers.checkBlackList;
+js_set $black_list_check helpers.checkBlackList;
 
 # Modsecurity and blacklist configuration
 include /etc/nginx/gen3_server*.conf;
@@ -247,7 +247,7 @@ server {
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 
   # update service release cookie
-  #add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
+  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
 
   if ($request_method = 'OPTIONS') {
     return 204;

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -74,9 +74,9 @@ default_type application/octet-stream;
 # Note - nginscript js_set, etc get processed
 #   on demand: https://www.nginx.com/blog/introduction-nginscript/
 #
-js_include helpers.js;
-js_set $userid userid;
-js_set $black_list_check checkBlackList;
+js_import helpers.js;
+js_set $userid helpers.userid;
+js_set $black_list_check helpers.checkBlackList;
 
 # Modsecurity and blacklist configuration
 include /etc/nginx/gen3_server*.conf;
@@ -98,7 +98,7 @@ perl_set $canary_percent_json 'sub { return $ENV{"CANARY_PERCENT_JSON"}; }';
 ##
 # Service release parsing and assignment
 #
-js_set $service_releases getServiceReleases;
+js_set $service_releases helpers.getServiceReleases;
 
 ##
 # Logging Settings
@@ -166,7 +166,7 @@ perl_set $des_domain 'sub { return $ENV{"DES_NAMESPACE"} ? qq{.$ENV{"DES_NAMESPA
 # CORS Credential White List
 ##
 perl_set $origins_allow_credentials 'sub { return $ENV{"ORIGINS_ALLOW_CREDENTIALS"}; }';
-js_set $credentials_allowed isCredentialsAllowed;
+js_set $credentials_allowed helpers.isCredentialsAllowed;
 
 ## For multi-domain deployments
 perl_set $csrf_cookie_domain 'sub { return $ENV{"COOKIE_DOMAIN"} ? qq{;domain=$ENV{"COOKIE_DOMAIN"}} : ""; }';

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -76,7 +76,7 @@ default_type application/octet-stream;
 #
 js_import helpers.js;
 js_set $userid helpers.userid;
-js_set $black_list_check helpers.checkBlackList;
+#js_set $black_list_check helpers.checkBlackList;
 
 # Modsecurity and blacklist configuration
 include /etc/nginx/gen3_server*.conf;
@@ -98,7 +98,7 @@ perl_set $canary_percent_json 'sub { return $ENV{"CANARY_PERCENT_JSON"}; }';
 ##
 # Service release parsing and assignment
 #
-js_set $service_releases helpers.getServiceReleases;
+#js_set $service_releases helpers.getServiceReleases;
 
 ##
 # Logging Settings

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -247,7 +247,7 @@ server {
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 
   # update service release cookie
-  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
+  #add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
 
   if ($request_method = 'OPTIONS') {
     return 204;
@@ -361,29 +361,12 @@ server {
   set $fence_release_name "fence";
   # TODO: configure the rest of the canary-related config later
   set $presigned_url_fence_release_name "presigned-url-fence";
-  if ($service_releases ~* "fence\.canary") {
-    set $fence_release_name "${fence_release_name}-canary";
-  }
   set $fenceshib_release_name "fenceshib";
-  if ($service_releases ~* "fenceshib\.canary") {
-    set $fenceshib_release_name "${fenceshib_release_name}-canary";
-  }
   set $sheepdog_release_name "sheepdog";
-  if ($service_releases ~* "sheepdog\.canary") {
-    set $sheepdog_release_name "${sheepdog_release_name}-canary";
-  }
   set $peregrine_release_name "peregrine";
-  if ($service_releases ~* "peregrine\.canary") {
-    set $peregrine_release_name "${peregrine_release_name}-canary";
-  }
   set $indexd_release_name "indexd";
-  if ($service_releases ~* "indexd\.canary") {
-    set $indexd_release_name "${indexd_release_name}-canary";
-  }
   set $manifestservice_release_name "manifestservice";
-  if ($service_releases ~* "manifestservice\.canary") {
-    set $manifestservice_release_name "${manifestservice_release_name}-canary";
-  }
+
   set $arborist_release_name "arborist";
 
   error_page 500 501 502 503 504 @5xx;

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -98,7 +98,7 @@ perl_set $canary_percent_json 'sub { return $ENV{"CANARY_PERCENT_JSON"}; }';
 ##
 # Service release parsing and assignment
 #
-#js_set $service_releases helpers.getServiceReleases;
+js_set $service_releases helpers.getServiceReleases;
 
 ##
 # Logging Settings

--- a/kube/services/revproxy/nginx.conf
+++ b/kube/services/revproxy/nginx.conf
@@ -247,7 +247,7 @@ server {
   more_set_headers "Access-Control-Expose-Headers: Content-Length,Content-Range";
 
   # update service release cookie
-  # add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
+  add_header Set-Cookie "service_releases=${service_releases};Path=/;Max-Age=600;HttpOnly;Secure;SameSite=Lax";
 
   if ($request_method = 'OPTIONS') {
     return 204;


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- Update nginx config to remove deprecated js_include (It was deprecated quite a while ago, in 0.4.0 or something) 


### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
