### PR TITLE
Update web_whitelist remove public.ecr.aws

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -153,7 +153,6 @@ ppa.launchpad.net
 prometheus-community.github.io
 proxy.golang.org
 pubmirrors.dal.corespace.com
-public.ecr.aws
 reflector.westga.edu
 registry.npmjs.org
 registry.ollama.ai


### PR DESCRIPTION
'public.ecr.aws' is a subdomain of '.aws'