### PR TITLE
Add openneuro.org and pennsieve.io to squid egress whitelist

### DIFF
--- a/files/squid_whitelist/web_wildcard_whitelist
+++ b/files/squid_whitelist/web_wildcard_whitelist
@@ -89,11 +89,13 @@
 .occ-pla.net
 .oicr.on.ca
 .okta.com
+.openneuro.org
 .opensciencedatacloud.org
 .osf.io
 .osuosl.org
 .paloaltonetworks.com
 .pandemicresponsecommons.org
+.pennsieve.io
 .perl.org
 .pedscommons.org
 .planx-ci.io


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->
Adds openneuro.org and pennsieve.io to the Squid egress wildcard whitelist. The HEAL file ETL enriches dataset names from repository APIs; SPARC (pennsieve.io) and OpenNeuro were being blocked by egress, so their dataset names couldn't be  resolved from adminvm/jumpbox builds.
Link to JIRA ticket if there is one:

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
