### PR TITLE
adding commands to allow for the new ccrypt image to work (backwards …

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2396,57 +2396,6 @@
         "line_number": 44
       }
     ],
-    "kube/services/jobs/usersync-job.yaml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "dbd5f43594a152b52261c8e21520a3989823fe55",
-        "is_verified": false,
-        "line_number": 64
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "1c062eaac9e6fa0766377d3cfc3e4a88982fecdb",
-        "is_verified": false,
-        "line_number": 67
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "694cfd0a009a42055e975de9111b2f3c6e8a3634",
-        "is_verified": false,
-        "line_number": 70
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "4b09a441cef18c75560f6c3caeafc96f2163c3fd",
-        "is_verified": false,
-        "line_number": 77
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "7e7478a28dcc3695a083b66b47243b050c813e2d",
-        "is_verified": false,
-        "line_number": 80
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "2f57bb00fcb93481c2be444e3e9f322b6cb5fadb",
-        "is_verified": false,
-        "line_number": 83
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "kube/services/jobs/usersync-job.yaml",
-        "hashed_secret": "ea73fcfdaa415890d5fde24d3b2245671be32f73",
-        "is_verified": false,
-        "line_number": 86
-      }
-    ],
     "kube/services/jobs/useryaml-job.yaml": [
       {
         "type": "Secret Keyword",
@@ -3237,5 +3186,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-16T15:40:00Z"
+  "generated_at": "2025-02-07T15:24:12Z"
 }

--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -189,6 +189,8 @@ spec:
           - "-c"
           # Script always succeeds if it runs (echo exits with 0)
           - |
+            sed -i 's/KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp256,/KexAlgorithms ecdh-sha2-nistp256,/g' /etc/crypto-policies/back-ends/openssh.config
+            sed -i 's/md5(self.asbytes()/md5(self.asbytes(),usedforsecurity=False/g' /.venv/lib/python3.9/site-packages/paramiko/pkey.py
             echo "${FENCE_PUBLIC_CONFIG:-""}" > "/var/www/fence/fence-config-public.yaml"
             python /var/www/fence/yaml_merge.py /var/www/fence/fence-config-public.yaml /var/www/fence/fence-config-secret.yaml > /var/www/fence/fence-config.yaml
             echo 'options use-vc' >> /etc/resolv.conf


### PR DESCRIPTION
…compatible)

### Improvements
We are releasing a new Amazon Linux 2023 image that is more secure. In order to do this we need to patch Paramiko so md5 is not blocked by fips. We also needed to remove some of the key exchange algorithms from the ssh config. 
