### PR TITLE
fix(hatchery): if it can create roles it ought to be able to get what…

### DIFF
--- a/gen3/bin/kube-setup-hatchery.sh
+++ b/gen3/bin/kube-setup-hatchery.sh
@@ -187,6 +187,7 @@ $assumeImageBuilderRolePolicyBlock
                 "iam:DeletePolicyVersion",
                 "iam:ListRoles",
                 "iam:CreateRole",
+                "iam:GetRole",
                 "iam:TagRole",
                 "iam:AttachRolePolicy",
                 "iam:CreateUser",


### PR DESCRIPTION
From discussion. Spelunking through aws I found this list:
https://cdis.slack.com/archives/CLZJVC38B/p1787857535895259

brh-staging service account has been manually updated, we'll likely need to do the same for prod when we swap.
