### PR TITLE
Update web_whitelist

### DIFF
--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -6,12 +6,15 @@ accounts.google.com
 achecker.ca
 apache.github.io
 api.epigraphdb.org
+api.gdc.cancer.gov
 api.monqcle.com
 app.getambassador.io
 artifacts.elastic.co
 awslabs.github.io
+bioconductor.org
 biodata-integration-tests.net
 marketing.biorender.com
+mghp.osn.xsede.org
 calypr.org
 cdn-lfs.huggingface.co
 cdn.playwright.dev

--- a/files/squid_whitelist/web_whitelist
+++ b/files/squid_whitelist/web_whitelist
@@ -6,15 +6,12 @@ accounts.google.com
 achecker.ca
 apache.github.io
 api.epigraphdb.org
-api.gdc.cancer.gov
 api.monqcle.com
 app.getambassador.io
 artifacts.elastic.co
 awslabs.github.io
-bioconductor.org
 biodata-integration-tests.net
 marketing.biorender.com
-mghp.osn.xsede.org
 calypr.org
 cdn-lfs.huggingface.co
 cdn.playwright.dev

--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -131,6 +131,7 @@
 .virtualbox.org
 .visitdata.org
 .wriwindber.org
+.xsede.org
 .xmission.com
 .yahooapis.com
 .yarnpkg.com


### PR DESCRIPTION
### Improvements

Added .xsede.org to whitelist.

BiocManager::install() for R/Bioconductor packages fails inside the workspace because Bioconductor redirects package index and archive requests to mghp.osn.xsede.org, which hosts Bioconductor's package archive on the XSEDE Open Storage Network. 