### PR TITLE
Feat: slightly increase webapi timeout to not conflict with gen3 one

### DIFF
--- a/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
+++ b/kube/services/ohdsi-webapi/ohdsi-webapi-config.yaml
@@ -22,7 +22,7 @@ stringData:
 
   security_cors_enabled: "true"
   security_origin: "*"
-  security_token_expiration: "900"
+  security_token_expiration: "960"
   security_ssl_enabled: "false"
 
   security_provider: AtlasRegularSecurity


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1589

### Improvements
- slightly increase webapi timeout to not conflict with gen3 one 

### Dependency updates
- assumes gen3 timeout is at 15 min (900 sec) 
