### PR TITLE
MIDRC-945 Add `s3:DeleteBucket` in kube-setup-gen3-workflow

### DIFF
--- a/gen3/bin/kube-setup-gen3-workflow.sh
+++ b/gen3/bin/kube-setup-gen3-workflow.sh
@@ -50,6 +50,7 @@ setup_gen3_workflow_infra() {
       "Effect": "Allow",
       "Action": [
         "s3:CreateBucket",
+        "s3:DeleteBucket",
         "s3:ListBucket",
         "s3:GetObject",
         "s3:PutObject",


### PR DESCRIPTION
Link to JIRA ticket if there is one:  [MIDRC-945] (https://ctds-planx.atlassian.net/browse/MIDRC-945)

### Improvements
* Gen3 Workflow service account supports s3:DeleteBucket action


[MIDRC-945]: https://ctds-planx.atlassian.net/browse/MIDRC-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ