### PR TITLE
Add new domains to web whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -201,3 +201,5 @@ data.qdr.syr.edu
 zenodo.org
 dataverse.harvard.edu
 sleepdata.org
+threatfox.abuse.ch
+attack-taxii.mitre.org

--- a/packer/configs/web_whitelist
+++ b/packer/configs/web_whitelist
@@ -108,3 +108,5 @@ www.oracle.com
 www.rabbitmq.com
 www.uniprot.org
 yahoo.com
+threatfox.abuse.ch
+attack-taxii.mitre.org

--- a/packer/configs/web_whitelist
+++ b/packer/configs/web_whitelist
@@ -108,5 +108,3 @@ www.oracle.com
 www.rabbitmq.com
 www.uniprot.org
 yahoo.com
-threatfox.abuse.ch
-attack-taxii.mitre.org


### PR DESCRIPTION


### New Features
- Adding in some domains necessary for Vectis to get threat feed data
