### PR TITLE
Adding ssh-keyscan step of dbGaP SFTP server to usersync job

### DIFF
--- a/kube/services/jobs/usersync-job.yaml
+++ b/kube/services/jobs/usersync-job.yaml
@@ -210,6 +210,13 @@ spec:
               fi
               exitcode=$?
             else
+              SFTP_PORT=22
+              KNOWN_HOSTS_PATH="/root/.ssh/known_hosts"
+              HOSTS=$(yq eval '[.dbGaP[].info.host] | join(" ")' /var/www/fence/fence-config.yaml)
+              for HOST in $HOSTS; do
+                echo "Scanning SSH key for $HOST"
+                ssh-keyscan -p $SFTP_PORT "$HOST" >> "$KNOWN_HOSTS_PATH"
+              done
               output=$(mktemp "/tmp/fence-create-output_XXXXXX")
               if [[ -f /mnt/shared/user.yaml && "$ONLY_DBGAP" != "true" ]]; then
                 echo "Running fence-create dbgap-sync with user.yaml - see $output"


### PR DESCRIPTION
Concerns [PPS-1936](https://ctds-planx.atlassian.net/browse/PPS-1936).
Adding this step to the usersync job will pull the dbGaP hosts from the fence-config.yaml found in the fence-deployment pod, performing a ssh-keyscan on the dbGaP servers and storing the public keys to a .ssh/known_hosts file. 

[PPS-1936]: https://ctds-planx.atlassian.net/browse/PPS-1936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ