### PR TITLE
Reduce WTS liveness interval to 20 seconds

### DIFF
--- a/kube/services/wts/wts-deploy.yaml
+++ b/kube/services/wts/wts-deploy.yaml
@@ -98,7 +98,7 @@ spec:
             port: 80
           initialDelaySeconds: 30
           periodSeconds: 60
-          timeoutSeconds: 30
+          timeoutSeconds: 20
           failureThreshold: 10
         readinessProbe:
           httpGet:


### PR DESCRIPTION
JIRA ticket: [HP-2177](https://ctds-planx.atlassian.net/browse/HP-2177) 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

* Reduce WTS liveness interval to 20 seconds

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
