### PR TITLE
Update awshelper Dockerfile

### DIFF
--- a/Docker/awshelper/Dockerfile
+++ b/Docker/awshelper/Dockerfile
@@ -1,7 +1,7 @@
 # Build from root of cloud-automation/ repo:
 #   docker build -f Docker/awshelper/Dockerfile 
 #
-FROM quay.io/cdis/ubuntu:24.04
+FROM quay.io/cdis/ubuntu-fips-base:master
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
update awshelper to use Ubuntu 24.04 FIPS as base image
