### PR TITLE
reduce liveness probe for wts to every 60 seconds

### DIFF
--- a/kube/services/wts/wts-deploy.yaml
+++ b/kube/services/wts/wts-deploy.yaml
@@ -96,8 +96,9 @@ spec:
           httpGet:
             path: /_status
             port: 80
-          failureThreshold: 10
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
+          periodSeconds: 60
+          timeoutSeconds: 30
         readinessProbe:
           httpGet:
             path: /_status

--- a/kube/services/wts/wts-deploy.yaml
+++ b/kube/services/wts/wts-deploy.yaml
@@ -99,6 +99,7 @@ spec:
           initialDelaySeconds: 30
           periodSeconds: 60
           timeoutSeconds: 30
+          failureThreshold: 10
         readinessProbe:
           httpGet:
             path: /_status


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
- reduce wts liveness probe to every 60s to reduce DB load
### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
