### PR TITLE
Add portal.dev.genie.dci.thehyve.nl to whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -149,6 +149,7 @@ opportunityinsights.org
 orcid.org
 pgp.mit.edu
 playwright.download.prss.microsoft.com
+portal.dev.genie.dci.thehyve.nl
 ppa.launchpad.net
 prometheus-community.github.io
 proxy.golang.org


### PR DESCRIPTION
### New Features

### Breaking Changes

### Bug Fixes

### Improvements
Added website to squid whitelist to unblock Pim
### Dependency updates

### Deployment changes
