### PR TITLE
feat(terraform): migrate EBS volumes from gp2 to gp3

### DIFF
--- a/tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf
+++ b/tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf
@@ -125,7 +125,7 @@ resource "aws_imagebuilder_image_recipe" "recipe" {
     ebs {
       delete_on_termination = true
       volume_size           = 30
-      volume_type           = "gp2"
+      volume_type           = "gp3"
       encrypted = false
     }
   }

--- a/tf_files/aws/storage-gateway/cloud.tf
+++ b/tf_files/aws/storage-gateway/cloud.tf
@@ -23,7 +23,7 @@ resource "aws_instance" "storage-gw-server" {
   root_block_device {
     # Get volume size from var permanently
     volume_size = "${var.size}"
-    volume_type = "gp2"
+    volume_type = "gp3"
     encrypted   = true
   }
   # add tags later
@@ -34,7 +34,7 @@ resource "aws_ebs_volume" "cache-disk" {
   # Get volume size from var permanently
   size = "${var.cache_size}"
   encrypted = true
-  type = "gp2"
+  type = "gp3"
   # add tags later
 }
 


### PR DESCRIPTION
### New Features
- None

### Breaking Changes
- None

### Bug Fixes
- None

### Improvements
- Migrates AWS EBS volumes from `gp2` to `gp3` to improve cost efficiency and baseline performance
- Updates Terraform configuration in:
  - `tf_files/aws/storage-gateway/cloud.tf`
  - `tf_files/aws/nextflow_ami_pipeline/imagebuilder.tf`
- Change identified through InfraScan analysis ([introduced in a PR](https://github.com/uc-cdis/cloud-automation/pull/2878)), which detected `gp2` usage as a cost optimization opportunity in the infrastructure
- Aligns storage configuration with AWS best practices for EBS volumes (`gp3` recommended over `gp2`)

### Dependency updates
- None

### Deployment changes
- None